### PR TITLE
S31-02 RepoBoard persistence for dependency metadata

### DIFF
--- a/src/server/durable/repo-board.ts
+++ b/src/server/durable/repo-board.ts
@@ -100,9 +100,10 @@ export class RepoBoardDO extends DurableObject<Env> {
       title: input.title,
       description: input.description,
       sourceRef: input.sourceRef,
-      dependencies: input.dependencies,
-      automationState: input.automationState,
-      branchSource: input.branchSource,
+      dependencies: cloneTaskDependencies(input.dependencies),
+      dependencyState: cloneTaskDependencyState(input.dependencyState),
+      automationState: cloneTaskAutomationState(input.automationState),
+      branchSource: cloneTaskBranchSource(input.branchSource),
       taskPrompt: input.taskPrompt,
       acceptanceCriteria: input.acceptanceCriteria,
       context: input.context,
@@ -137,9 +138,19 @@ export class RepoBoardDO extends DurableObject<Env> {
       validateDependenciesForTask(existing.repoId, existing.taskId, patch.dependencies);
     }
 
+    const hasPatchField = <K extends keyof UpdateTaskInput>(key: K) => Object.prototype.hasOwnProperty.call(patch, key);
+
     const updated: Task = {
       ...existing,
       ...patch,
+      dependencies: hasPatchField('dependencies') ? cloneTaskDependencies(patch.dependencies) : cloneTaskDependencies(existing.dependencies),
+      dependencyState: hasPatchField('dependencyState')
+        ? cloneTaskDependencyState(patch.dependencyState)
+        : cloneTaskDependencyState(existing.dependencyState),
+      automationState: hasPatchField('automationState')
+        ? cloneTaskAutomationState(patch.automationState)
+        : cloneTaskAutomationState(existing.automationState),
+      branchSource: hasPatchField('branchSource') ? cloneTaskBranchSource(patch.branchSource) : cloneTaskBranchSource(existing.branchSource),
       sourceRef: patch.sourceRef ?? existing.sourceRef,
       context: patch.context ?? existing.context,
       acceptanceCriteria: patch.acceptanceCriteria ?? existing.acceptanceCriteria,
@@ -756,7 +767,15 @@ function getOperatorSessionName(run: AgentRun) {
 
 function cloneRepoBoardState(state: RepoBoardState): RepoBoardState {
   return {
-    tasks: state.tasks.map((task) => ({ ...task, context: { ...task.context, links: task.context.links.map((link) => ({ ...link })) }, uiMeta: task.uiMeta ? { ...task.uiMeta } : undefined })),
+    tasks: state.tasks.map((task) => ({
+      ...task,
+      dependencies: cloneTaskDependencies(task.dependencies),
+      dependencyState: cloneTaskDependencyState(task.dependencyState),
+      automationState: cloneTaskAutomationState(task.automationState),
+      branchSource: cloneTaskBranchSource(task.branchSource),
+      context: { ...task.context, links: task.context.links.map((link) => ({ ...link })) },
+      uiMeta: task.uiMeta ? { ...task.uiMeta } : undefined
+    })),
     runs: state.runs.map((run) => ({
       ...run,
       codexProcessId: run.codexProcessId,
@@ -795,4 +814,25 @@ function normalizeRepoBoardState(state?: Partial<RepoBoardState> | null): RepoBo
     events: state?.events ?? [],
     commands: state?.commands ?? []
   };
+}
+
+function cloneTaskDependencies(dependencies: Task['dependencies']) {
+  return dependencies?.map((dependency) => ({ ...dependency }));
+}
+
+function cloneTaskDependencyState(dependencyState: Task['dependencyState']) {
+  return dependencyState
+    ? {
+        ...dependencyState,
+        reasons: dependencyState.reasons.map((reason) => ({ ...reason }))
+      }
+    : undefined;
+}
+
+function cloneTaskAutomationState(automationState: Task['automationState']) {
+  return automationState ? { ...automationState } : undefined;
+}
+
+function cloneTaskBranchSource(branchSource: Task['branchSource']) {
+  return branchSource ? { ...branchSource } : undefined;
 }

--- a/src/server/http/validation.test.ts
+++ b/src/server/http/validation.test.ts
@@ -19,6 +19,11 @@ describe('task validation', () => {
     const parsed = parseCreateTaskInput(
       createTaskPayload({
         dependencies: [{ upstreamTaskId: 'task_upstream', mode: 'review_ready', primary: true }],
+        dependencyState: {
+          blocked: false,
+          unblockedAt: '2026-03-02T01:05:00.000Z',
+          reasons: [{ upstreamTaskId: 'task_upstream', state: 'ready', message: 'Upstream task is in review.' }]
+        },
         automationState: {
           autoStartEligible: true,
           autoStartedAt: '2026-03-02T00:00:00.000Z',
@@ -37,6 +42,8 @@ describe('task validation', () => {
     );
 
     expect(parsed.dependencies).toEqual([{ upstreamTaskId: 'task_upstream', mode: 'review_ready', primary: true }]);
+    expect(parsed.dependencyState?.blocked).toBe(false);
+    expect(parsed.dependencyState?.reasons[0]?.state).toBe('ready');
     expect(parsed.automationState?.autoStartEligible).toBe(true);
     expect(parsed.branchSource?.kind).toBe('dependency_review_head');
   });
@@ -68,6 +75,14 @@ describe('task validation', () => {
         automationState: { autoStartEligible: 'yes' }
       })
     ).toThrow('Invalid automationState.autoStartEligible.');
+  });
+
+  it('rejects update payload with invalid dependencyState shape', () => {
+    expect(() =>
+      parseUpdateTaskInput({
+        dependencyState: { blocked: 'yes', reasons: [] }
+      })
+    ).toThrow('Invalid dependencyState.blocked.');
   });
 
   it('rejects update payload with invalid branchSource fields', () => {

--- a/src/server/http/validation.ts
+++ b/src/server/http/validation.ts
@@ -147,6 +147,37 @@ function readAutomationState(value: unknown, required = true): CreateTaskInput['
   };
 }
 
+function readDependencyState(value: unknown, required = true): CreateTaskInput['dependencyState'] | undefined {
+  if (!required && typeof value === 'undefined') {
+    return undefined;
+  }
+
+  if (!isRecord(value)) {
+    throw badRequest('Invalid dependencyState.');
+  }
+
+  const reasonsValue = value.reasons;
+  if (!Array.isArray(reasonsValue)) {
+    throw badRequest('Invalid dependencyState.reasons.');
+  }
+
+  return {
+    blocked: readBoolean(value.blocked, 'dependencyState.blocked', true)!,
+    unblockedAt: readString(value.unblockedAt, 'dependencyState.unblockedAt', false),
+    reasons: reasonsValue.map((reason, index) => {
+      if (!isRecord(reason)) {
+        throw badRequest(`Invalid dependencyState.reasons[${index}].`);
+      }
+
+      return {
+        upstreamTaskId: readTrimmedString(reason.upstreamTaskId, `dependencyState.reasons[${index}].upstreamTaskId`)!,
+        state: readEnumValue(reason.state, `dependencyState.reasons[${index}].state`, new Set(['missing', 'not_ready', 'ready'] as const))!,
+        message: readString(reason.message, `dependencyState.reasons[${index}].message`)!
+      };
+    })
+  };
+}
+
 function readBranchSource(value: unknown, required = true): CreateTaskInput['branchSource'] | undefined {
   if (!required && typeof value === 'undefined') {
     return undefined;
@@ -223,6 +254,7 @@ export function parseCreateTaskInput(body: unknown): CreateTaskInput {
     description: readString(body.description, 'description', false),
     sourceRef: readTrimmedString(body.sourceRef, 'sourceRef', false),
     dependencies: readDependencies(body.dependencies, false),
+    dependencyState: readDependencyState(body.dependencyState, false),
     automationState: readAutomationState(body.automationState, false),
     branchSource: readBranchSource(body.branchSource, false),
     taskPrompt: readString(body.taskPrompt, 'taskPrompt')!,
@@ -247,6 +279,7 @@ export function parseUpdateTaskInput(body: unknown): UpdateTaskInput {
   if (hasOwn(body, 'description')) patch.description = readString(body.description, 'description', false);
   if (hasOwn(body, 'sourceRef')) patch.sourceRef = readTrimmedString(body.sourceRef, 'sourceRef', false);
   if (hasOwn(body, 'dependencies')) patch.dependencies = readDependencies(body.dependencies, false);
+  if (hasOwn(body, 'dependencyState')) patch.dependencyState = readDependencyState(body.dependencyState, false);
   if (hasOwn(body, 'automationState')) patch.automationState = readAutomationState(body.automationState, false);
   if (hasOwn(body, 'branchSource')) patch.branchSource = readBranchSource(body.branchSource, false);
   if (hasOwn(body, 'taskPrompt')) patch.taskPrompt = readString(body.taskPrompt, 'taskPrompt', false);

--- a/src/ui/domain/api.ts
+++ b/src/ui/domain/api.ts
@@ -31,6 +31,7 @@ export type CreateTaskInput = {
   description?: string;
   sourceRef?: string;
   dependencies?: Task['dependencies'];
+  dependencyState?: Task['dependencyState'];
   automationState?: Task['automationState'];
   branchSource?: Task['branchSource'];
   taskPrompt: string;


### PR DESCRIPTION
Task: S31-02 RepoBoard persistence for dependency metadata

Persist new Stage 3.1 task metadata in RepoBoardDO.

Stage reference: Stage 3.1
Docs: docs/stage_3_1.md

Execution mode: skip preview/evidence steps for this repo.


Acceptance criteria:
- Implementation compiles and passes relevant checks
- Behavior matches task scope without regressions
- Preview URL and evidence are explicitly out of scope for this repo

Run ID: run_repo_abuiles_minions_mm8sb65jk75v