### PR TITLE
S31-03 Dependency state computation engine

### DIFF
--- a/src/server/durable/repo-board.ts
+++ b/src/server/durable/repo-board.ts
@@ -20,6 +20,7 @@ import { stringifyBoardEvent } from '../shared/events';
 import { EMPTY_REPO_BOARD_STATE, type RepoBoardState } from '../shared/state';
 import { applyRunTransition, appendRunError, buildArtifactManifest, createRealRun, type RunTransitionPatch } from '../shared/real-run';
 import { executeRunJob } from '../run-orchestrator';
+import { refreshDependencyStates } from '../shared/dependency-state';
 
 const STORAGE_KEY = 'repo-board-state';
 const LOCAL_JOBS_KEY = 'repo-board-local-jobs';
@@ -122,9 +123,12 @@ export class RepoBoardDO extends DurableObject<Env> {
       ...this.state,
       tasks: [task, ...this.state.tasks]
     };
+    const refreshedTasks = this.refreshDependencyStatesForRepo(now);
+    const finalTask = this.state.tasks.find((candidate) => candidate.taskId === task.taskId) ?? task;
     await this.persist();
-    await this.emit({ type: 'task.updated', payload: { task } }, input.repoId);
-    return task;
+    await this.emit({ type: 'task.updated', payload: { task: finalTask } }, input.repoId);
+    await this.emitDependencyRefreshUpdates(input.repoId, refreshedTasks, [finalTask.taskId]);
+    return finalTask;
   }
 
   async updateTask(taskId: string, patch: UpdateTaskInput): Promise<Task> {
@@ -166,9 +170,12 @@ export class RepoBoardDO extends DurableObject<Env> {
       ...this.state,
       tasks: this.state.tasks.map((candidate) => (candidate.taskId === taskId ? updated : candidate))
     };
+    const refreshedTasks = this.refreshDependencyStatesForRepo(updated.updatedAt);
+    const finalTask = this.state.tasks.find((candidate) => candidate.taskId === updated.taskId) ?? updated;
     await this.persist();
-    await this.emit({ type: 'task.updated', payload: { task: updated } }, updated.repoId);
-    return updated;
+    await this.emit({ type: 'task.updated', payload: { task: finalTask } }, updated.repoId);
+    await this.emitDependencyRefreshUpdates(updated.repoId, refreshedTasks, [finalTask.taskId]);
+    return finalTask;
   }
 
   async startRun(taskId: string): Promise<AgentRun> {
@@ -193,9 +200,11 @@ export class RepoBoardDO extends DurableObject<Env> {
       ),
       runs: [run, ...this.state.runs]
     };
+    const refreshedTasks = this.refreshDependencyStatesForRepo(now.toISOString());
     await this.persist();
     await this.emit({ type: 'task.updated', payload: { task: this.state.tasks.find((candidate) => candidate.taskId === taskId)! } }, task.repoId);
     await this.emit({ type: 'run.updated', payload: { run } }, task.repoId);
+    await this.emitDependencyRefreshUpdates(task.repoId, refreshedTasks, [taskId]);
     return run;
   }
 
@@ -242,9 +251,11 @@ export class RepoBoardDO extends DurableObject<Env> {
       ),
       runs: [nextRun, ...this.state.runs]
     };
+    const refreshedTasks = this.refreshDependencyStatesForRepo(now.toISOString());
     await this.persist();
     await this.emit({ type: 'task.updated', payload: { task: this.state.tasks.find((candidate) => candidate.taskId === task.taskId)! } }, task.repoId);
     await this.emit({ type: 'run.updated', payload: { run: nextRun } }, task.repoId);
+    await this.emitDependencyRefreshUpdates(task.repoId, refreshedTasks, [task.taskId]);
     return nextRun;
   }
 
@@ -270,8 +281,10 @@ export class RepoBoardDO extends DurableObject<Env> {
         candidate.taskId === run.taskId ? { ...candidate, status: 'REVIEW', updatedAt: nowIso } : candidate
       )
     };
+    const refreshedTasks = this.refreshDependencyStatesForRepo(nowIso);
     await this.persist();
     await this.emit({ type: 'run.updated', payload: { run: updated } }, updated.repoId);
+    await this.emitDependencyRefreshUpdates(updated.repoId, refreshedTasks, [run.taskId]);
     return updated;
   }
 
@@ -298,8 +311,10 @@ export class RepoBoardDO extends DurableObject<Env> {
         candidate.taskId === run.taskId ? { ...candidate, status: 'REVIEW', updatedAt: nowIso } : candidate
       )
     };
+    const refreshedTasks = this.refreshDependencyStatesForRepo(nowIso);
     await this.persist();
     await this.emit({ type: 'run.updated', payload: { run: updated } }, updated.repoId);
+    await this.emitDependencyRefreshUpdates(updated.repoId, refreshedTasks, [run.taskId]);
     return updated;
   }
 
@@ -394,12 +409,15 @@ export class RepoBoardDO extends DurableObject<Env> {
       runs: this.state.runs.map((candidate) => (candidate.runId === runId ? updated : candidate)),
       events: [...this.state.events, ...events]
     };
+    const refreshedTasks = this.refreshDependencyStatesForRepo(nowIso);
     await this.persist();
-    await this.emit({ type: 'task.updated', payload: { task: nextTask } }, updated.repoId);
+    const finalTask = this.state.tasks.find((candidate) => candidate.taskId === nextTask.taskId) ?? nextTask;
+    await this.emit({ type: 'task.updated', payload: { task: finalTask } }, updated.repoId);
     await this.emit({ type: 'run.updated', payload: { run: updated } }, updated.repoId);
     if (events.length) {
       await this.emit({ type: 'run.events_appended', payload: { runId, events } }, updated.repoId);
     }
+    await this.emitDependencyRefreshUpdates(updated.repoId, refreshedTasks, [finalTask.taskId]);
     return updated;
   }
 
@@ -425,9 +443,12 @@ export class RepoBoardDO extends DurableObject<Env> {
       tasks: this.state.tasks.map((candidate) => (candidate.taskId === nextTask.taskId ? nextTask : candidate)),
       runs: this.state.runs.map((candidate) => (candidate.runId === runId ? updated : candidate))
     };
+    const refreshedTasks = this.refreshDependencyStatesForRepo(nowIso);
     await this.persist();
-    await this.emit({ type: 'task.updated', payload: { task: nextTask } }, updated.repoId);
+    const finalTask = this.state.tasks.find((candidate) => candidate.taskId === nextTask.taskId) ?? nextTask;
+    await this.emit({ type: 'task.updated', payload: { task: finalTask } }, updated.repoId);
     await this.emit({ type: 'run.updated', payload: { run: updated } }, updated.repoId);
+    await this.emitDependencyRefreshUpdates(updated.repoId, refreshedTasks, [finalTask.taskId]);
     return updated;
   }
 
@@ -602,11 +623,14 @@ export class RepoBoardDO extends DurableObject<Env> {
       runs: this.state.runs.map((candidate) => (candidate.runId === runId ? updated : candidate)),
       events: [...this.state.events, ...events]
     };
+    const refreshedTasks = this.refreshDependencyStatesForRepo(now);
     await this.persist();
-    await this.emit({ type: 'task.updated', payload: { task: nextTask } }, updated.repoId);
+    const finalTask = this.state.tasks.find((candidate) => candidate.taskId === nextTask.taskId) ?? nextTask;
+    await this.emit({ type: 'task.updated', payload: { task: finalTask } }, updated.repoId);
     await this.emit({ type: 'run.updated', payload: { run: updated } }, updated.repoId);
     await this.emit({ type: 'run.operator_session_updated', payload: { runId, session: nextSession } }, updated.repoId);
     await this.emit({ type: 'run.events_appended', payload: { runId, events } }, updated.repoId);
+    await this.emitDependencyRefreshUpdates(updated.repoId, refreshedTasks, [finalTask.taskId]);
     return updated;
   }
 
@@ -688,6 +712,33 @@ export class RepoBoardDO extends DurableObject<Env> {
       events: [...this.state.events],
       commands: [...this.state.commands]
     };
+  }
+
+  private refreshDependencyStatesForRepo(nowIso: string) {
+    const result = refreshDependencyStates(this.state.tasks, this.state.runs, nowIso);
+    if (!result.changedTaskIds.length) {
+      return [];
+    }
+
+    this.state = {
+      ...this.state,
+      tasks: result.tasks
+    };
+    return result.tasks.filter((task) => result.changedTaskIds.includes(task.taskId));
+  }
+
+  private async emitDependencyRefreshUpdates(repoId: string, tasks: Task[], excludeTaskIds: string[] = []) {
+    if (!tasks.length) {
+      return;
+    }
+
+    const excluded = new Set(excludeTaskIds);
+    for (const task of tasks) {
+      if (excluded.has(task.taskId)) {
+        continue;
+      }
+      await this.emit({ type: 'task.updated', payload: { task } }, repoId);
+    }
   }
 }
 

--- a/src/server/shared/dependency-state.test.ts
+++ b/src/server/shared/dependency-state.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'vitest';
+import type { AgentRun, Task } from '../../ui/domain/types';
+import { refreshDependencyStates } from './dependency-state';
+
+function buildTask(taskId: string, overrides: Partial<Task> = {}): Task {
+  return {
+    taskId,
+    repoId: 'repo_demo',
+    title: taskId,
+    taskPrompt: 'prompt',
+    acceptanceCriteria: ['done'],
+    context: { links: [] },
+    status: 'INBOX',
+    createdAt: '2026-03-02T00:00:00.000Z',
+    updatedAt: '2026-03-02T00:00:00.000Z',
+    ...overrides
+  };
+}
+
+function buildRun(taskId: string, status: AgentRun['status'], overrides: Partial<AgentRun> = {}): AgentRun {
+  return {
+    runId: `run_${taskId}`,
+    taskId,
+    repoId: 'repo_demo',
+    status,
+    branchName: `agent/${taskId}/run`,
+    errors: [],
+    startedAt: '2026-03-02T00:00:00.000Z',
+    timeline: [{ status, at: '2026-03-02T00:00:00.000Z' }],
+    simulationProfile: 'happy_path',
+    pendingEvents: [],
+    ...overrides
+  };
+}
+
+describe('refreshDependencyStates', () => {
+  it('marks downstream blocked when the upstream task is missing', () => {
+    const downstream = buildTask('task_down', {
+      dependencies: [{ upstreamTaskId: 'task_up', mode: 'review_ready' }]
+    });
+    const nowIso = '2026-03-02T01:00:00.000Z';
+
+    const result = refreshDependencyStates([downstream], [], nowIso);
+    const refreshed = result.tasks[0];
+
+    expect(result.changedTaskIds).toEqual(['task_down']);
+    expect(refreshed.dependencyState).toEqual({
+      blocked: true,
+      unblockedAt: undefined,
+      reasons: [
+        {
+          upstreamTaskId: 'task_up',
+          state: 'missing',
+          message: 'Upstream task task_up is missing.'
+        }
+      ]
+    });
+  });
+
+  it('unblocks dependencies when upstream task reaches review', () => {
+    const upstream = buildTask('task_up', { status: 'REVIEW' });
+    const downstream = buildTask('task_down', {
+      dependencies: [{ upstreamTaskId: 'task_up', mode: 'review_ready' }]
+    });
+    const nowIso = '2026-03-02T01:05:00.000Z';
+
+    const result = refreshDependencyStates([upstream, downstream], [], nowIso);
+    const refreshed = result.tasks.find((task) => task.taskId === 'task_down')!;
+
+    expect(refreshed.dependencyState?.blocked).toBe(false);
+    expect(refreshed.dependencyState?.unblockedAt).toBe(nowIso);
+    expect(refreshed.dependencyState?.reasons[0]).toMatchObject({
+      upstreamTaskId: 'task_up',
+      state: 'ready'
+    });
+  });
+
+  it('uses latest upstream run state to mark readiness', () => {
+    const upstream = buildTask('task_up', { status: 'ACTIVE' });
+    const downstream = buildTask('task_down', {
+      dependencies: [{ upstreamTaskId: 'task_up', mode: 'review_ready' }]
+    });
+    const nowIso = '2026-03-02T01:10:00.000Z';
+
+    const result = refreshDependencyStates([upstream, downstream], [buildRun('task_up', 'WAITING_PREVIEW')], nowIso);
+    const refreshed = result.tasks.find((task) => task.taskId === 'task_down')!;
+
+    expect(refreshed.dependencyState?.blocked).toBe(false);
+    expect(refreshed.dependencyState?.reasons[0]?.state).toBe('ready');
+  });
+
+  it('preserves existing unblockedAt while still unblocked', () => {
+    const upstream = buildTask('task_up', { status: 'REVIEW' });
+    const downstream = buildTask('task_down', {
+      dependencies: [{ upstreamTaskId: 'task_up', mode: 'review_ready' }],
+      dependencyState: {
+        blocked: false,
+        unblockedAt: '2026-03-02T00:30:00.000Z',
+        reasons: [{ upstreamTaskId: 'task_up', state: 'ready', message: 'old' }]
+      }
+    });
+
+    const result = refreshDependencyStates([upstream, downstream], [], '2026-03-02T02:00:00.000Z');
+    const refreshed = result.tasks.find((task) => task.taskId === 'task_down')!;
+    expect(refreshed.dependencyState?.unblockedAt).toBe('2026-03-02T00:30:00.000Z');
+  });
+
+  it('clears unblockedAt when dependencies become blocked again', () => {
+    const upstream = buildTask('task_up', { status: 'ACTIVE' });
+    const downstream = buildTask('task_down', {
+      dependencies: [{ upstreamTaskId: 'task_up', mode: 'review_ready' }],
+      dependencyState: {
+        blocked: false,
+        unblockedAt: '2026-03-02T00:30:00.000Z',
+        reasons: [{ upstreamTaskId: 'task_up', state: 'ready', message: 'old' }]
+      }
+    });
+
+    const result = refreshDependencyStates([upstream, downstream], [], '2026-03-02T02:05:00.000Z');
+    const refreshed = result.tasks.find((task) => task.taskId === 'task_down')!;
+    expect(refreshed.dependencyState?.blocked).toBe(true);
+    expect(refreshed.dependencyState?.unblockedAt).toBeUndefined();
+    expect(refreshed.dependencyState?.reasons[0]?.state).toBe('not_ready');
+  });
+});

--- a/src/server/shared/dependency-state.ts
+++ b/src/server/shared/dependency-state.ts
@@ -1,0 +1,167 @@
+import type { AgentRun, Task, TaskAutomationState, TaskDependencyReason, TaskDependencyState } from '../../ui/domain/types';
+
+type RefreshDependencyStatesResult = {
+  tasks: Task[];
+  changedTaskIds: string[];
+};
+
+const REVIEW_READY_RUN_STATUSES: Set<AgentRun['status']> = new Set([
+  'PR_OPEN',
+  'WAITING_PREVIEW',
+  'EVIDENCE_RUNNING',
+  'DONE'
+]);
+
+export function refreshDependencyStates(tasks: Task[], runs: AgentRun[], nowIso: string): RefreshDependencyStatesResult {
+  if (!tasks.length) {
+    return { tasks, changedTaskIds: [] };
+  }
+
+  const tasksById = new Map(tasks.map((task) => [task.taskId, task]));
+  const latestRunsByTaskId = buildLatestRunsByTaskId(runs);
+  const changedTaskIds: string[] = [];
+
+  const nextTasks = tasks.map((task) => {
+    if (!task.dependencies?.length) {
+      return task;
+    }
+
+    const dependencyState = buildDependencyState(task, tasksById, latestRunsByTaskId, nowIso);
+    const automationState = buildAutomationState(task.automationState, nowIso);
+    if (
+      areDependencyStatesEqual(task.dependencyState, dependencyState)
+      && areAutomationStatesEqual(task.automationState, automationState)
+    ) {
+      return task;
+    }
+
+    changedTaskIds.push(task.taskId);
+    return {
+      ...task,
+      dependencyState,
+      automationState,
+      updatedAt: nowIso
+    };
+  });
+
+  if (!changedTaskIds.length) {
+    return { tasks, changedTaskIds };
+  }
+
+  return { tasks: nextTasks, changedTaskIds };
+}
+
+function buildLatestRunsByTaskId(runs: AgentRun[]) {
+  const latestRunsByTaskId = new Map<string, AgentRun>();
+  for (const run of runs) {
+    const current = latestRunsByTaskId.get(run.taskId);
+    if (!current || run.startedAt > current.startedAt) {
+      latestRunsByTaskId.set(run.taskId, run);
+    }
+  }
+  return latestRunsByTaskId;
+}
+
+function buildDependencyState(
+  task: Task,
+  tasksById: Map<string, Task>,
+  latestRunsByTaskId: Map<string, AgentRun>,
+  nowIso: string
+): TaskDependencyState {
+  const reasons: TaskDependencyReason[] = task.dependencies!.map((dependency) => {
+    const upstreamTask = tasksById.get(dependency.upstreamTaskId);
+    if (!upstreamTask) {
+      return {
+        upstreamTaskId: dependency.upstreamTaskId,
+        state: 'missing',
+        message: `Upstream task ${dependency.upstreamTaskId} is missing.`
+      };
+    }
+
+    const upstreamRun = latestRunsByTaskId.get(dependency.upstreamTaskId);
+    if (isReviewReady(upstreamTask, upstreamRun)) {
+      return {
+        upstreamTaskId: dependency.upstreamTaskId,
+        state: 'ready',
+        message: `Upstream task ${dependency.upstreamTaskId} is review-ready.`
+      };
+    }
+
+    return {
+      upstreamTaskId: dependency.upstreamTaskId,
+      state: 'not_ready',
+      message: `Upstream task ${dependency.upstreamTaskId} is not review-ready yet.`
+    };
+  });
+  const blocked = reasons.some((reason) => reason.state !== 'ready');
+
+  return {
+    blocked,
+    unblockedAt: blocked ? undefined : (task.dependencyState?.unblockedAt ?? nowIso),
+    reasons
+  };
+}
+
+function buildAutomationState(automationState: TaskAutomationState | undefined, nowIso: string) {
+  if (!automationState) {
+    return undefined;
+  }
+  return {
+    ...automationState,
+    lastDependencyRefreshAt: nowIso
+  };
+}
+
+function isReviewReady(task: Task, latestRun: AgentRun | undefined) {
+  if (task.status === 'REVIEW' || task.status === 'DONE') {
+    return true;
+  }
+
+  if (!latestRun) {
+    return false;
+  }
+
+  if (REVIEW_READY_RUN_STATUSES.has(latestRun.status)) {
+    return true;
+  }
+
+  return latestRun.status === 'FAILED' && Boolean(latestRun.prUrl);
+}
+
+function areDependencyStatesEqual(left: TaskDependencyState | undefined, right: TaskDependencyState | undefined) {
+  if (!left && !right) {
+    return true;
+  }
+  if (!left || !right) {
+    return false;
+  }
+  if (left.blocked !== right.blocked || left.unblockedAt !== right.unblockedAt || left.reasons.length !== right.reasons.length) {
+    return false;
+  }
+
+  for (let index = 0; index < left.reasons.length; index += 1) {
+    const leftReason = left.reasons[index];
+    const rightReason = right.reasons[index];
+    if (
+      leftReason.upstreamTaskId !== rightReason.upstreamTaskId
+      || leftReason.state !== rightReason.state
+      || leftReason.message !== rightReason.message
+    ) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function areAutomationStatesEqual(left: TaskAutomationState | undefined, right: TaskAutomationState | undefined) {
+  if (!left && !right) {
+    return true;
+  }
+  if (!left || !right) {
+    return false;
+  }
+  return left.autoStartEligible === right.autoStartEligible
+    && left.autoStartedAt === right.autoStartedAt
+    && left.lastDependencyRefreshAt === right.lastDependencyRefreshAt;
+}


### PR DESCRIPTION
Task: S31-03 Dependency state computation engine

Compute blocked/unblocked status and reasons for downstream tasks.

Stage reference: Stage 3.1
Docs: docs/stage_3_1.md

Execution mode: skip preview/evidence steps for this repo.


Acceptance criteria:
- Implementation compiles and passes relevant checks
- Behavior matches task scope without regressions
- Preview URL and evidence are explicitly out of scope for this repo

Run ID: run_repo_abuiles_minions_mm8si155bs02