### PR TITLE
S31-04 Source resolution precedence

### DIFF
--- a/src/server/durable/repo-board.ts
+++ b/src/server/durable/repo-board.ts
@@ -21,6 +21,7 @@ import { EMPTY_REPO_BOARD_STATE, type RepoBoardState } from '../shared/state';
 import { applyRunTransition, appendRunError, buildArtifactManifest, createRealRun, type RunTransitionPatch } from '../shared/real-run';
 import { executeRunJob } from '../run-orchestrator';
 import { refreshDependencyStates } from '../shared/dependency-state';
+import { resolveRunSource } from '../shared/run-source-resolution';
 
 const STORAGE_KEY = 'repo-board-state';
 const LOCAL_JOBS_KEY = 'repo-board-local-jobs';
@@ -190,17 +191,44 @@ export class RepoBoardDO extends DurableObject<Env> {
       return existing;
     }
 
+    const repo = await this.getRepo(task.repoId);
     const now = new Date();
-    const run = createRealRun(task, createRunId(task.repoId), now);
+    const nowIso = now.toISOString();
+    const resolvedSource = resolveRunSource({
+      task,
+      tasks: this.state.tasks,
+      runs: this.state.runs,
+      defaultBranch: repo.defaultBranch,
+      resolvedAt: nowIso
+    });
+    const run = createRealRun(
+      {
+        ...task,
+        branchSource: resolvedSource.branchSource
+      },
+      createRunId(task.repoId),
+      now,
+      {
+        dependencyContext: resolvedSource.dependencyContext
+      }
+    );
 
     this.state = {
       ...this.state,
       tasks: this.state.tasks.map((candidate) =>
-        candidate.taskId === taskId ? { ...candidate, status: 'ACTIVE', runId: run.runId, updatedAt: now.toISOString() } : candidate
+        candidate.taskId === taskId
+          ? {
+              ...candidate,
+              status: 'ACTIVE',
+              runId: run.runId,
+              branchSource: resolvedSource.branchSource,
+              updatedAt: nowIso
+            }
+          : candidate
       ),
       runs: [run, ...this.state.runs]
     };
-    const refreshedTasks = this.refreshDependencyStatesForRepo(now.toISOString());
+    const refreshedTasks = this.refreshDependencyStatesForRepo(nowIso);
     await this.persist();
     await this.emit({ type: 'task.updated', payload: { task: this.state.tasks.find((candidate) => candidate.taskId === taskId)! } }, task.repoId);
     await this.emit({ type: 'run.updated', payload: { run } }, task.repoId);
@@ -238,6 +266,7 @@ export class RepoBoardDO extends DurableObject<Env> {
       prUrl: existingRun.prUrl,
       prNumber: existingRun.prNumber,
       baseRunId: existingRun.runId,
+      dependencyContext: existingRun.dependencyContext,
       changeRequest: {
         prompt,
         requestedAt: now.toISOString()
@@ -831,6 +860,7 @@ function cloneRepoBoardState(state: RepoBoardState): RepoBoardState {
       ...run,
       codexProcessId: run.codexProcessId,
       changeRequest: run.changeRequest ? { ...run.changeRequest } : undefined,
+      dependencyContext: run.dependencyContext ? { ...run.dependencyContext } : undefined,
       operatorSession: run.operatorSession ? { ...run.operatorSession } : undefined,
       errors: run.errors.map((error) => ({ ...error })),
       timeline: run.timeline.map((entry) => ({ ...entry })),

--- a/src/server/run-orchestrator.ts
+++ b/src/server/run-orchestrator.ts
@@ -1228,8 +1228,40 @@ async function prepareRunBranchFromTaskSource(
     return;
   }
 
-  const sourceRef = resolveTaskSourceRef(task);
-  if (!sourceRef) {
+  if (task.branchSource?.kind === 'dependency_review_head') {
+    await repoBoard.appendRunLogs(runId, [
+      buildRunLog(
+        runId,
+        `Preparing run branch ${run.branchName} from upstream review head ${task.branchSource.upstreamHeadSha?.slice(0, 12) ?? task.branchSource.resolvedRef}.`,
+        'bootstrap'
+      )
+    ]);
+    const checkout = await sandbox.exec(
+      `cd /workspace/repo && git fetch origin ${shellEscape(task.branchSource.resolvedRef)} && git checkout -B ${shellEscape(run.branchName)} FETCH_HEAD`
+    );
+    await appendCommandLogs(repoBoard, runId, 'bootstrap', checkout.stdout, checkout.stderr);
+    if (!checkout.success) {
+      throw new Error(checkout.stderr || `Failed to prepare run branch ${run.branchName} from upstream review head.`);
+    }
+    return;
+  }
+
+  if (task.branchSource?.kind === 'default_branch') {
+    await repoBoard.appendRunLogs(runId, [
+      buildRunLog(runId, `Preparing run branch ${run.branchName} from default branch ${repo.defaultBranch}.`, 'bootstrap')
+    ]);
+    const checkout = await sandbox.exec(
+      `cd /workspace/repo && git fetch origin ${shellEscape(repo.defaultBranch)} && git checkout -B ${shellEscape(run.branchName)} FETCH_HEAD`
+    );
+    await appendCommandLogs(repoBoard, runId, 'bootstrap', checkout.stdout, checkout.stderr);
+    if (!checkout.success) {
+      throw new Error(checkout.stderr || `Failed to prepare run branch ${run.branchName} from default branch ${repo.defaultBranch}.`);
+    }
+    return;
+  }
+
+  const explicitSourceRef = task.branchSource?.kind === 'explicit_source_ref' ? task.branchSource.resolvedRef : resolveTaskSourceRef(task);
+  if (!explicitSourceRef) {
     const checkout = await sandbox.exec(`cd /workspace/repo && git checkout -b ${shellEscape(run.branchName)}`);
     await appendCommandLogs(repoBoard, runId, 'bootstrap', checkout.stdout, checkout.stderr);
     if (!checkout.success) {
@@ -1238,9 +1270,9 @@ async function prepareRunBranchFromTaskSource(
     return;
   }
 
-  const normalized = normalizeTaskSourceRef(sourceRef, repo.slug);
+  const normalized = normalizeTaskSourceRef(explicitSourceRef, repo.slug);
   await repoBoard.appendRunLogs(runId, [
-    buildRunLog(runId, `Preparing run branch ${run.branchName} from task source ref ${normalized.label}.`, 'bootstrap')
+    buildRunLog(runId, `Preparing run branch ${run.branchName} from explicit source ref ${normalized.label}.`, 'bootstrap')
   ]);
   const checkout = await sandbox.exec(
     `cd /workspace/repo && git fetch origin ${shellEscape(normalized.fetchSpec)} && git checkout -B ${shellEscape(run.branchName)} FETCH_HEAD`

--- a/src/server/shared/real-run.ts
+++ b/src/server/shared/real-run.ts
@@ -42,6 +42,7 @@ type CreateRealRunOptions = {
   prNumber?: number;
   baseRunId?: string;
   changeRequest?: AgentRun['changeRequest'];
+  dependencyContext?: AgentRun['dependencyContext'];
 };
 
 export function createRealRun(task: Task, runId: string, now = new Date(), options?: CreateRealRunOptions): AgentRun {
@@ -56,6 +57,7 @@ export function createRealRun(task: Task, runId: string, now = new Date(), optio
     changeRequest: options?.changeRequest,
     prUrl: options?.prUrl,
     prNumber: options?.prNumber,
+    dependencyContext: options?.dependencyContext,
     errors: [],
     startedAt: nowIso,
     timeline: [{ status: 'QUEUED', at: nowIso, note: 'Run queued for real sandbox execution.' }],

--- a/src/server/shared/run-source-resolution.test.ts
+++ b/src/server/shared/run-source-resolution.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from 'vitest';
+import type { AgentRun, Task } from '../../ui/domain/types';
+import { resolveRunSource } from './run-source-resolution';
+
+function buildTask(taskId: string, overrides: Partial<Task> = {}): Task {
+  return {
+    taskId,
+    repoId: 'repo_demo',
+    title: taskId,
+    taskPrompt: 'prompt',
+    acceptanceCriteria: ['done'],
+    context: { links: [] },
+    status: 'INBOX',
+    createdAt: '2026-03-02T00:00:00.000Z',
+    updatedAt: '2026-03-02T00:00:00.000Z',
+    ...overrides
+  };
+}
+
+function buildRun(taskId: string, status: AgentRun['status'], overrides: Partial<AgentRun> = {}): AgentRun {
+  return {
+    runId: `run_${taskId}`,
+    taskId,
+    repoId: 'repo_demo',
+    status,
+    branchName: `agent/${taskId}/run`,
+    errors: [],
+    startedAt: '2026-03-02T00:00:00.000Z',
+    timeline: [{ status, at: '2026-03-02T00:00:00.000Z' }],
+    simulationProfile: 'happy_path',
+    pendingEvents: [],
+    ...overrides
+  };
+}
+
+describe('resolveRunSource', () => {
+  const resolvedAt = '2026-03-02T01:00:00.000Z';
+
+  it('prefers explicit task source refs over dependency lineage', () => {
+    const upstreamTask = buildTask('task_up', { status: 'REVIEW' });
+    const downstreamTask = buildTask('task_down', {
+      sourceRef: 'feature/explicit',
+      dependencies: [{ upstreamTaskId: 'task_up', mode: 'review_ready' }]
+    });
+    const upstreamRun = buildRun('task_up', 'PR_OPEN', { headSha: 'a'.repeat(40), prNumber: 42 });
+
+    const source = resolveRunSource({
+      task: downstreamTask,
+      tasks: [upstreamTask, downstreamTask],
+      runs: [upstreamRun],
+      defaultBranch: 'main',
+      resolvedAt
+    });
+
+    expect(source.branchSource).toMatchObject({
+      kind: 'explicit_source_ref',
+      resolvedRef: 'feature/explicit'
+    });
+    expect(source.dependencyContext.sourceMode).toBe('explicit_source_ref');
+  });
+
+  it('uses dependency review head when no explicit source exists', () => {
+    const upstreamTask = buildTask('task_up', { status: 'REVIEW' });
+    const downstreamTask = buildTask('task_down', {
+      dependencies: [{ upstreamTaskId: 'task_up', mode: 'review_ready' }]
+    });
+    const upstreamRun = buildRun('task_up', 'WAITING_PREVIEW', { headSha: 'b'.repeat(40), prNumber: 7 });
+
+    const source = resolveRunSource({
+      task: downstreamTask,
+      tasks: [upstreamTask, downstreamTask],
+      runs: [upstreamRun],
+      defaultBranch: 'main',
+      resolvedAt
+    });
+
+    expect(source.branchSource).toMatchObject({
+      kind: 'dependency_review_head',
+      upstreamTaskId: 'task_up',
+      upstreamRunId: 'run_task_up',
+      upstreamPrNumber: 7,
+      upstreamHeadSha: 'b'.repeat(40),
+      resolvedRef: 'b'.repeat(40)
+    });
+    expect(source.dependencyContext).toMatchObject({
+      sourceTaskId: 'task_up',
+      sourceRunId: 'run_task_up',
+      sourcePrNumber: 7,
+      sourceHeadSha: 'b'.repeat(40),
+      sourceMode: 'dependency_review_head'
+    });
+  });
+
+  it('falls back to default branch when multiple dependencies have no primary', () => {
+    const upOne = buildTask('task_up_1', { status: 'REVIEW' });
+    const upTwo = buildTask('task_up_2', { status: 'REVIEW' });
+    const downstreamTask = buildTask('task_down', {
+      dependencies: [
+        { upstreamTaskId: 'task_up_1', mode: 'review_ready' },
+        { upstreamTaskId: 'task_up_2', mode: 'review_ready' }
+      ]
+    });
+
+    const source = resolveRunSource({
+      task: downstreamTask,
+      tasks: [upOne, upTwo, downstreamTask],
+      runs: [
+        buildRun('task_up_1', 'PR_OPEN', { headSha: 'c'.repeat(40), prNumber: 1 }),
+        buildRun('task_up_2', 'PR_OPEN', { headSha: 'd'.repeat(40), prNumber: 2 })
+      ],
+      defaultBranch: 'main',
+      resolvedAt
+    });
+
+    expect(source.branchSource).toMatchObject({
+      kind: 'default_branch',
+      resolvedRef: 'main'
+    });
+    expect(source.dependencyContext.sourceMode).toBe('default_branch');
+  });
+
+  it('uses primary dependency when multiple dependencies exist', () => {
+    const upOne = buildTask('task_up_1', { status: 'REVIEW' });
+    const upTwo = buildTask('task_up_2', { status: 'REVIEW' });
+    const downstreamTask = buildTask('task_down', {
+      dependencies: [
+        { upstreamTaskId: 'task_up_1', mode: 'review_ready' },
+        { upstreamTaskId: 'task_up_2', mode: 'review_ready', primary: true }
+      ]
+    });
+
+    const source = resolveRunSource({
+      task: downstreamTask,
+      tasks: [upOne, upTwo, downstreamTask],
+      runs: [
+        buildRun('task_up_1', 'PR_OPEN', { headSha: 'e'.repeat(40), prNumber: 11 }),
+        buildRun('task_up_2', 'PR_OPEN', { headSha: 'f'.repeat(40), prNumber: 22 })
+      ],
+      defaultBranch: 'main',
+      resolvedAt
+    });
+
+    expect(source.branchSource).toMatchObject({
+      kind: 'dependency_review_head',
+      upstreamTaskId: 'task_up_2',
+      upstreamPrNumber: 22,
+      upstreamHeadSha: 'f'.repeat(40)
+    });
+    expect(source.dependencyContext.sourceTaskId).toBe('task_up_2');
+  });
+
+  it('falls back to default branch when upstream review run has no head/pr context', () => {
+    const upstreamTask = buildTask('task_up', { status: 'REVIEW' });
+    const downstreamTask = buildTask('task_down', {
+      dependencies: [{ upstreamTaskId: 'task_up', mode: 'review_ready' }]
+    });
+
+    const source = resolveRunSource({
+      task: downstreamTask,
+      tasks: [upstreamTask, downstreamTask],
+      runs: [buildRun('task_up', 'PR_OPEN', { prNumber: 19 })],
+      defaultBranch: 'main',
+      resolvedAt
+    });
+
+    expect(source.branchSource.kind).toBe('default_branch');
+    expect(source.dependencyContext.sourceMode).toBe('default_branch');
+  });
+});

--- a/src/server/shared/run-source-resolution.ts
+++ b/src/server/shared/run-source-resolution.ts
@@ -1,0 +1,137 @@
+import type { AgentRun, Task, TaskBranchSource } from '../../ui/domain/types';
+
+const REVIEW_READY_RUN_STATUSES: Set<AgentRun['status']> = new Set([
+  'PR_OPEN',
+  'WAITING_PREVIEW',
+  'EVIDENCE_RUNNING',
+  'DONE'
+]);
+
+type ResolveRunSourceInput = {
+  task: Task;
+  tasks: Task[];
+  runs: AgentRun[];
+  defaultBranch: string;
+  resolvedAt: string;
+};
+
+type ResolvedRunSource = {
+  branchSource: TaskBranchSource;
+  dependencyContext: NonNullable<AgentRun['dependencyContext']>;
+};
+
+export function resolveRunSource({
+  task,
+  tasks,
+  runs,
+  defaultBranch,
+  resolvedAt
+}: ResolveRunSourceInput): ResolvedRunSource {
+  const explicitSourceRef = task.sourceRef?.trim();
+  if (explicitSourceRef) {
+    return {
+      branchSource: {
+        kind: 'explicit_source_ref',
+        resolvedRef: explicitSourceRef,
+        resolvedAt
+      },
+      dependencyContext: {
+        sourceMode: 'explicit_source_ref'
+      }
+    };
+  }
+
+  const dependencyReviewSource = resolveDependencyReviewSource(task, tasks, runs, resolvedAt);
+  if (dependencyReviewSource) {
+    return dependencyReviewSource;
+  }
+
+  return {
+    branchSource: {
+      kind: 'default_branch',
+      resolvedRef: defaultBranch,
+      resolvedAt
+    },
+    dependencyContext: {
+      sourceMode: 'default_branch'
+    }
+  };
+}
+
+function resolveDependencyReviewSource(task: Task, tasks: Task[], runs: AgentRun[], resolvedAt: string): ResolvedRunSource | undefined {
+  const dependency = pickDependencyForLineage(task);
+  if (!dependency) {
+    return undefined;
+  }
+
+  const upstreamTask = tasks.find((candidate) => candidate.taskId === dependency.upstreamTaskId);
+  if (!upstreamTask) {
+    return undefined;
+  }
+
+  const upstreamRun = getLatestRunForTask(runs, dependency.upstreamTaskId);
+  if (!upstreamRun) {
+    return undefined;
+  }
+
+  if (!isReviewReadyRun(upstreamRun) || !upstreamRun.headSha || !upstreamRun.prNumber) {
+    return undefined;
+  }
+
+  return {
+    branchSource: {
+      kind: 'dependency_review_head',
+      upstreamTaskId: upstreamTask.taskId,
+      upstreamRunId: upstreamRun.runId,
+      upstreamPrNumber: upstreamRun.prNumber,
+      upstreamHeadSha: upstreamRun.headSha,
+      resolvedRef: upstreamRun.headSha,
+      resolvedAt
+    },
+    dependencyContext: {
+      sourceTaskId: upstreamTask.taskId,
+      sourceRunId: upstreamRun.runId,
+      sourcePrNumber: upstreamRun.prNumber,
+      sourceHeadSha: upstreamRun.headSha,
+      sourceMode: 'dependency_review_head'
+    }
+  };
+}
+
+function pickDependencyForLineage(task: Task) {
+  const dependencies = task.dependencies ?? [];
+  if (!dependencies.length) {
+    return undefined;
+  }
+
+  if (dependencies.length === 1) {
+    return dependencies[0];
+  }
+
+  const primaryDependencies = dependencies.filter((dependency) => dependency.primary);
+  if (primaryDependencies.length !== 1) {
+    return undefined;
+  }
+
+  return primaryDependencies[0];
+}
+
+function getLatestRunForTask(runs: AgentRun[], taskId: string) {
+  let latestRun: AgentRun | undefined;
+  for (const run of runs) {
+    if (run.taskId !== taskId) {
+      continue;
+    }
+    if (!latestRun || run.startedAt > latestRun.startedAt) {
+      latestRun = run;
+    }
+  }
+  return latestRun;
+}
+
+function isReviewReadyRun(run: AgentRun) {
+  if (REVIEW_READY_RUN_STATUSES.has(run.status)) {
+    return true;
+  }
+  return run.status === 'FAILED' && Boolean(run.prUrl);
+}


### PR DESCRIPTION
Task: S31-04 Source resolution precedence

Enforce source selection order explicit->dependency_review_head->default_branch.

Stage reference: Stage 3.1
Docs: docs/stage_3_1.md

Execution mode: skip preview/evidence steps for this repo.
Source ref: main

Acceptance criteria:
- Implementation compiles and passes relevant checks
- Behavior matches task scope without regressions
- Preview URL and evidence are explicitly out of scope for this repo

Run ID: run_repo_abuiles_minions_mm8u7w150zp7