### PR TITLE
S31-05 Fanout auto-start trigger

### DIFF
--- a/src/server/durable/repo-board.ts
+++ b/src/server/durable/repo-board.ts
@@ -774,12 +774,89 @@ export class RepoBoardDO extends DurableObject<Env> {
 
     const excluded = new Set(excludeTaskIds);
     for (const task of tasks) {
+      if (task.repoId !== repoId) {
+        continue;
+      }
       if (excluded.has(task.taskId)) {
         continue;
       }
       await this.emit({ type: 'task.updated', payload: { task } }, repoId);
     }
+
+    await this.autoStartRunnableDependencyTasks(repoId, tasks.map((task) => task.taskId));
   }
+
+  private async autoStartRunnableDependencyTasks(repoId: string, candidateTaskIds: string[]) {
+    if (!candidateTaskIds.length) {
+      return;
+    }
+
+    const candidateIds = new Set(candidateTaskIds);
+    const repo = await this.getRepo(repoId);
+    const nowIso = new Date().toISOString();
+
+    for (const task of this.state.tasks) {
+      if (task.repoId !== repoId || !candidateIds.has(task.taskId) || !isRunnableDependencyAutoStartTask(task)) {
+        continue;
+      }
+
+      const hasActiveRun = this.state.runs.some((run) => run.taskId === task.taskId && !isTerminalRunStatus(run.status));
+      if (hasActiveRun) {
+        continue;
+      }
+
+      const resolvedSource = resolveRunSource({
+        task,
+        tasks: this.state.tasks,
+        runs: this.state.runs,
+        defaultBranch: repo.defaultBranch,
+        resolvedAt: nowIso
+      });
+      if (resolvedSource.dependencyContext.sourceMode !== 'dependency_review_head') {
+        continue;
+      }
+
+      if (task.automationState && !task.automationState.autoStartedAt) {
+        this.state = {
+          ...this.state,
+          tasks: this.state.tasks.map((candidate) =>
+            candidate.taskId === task.taskId
+              ? {
+                  ...candidate,
+                  automationState: {
+                    ...candidate.automationState!,
+                    autoStartedAt: nowIso
+                  },
+                  updatedAt: nowIso
+                }
+              : candidate
+          )
+        };
+      }
+
+      await this.startRun(task.taskId);
+    }
+  }
+}
+
+function isRunnableDependencyAutoStartTask(task: Task) {
+  if (!task.dependencies?.length) {
+    return false;
+  }
+
+  if (task.dependencyState?.blocked !== false) {
+    return false;
+  }
+
+  if (!task.automationState?.autoStartEligible) {
+    return false;
+  }
+
+  if (task.sourceRef?.trim()) {
+    return false;
+  }
+
+  return task.status !== 'ACTIVE' && task.status !== 'REVIEW' && task.status !== 'DONE';
 }
 
 function validateDependenciesForTask(repoId: string, taskId: string, dependencies: Task['dependencies']) {


### PR DESCRIPTION
Task: S31-05 Fanout auto-start trigger

Auto-start eligible downstream tasks when upstream reaches review-ready state.

Stage reference: Stage 3.1
Docs: docs/stage_3_1.md

Execution mode: skip preview/evidence steps for this repo.


Acceptance criteria:
- Implementation compiles and passes relevant checks
- Behavior matches task scope without regressions
- Preview URL and evidence are explicitly out of scope for this repo

Run ID: run_repo_abuiles_minions_mm8ul252bac4