### PR TITLE
S31-06 Merged-to-main fallback readiness

### DIFF
--- a/src/server/durable/repo-board.ts
+++ b/src/server/durable/repo-board.ts
@@ -21,6 +21,7 @@ import { EMPTY_REPO_BOARD_STATE, type RepoBoardState } from '../shared/state';
 import { applyRunTransition, appendRunError, buildArtifactManifest, createRealRun, type RunTransitionPatch } from '../shared/real-run';
 import { executeRunJob } from '../run-orchestrator';
 import { refreshDependencyStates } from '../shared/dependency-state';
+import { buildLatestRunsByTaskId, isDependencyMergedToDefaultBranch } from '../shared/dependency-readiness';
 import { resolveRunSource } from '../shared/run-source-resolution';
 
 const STORAGE_KEY = 'repo-board-state';
@@ -794,6 +795,8 @@ export class RepoBoardDO extends DurableObject<Env> {
     const candidateIds = new Set(candidateTaskIds);
     const repo = await this.getRepo(repoId);
     const nowIso = new Date().toISOString();
+    const tasksById = new Map(this.state.tasks.map((task) => [task.taskId, task]));
+    const latestRunsByTaskId = buildLatestRunsByTaskId(this.state.runs);
 
     for (const task of this.state.tasks) {
       if (task.repoId !== repoId || !candidateIds.has(task.taskId) || !isRunnableDependencyAutoStartTask(task)) {
@@ -812,7 +815,7 @@ export class RepoBoardDO extends DurableObject<Env> {
         defaultBranch: repo.defaultBranch,
         resolvedAt: nowIso
       });
-      if (resolvedSource.dependencyContext.sourceMode !== 'dependency_review_head') {
+      if (!canAutoStartFromResolvedDependencySource(task, resolvedSource.dependencyContext.sourceMode, tasksById, latestRunsByTaskId)) {
         continue;
       }
 
@@ -837,6 +840,40 @@ export class RepoBoardDO extends DurableObject<Env> {
       await this.startRun(task.taskId);
     }
   }
+}
+
+function canAutoStartFromResolvedDependencySource(
+  task: Task,
+  sourceMode: NonNullable<AgentRun['dependencyContext']>['sourceMode'],
+  tasksById: Map<string, Task>,
+  latestRunsByTaskId: Map<string, AgentRun>
+) {
+  if (sourceMode === 'dependency_review_head') {
+    return true;
+  }
+
+  if (sourceMode !== 'default_branch') {
+    return false;
+  }
+
+  if (task.status !== 'INBOX' && task.status !== 'READY') {
+    return false;
+  }
+
+  const dependencies = task.dependencies ?? [];
+  if (!dependencies.length) {
+    return false;
+  }
+
+  for (const dependency of dependencies) {
+    const upstreamTask = tasksById.get(dependency.upstreamTaskId);
+    const upstreamRun = latestRunsByTaskId.get(dependency.upstreamTaskId);
+    if (!upstreamTask || !isDependencyMergedToDefaultBranch(upstreamTask, upstreamRun)) {
+      return false;
+    }
+  }
+
+  return true;
 }
 
 function isRunnableDependencyAutoStartTask(task: Task) {

--- a/src/server/shared/dependency-readiness.ts
+++ b/src/server/shared/dependency-readiness.ts
@@ -1,0 +1,39 @@
+import type { AgentRun, Task } from '../../ui/domain/types';
+
+const REVIEW_READY_RUN_STATUSES: Set<AgentRun['status']> = new Set([
+  'PR_OPEN',
+  'WAITING_PREVIEW',
+  'EVIDENCE_RUNNING',
+  'DONE'
+]);
+
+export function isDependencyMergedToDefaultBranch(task: Task, latestRun: AgentRun | undefined) {
+  return task.status === 'DONE' && Boolean(latestRun?.prUrl && latestRun.prNumber);
+}
+
+export function isDependencyReviewReady(task: Task, latestRun: AgentRun | undefined) {
+  if (task.status === 'REVIEW' || task.status === 'DONE') {
+    return true;
+  }
+
+  if (!latestRun) {
+    return false;
+  }
+
+  if (REVIEW_READY_RUN_STATUSES.has(latestRun.status)) {
+    return true;
+  }
+
+  return latestRun.status === 'FAILED' && Boolean(latestRun.prUrl);
+}
+
+export function buildLatestRunsByTaskId(runs: AgentRun[]) {
+  const latestRunsByTaskId = new Map<string, AgentRun>();
+  for (const run of runs) {
+    const current = latestRunsByTaskId.get(run.taskId);
+    if (!current || run.startedAt > current.startedAt) {
+      latestRunsByTaskId.set(run.taskId, run);
+    }
+  }
+  return latestRunsByTaskId;
+}

--- a/src/server/shared/dependency-state.test.ts
+++ b/src/server/shared/dependency-state.test.ts
@@ -89,6 +89,27 @@ describe('refreshDependencyStates', () => {
     expect(refreshed.dependencyState?.reasons[0]?.state).toBe('ready');
   });
 
+  it('uses merged-to-default readiness when upstream task is done with a PR run', () => {
+    const upstream = buildTask('task_up', { status: 'DONE' });
+    const downstream = buildTask('task_down', {
+      dependencies: [{ upstreamTaskId: 'task_up', mode: 'review_ready' }]
+    });
+
+    const result = refreshDependencyStates(
+      [upstream, downstream],
+      [buildRun('task_up', 'DONE', { prUrl: 'https://github.com/acme/repo/pull/10', prNumber: 10 })],
+      '2026-03-02T01:15:00.000Z'
+    );
+    const refreshed = result.tasks.find((task) => task.taskId === 'task_down')!;
+
+    expect(refreshed.dependencyState?.blocked).toBe(false);
+    expect(refreshed.dependencyState?.reasons[0]).toMatchObject({
+      upstreamTaskId: 'task_up',
+      state: 'ready',
+      message: 'Upstream task task_up is merged into the default branch.'
+    });
+  });
+
   it('preserves existing unblockedAt while still unblocked', () => {
     const upstream = buildTask('task_up', { status: 'REVIEW' });
     const downstream = buildTask('task_down', {

--- a/src/server/shared/dependency-state.ts
+++ b/src/server/shared/dependency-state.ts
@@ -1,16 +1,10 @@
 import type { AgentRun, Task, TaskAutomationState, TaskDependencyReason, TaskDependencyState } from '../../ui/domain/types';
+import { buildLatestRunsByTaskId, isDependencyMergedToDefaultBranch, isDependencyReviewReady } from './dependency-readiness';
 
 type RefreshDependencyStatesResult = {
   tasks: Task[];
   changedTaskIds: string[];
 };
-
-const REVIEW_READY_RUN_STATUSES: Set<AgentRun['status']> = new Set([
-  'PR_OPEN',
-  'WAITING_PREVIEW',
-  'EVIDENCE_RUNNING',
-  'DONE'
-]);
 
 export function refreshDependencyStates(tasks: Task[], runs: AgentRun[], nowIso: string): RefreshDependencyStatesResult {
   if (!tasks.length) {
@@ -51,17 +45,6 @@ export function refreshDependencyStates(tasks: Task[], runs: AgentRun[], nowIso:
   return { tasks: nextTasks, changedTaskIds };
 }
 
-function buildLatestRunsByTaskId(runs: AgentRun[]) {
-  const latestRunsByTaskId = new Map<string, AgentRun>();
-  for (const run of runs) {
-    const current = latestRunsByTaskId.get(run.taskId);
-    if (!current || run.startedAt > current.startedAt) {
-      latestRunsByTaskId.set(run.taskId, run);
-    }
-  }
-  return latestRunsByTaskId;
-}
-
 function buildDependencyState(
   task: Task,
   tasksById: Map<string, Task>,
@@ -79,7 +62,15 @@ function buildDependencyState(
     }
 
     const upstreamRun = latestRunsByTaskId.get(dependency.upstreamTaskId);
-    if (isReviewReady(upstreamTask, upstreamRun)) {
+    if (isDependencyMergedToDefaultBranch(upstreamTask, upstreamRun)) {
+      return {
+        upstreamTaskId: dependency.upstreamTaskId,
+        state: 'ready',
+        message: `Upstream task ${dependency.upstreamTaskId} is merged into the default branch.`
+      };
+    }
+
+    if (isDependencyReviewReady(upstreamTask, upstreamRun)) {
       return {
         upstreamTaskId: dependency.upstreamTaskId,
         state: 'ready',
@@ -110,22 +101,6 @@ function buildAutomationState(automationState: TaskAutomationState | undefined, 
     ...automationState,
     lastDependencyRefreshAt: nowIso
   };
-}
-
-function isReviewReady(task: Task, latestRun: AgentRun | undefined) {
-  if (task.status === 'REVIEW' || task.status === 'DONE') {
-    return true;
-  }
-
-  if (!latestRun) {
-    return false;
-  }
-
-  if (REVIEW_READY_RUN_STATUSES.has(latestRun.status)) {
-    return true;
-  }
-
-  return latestRun.status === 'FAILED' && Boolean(latestRun.prUrl);
 }
 
 function areDependencyStatesEqual(left: TaskDependencyState | undefined, right: TaskDependencyState | undefined) {

--- a/src/server/shared/run-source-resolution.test.ts
+++ b/src/server/shared/run-source-resolution.test.ts
@@ -166,4 +166,23 @@ describe('resolveRunSource', () => {
     expect(source.branchSource.kind).toBe('default_branch');
     expect(source.dependencyContext.sourceMode).toBe('default_branch');
   });
+
+  it('uses default branch after upstream is merged, even if review lineage metadata exists', () => {
+    const upstreamTask = buildTask('task_up', { status: 'DONE' });
+    const downstreamTask = buildTask('task_down', {
+      dependencies: [{ upstreamTaskId: 'task_up', mode: 'review_ready' }]
+    });
+
+    const source = resolveRunSource({
+      task: downstreamTask,
+      tasks: [upstreamTask, downstreamTask],
+      runs: [buildRun('task_up', 'DONE', { headSha: 'a'.repeat(40), prNumber: 45, prUrl: 'https://github.com/acme/repo/pull/45' })],
+      defaultBranch: 'main',
+      resolvedAt
+    });
+
+    expect(source.branchSource.kind).toBe('default_branch');
+    expect(source.branchSource.resolvedRef).toBe('main');
+    expect(source.dependencyContext.sourceMode).toBe('default_branch');
+  });
 });

--- a/src/server/shared/run-source-resolution.ts
+++ b/src/server/shared/run-source-resolution.ts
@@ -1,11 +1,5 @@
 import type { AgentRun, Task, TaskBranchSource } from '../../ui/domain/types';
-
-const REVIEW_READY_RUN_STATUSES: Set<AgentRun['status']> = new Set([
-  'PR_OPEN',
-  'WAITING_PREVIEW',
-  'EVIDENCE_RUNNING',
-  'DONE'
-]);
+import { isDependencyMergedToDefaultBranch, isDependencyReviewReady } from './dependency-readiness';
 
 type ResolveRunSourceInput = {
   task: Task;
@@ -74,7 +68,11 @@ function resolveDependencyReviewSource(task: Task, tasks: Task[], runs: AgentRun
     return undefined;
   }
 
-  if (!isReviewReadyRun(upstreamRun) || !upstreamRun.headSha || !upstreamRun.prNumber) {
+  if (isDependencyMergedToDefaultBranch(upstreamTask, upstreamRun)) {
+    return undefined;
+  }
+
+  if (!isDependencyReviewReady(upstreamTask, upstreamRun) || !upstreamRun.headSha || !upstreamRun.prNumber) {
     return undefined;
   }
 
@@ -127,11 +125,4 @@ function getLatestRunForTask(runs: AgentRun[], taskId: string) {
     }
   }
   return latestRun;
-}
-
-function isReviewReadyRun(run: AgentRun) {
-  if (REVIEW_READY_RUN_STATUSES.has(run.status)) {
-    return true;
-  }
-  return run.status === 'FAILED' && Boolean(run.prUrl);
 }


### PR DESCRIPTION
Task: S31-06 Merged-to-main fallback readiness

Treat downstream tasks as ready from default branch when upstream is merged.

Stage reference: Stage 3.1
Docs: docs/stage_3_1.md

Execution mode: skip preview/evidence steps for this repo.


Acceptance criteria:
- Implementation compiles and passes relevant checks
- Behavior matches task scope without regressions
- Preview URL and evidence are explicitly out of scope for this repo

Run ID: run_repo_abuiles_minions_mm8utpry5m2b