### PR TITLE
S31-07 Idempotency and duplicate-start guards

### DIFF
--- a/src/server/durable/repo-board.ts
+++ b/src/server/durable/repo-board.ts
@@ -186,7 +186,7 @@ export class RepoBoardDO extends DurableObject<Env> {
     return finalTask;
   }
 
-  async startRun(taskId: string, options?: { forceNew?: boolean; baseRunId?: string }): Promise<AgentRun> {
+  async startRun(taskId: string, options?: { forceNew?: boolean; baseRunId?: string; dependencyAutoStart?: boolean }): Promise<AgentRun> {
     await this.ready;
     const task = this.state.tasks.find((candidate) => candidate.taskId === taskId);
     if (!task) {
@@ -196,6 +196,12 @@ export class RepoBoardDO extends DurableObject<Env> {
     const existing = this.state.runs.find((run) => run.taskId === taskId && !isTerminalRunStatus(run.status));
     if (existing && !options?.forceNew) {
       return existing;
+    }
+    if (options?.dependencyAutoStart && task.runId) {
+      const existingRun = this.state.runs.find((run) => run.runId === task.runId) ?? this.state.runs.find((run) => run.taskId === taskId);
+      if (existingRun) {
+        return existingRun;
+      }
     }
 
     const repo = await this.getRepo(task.repoId);
@@ -229,6 +235,12 @@ export class RepoBoardDO extends DurableObject<Env> {
               ...candidate,
               status: 'ACTIVE',
               runId: run.runId,
+              automationState: options?.dependencyAutoStart && candidate.automationState && !candidate.automationState.autoStartedAt
+                ? {
+                    ...candidate.automationState,
+                    autoStartedAt: nowIso
+                  }
+                : candidate.automationState,
               branchSource: resolvedSource.branchSource,
               updatedAt: nowIso
             }
@@ -797,9 +809,13 @@ export class RepoBoardDO extends DurableObject<Env> {
     const nowIso = new Date().toISOString();
     const tasksById = new Map(this.state.tasks.map((task) => [task.taskId, task]));
     const latestRunsByTaskId = buildLatestRunsByTaskId(this.state.runs);
+    const runHistoryTaskIds = new Set(this.state.runs.map((run) => run.taskId));
 
     for (const task of this.state.tasks) {
       if (task.repoId !== repoId || !candidateIds.has(task.taskId) || !isRunnableDependencyAutoStartTask(task)) {
+        continue;
+      }
+      if (task.runId || runHistoryTaskIds.has(task.taskId) || task.automationState?.autoStartedAt) {
         continue;
       }
 
@@ -819,25 +835,7 @@ export class RepoBoardDO extends DurableObject<Env> {
         continue;
       }
 
-      if (task.automationState && !task.automationState.autoStartedAt) {
-        this.state = {
-          ...this.state,
-          tasks: this.state.tasks.map((candidate) =>
-            candidate.taskId === task.taskId
-              ? {
-                  ...candidate,
-                  automationState: {
-                    ...candidate.automationState!,
-                    autoStartedAt: nowIso
-                  },
-                  updatedAt: nowIso
-                }
-              : candidate
-          )
-        };
-      }
-
-      await this.startRun(task.taskId);
+      await this.startRun(task.taskId, { dependencyAutoStart: true });
     }
   }
 }


### PR DESCRIPTION
Task: S31-07 Idempotency and duplicate-start guards

Prevent duplicate run starts from repeated dependency signals.

Stage reference: Stage 3.1
Docs: docs/stage_3_1.md

Execution mode: skip preview/evidence steps for this repo.


Acceptance criteria:
- Implementation compiles and passes relevant checks
- Behavior matches task scope without regressions
- Preview URL and evidence are explicitly out of scope for this repo

Run ID: run_repo_abuiles_minions_mm8v2mr421vo