### PR TITLE
S35-03 Provider-neutral source refs and review fields

### DIFF
--- a/src/server/durable/repo-board.ts
+++ b/src/server/durable/repo-board.ts
@@ -23,6 +23,7 @@ import { executeRunJob } from '../run-orchestrator';
 import { refreshDependencyStates } from '../shared/dependency-state';
 import { buildLatestRunsByTaskId, isDependencyMergedToDefaultBranch } from '../shared/dependency-readiness';
 import { resolveRunSource } from '../shared/run-source-resolution';
+import { hasRunReview, normalizeDependencyReviewMetadata, normalizeRunReviewMetadata, normalizeTaskBranchSourceReviewMetadata } from '../../shared/scm';
 
 const STORAGE_KEY = 'repo-board-state';
 const LOCAL_JOBS_KEY = 'repo-board-local-jobs';
@@ -303,6 +304,9 @@ export class RepoBoardDO extends DurableObject<Env> {
     const now = new Date();
     const nextRun = createRealRun(task, createRunId(task.repoId), now, {
       branchName: existingRun.branchName,
+      reviewUrl: existingRun.reviewUrl,
+      reviewNumber: existingRun.reviewNumber,
+      reviewProvider: existingRun.reviewProvider,
       prUrl: existingRun.prUrl,
       prNumber: existingRun.prNumber,
       baseRunId: existingRun.runId,
@@ -505,7 +509,7 @@ export class RepoBoardDO extends DurableObject<Env> {
 
     const nextTask: Task = {
       ...task,
-      status: updated.prUrl ? 'REVIEW' : 'FAILED',
+      status: hasRunReview(updated) ? 'REVIEW' : 'FAILED',
       updatedAt: nowIso,
       runId
     };
@@ -964,7 +968,7 @@ function deriveTaskStatus(run: AgentRun, current: TaskStatus): TaskStatus {
     return 'REVIEW';
   }
   if (run.status === 'FAILED') {
-    return run.prUrl ? 'REVIEW' : 'FAILED';
+    return hasRunReview(run) ? 'REVIEW' : 'FAILED';
   }
   if (run.status === 'QUEUED' || run.status === 'BOOTSTRAPPING' || run.status === 'RUNNING_CODEX' || run.status === 'OPERATOR_CONTROLLED' || run.status === 'RUNNING_TESTS' || run.status === 'PUSHING_BRANCH') {
     return 'ACTIVE';
@@ -1000,10 +1004,10 @@ function cloneRepoBoardState(state: RepoBoardState): RepoBoardState {
       uiMeta: task.uiMeta ? { ...task.uiMeta } : undefined
     })),
     runs: state.runs.map((run) => ({
-      ...run,
+      ...normalizeRunReviewMetadata(run),
       codexProcessId: run.codexProcessId,
       changeRequest: run.changeRequest ? { ...run.changeRequest } : undefined,
-      dependencyContext: run.dependencyContext ? { ...run.dependencyContext } : undefined,
+      dependencyContext: run.dependencyContext ? normalizeDependencyReviewMetadata({ ...run.dependencyContext }) : undefined,
       operatorSession: run.operatorSession ? { ...run.operatorSession } : undefined,
       errors: run.errors.map((error) => ({ ...error })),
       timeline: run.timeline.map((entry) => ({ ...entry })),
@@ -1032,8 +1036,14 @@ function cloneRepoBoardState(state: RepoBoardState): RepoBoardState {
 
 function normalizeRepoBoardState(state?: Partial<RepoBoardState> | null): RepoBoardState {
   return {
-    tasks: state?.tasks ?? [],
-    runs: state?.runs ?? [],
+    tasks: (state?.tasks ?? []).map((task) => ({
+      ...task,
+      branchSource: cloneTaskBranchSource(task.branchSource)
+    })),
+    runs: (state?.runs ?? []).map((run) => ({
+      ...normalizeRunReviewMetadata(run),
+      dependencyContext: run.dependencyContext ? normalizeDependencyReviewMetadata({ ...run.dependencyContext }) : undefined
+    })),
     logs: (state?.logs ?? [])
       .slice(-MAX_LOG_ENTRIES)
       .map((log) => ({ ...log, message: trimText(log.message, MAX_LOG_MESSAGE_CHARS) })),
@@ -1076,5 +1086,5 @@ function cloneTaskAutomationState(automationState: Task['automationState']) {
 }
 
 function cloneTaskBranchSource(branchSource: Task['branchSource']) {
-  return branchSource ? { ...branchSource } : undefined;
+  return branchSource ? normalizeTaskBranchSourceReviewMetadata({ ...branchSource }) : undefined;
 }

--- a/src/server/http/validation.test.ts
+++ b/src/server/http/validation.test.ts
@@ -33,6 +33,9 @@ describe('task validation', () => {
           kind: 'dependency_review_head',
           upstreamTaskId: 'task_upstream',
           upstreamRunId: 'run_upstream',
+          upstreamReviewUrl: 'https://gitlab.example.com/group/repo/-/merge_requests/42',
+          upstreamReviewNumber: 42,
+          upstreamReviewProvider: 'gitlab',
           upstreamPrNumber: 42,
           upstreamHeadSha: 'abc123',
           resolvedRef: 'refs/heads/agent/task_upstream/run_upstream',
@@ -46,6 +49,7 @@ describe('task validation', () => {
     expect(parsed.dependencyState?.reasons[0]?.state).toBe('ready');
     expect(parsed.automationState?.autoStartEligible).toBe(true);
     expect(parsed.branchSource?.kind).toBe('dependency_review_head');
+    expect(parsed.branchSource?.upstreamReviewProvider).toBe('gitlab');
   });
 
   it('rejects create payload with multiple primary dependencies', () => {
@@ -90,12 +94,12 @@ describe('task validation', () => {
       parseUpdateTaskInput({
         branchSource: {
           kind: 'dependency_review_head',
-          upstreamPrNumber: 0,
+          upstreamReviewNumber: 0,
           resolvedRef: 'refs/heads/demo',
           resolvedAt: '2026-03-02T00:00:00.000Z'
         }
       })
-    ).toThrow('Invalid branchSource.upstreamPrNumber.');
+    ).toThrow('Invalid branchSource.upstreamReviewNumber.');
   });
 });
 

--- a/src/server/http/validation.ts
+++ b/src/server/http/validation.ts
@@ -192,6 +192,16 @@ function readBranchSource(value: unknown, required = true): CreateTaskInput['bra
     kind: readEnumValue(value.kind, 'branchSource.kind', new Set(['explicit_source_ref', 'dependency_review_head', 'default_branch'] as const))!,
     upstreamTaskId: readString(value.upstreamTaskId, 'branchSource.upstreamTaskId', false),
     upstreamRunId: readString(value.upstreamRunId, 'branchSource.upstreamRunId', false),
+    upstreamReviewUrl: readString(value.upstreamReviewUrl, 'branchSource.upstreamReviewUrl', false),
+    upstreamReviewNumber: hasOwn(value, 'upstreamReviewNumber')
+      ? (() => {
+          if (typeof value.upstreamReviewNumber !== 'number' || !Number.isInteger(value.upstreamReviewNumber) || value.upstreamReviewNumber < 1) {
+            throw badRequest('Invalid branchSource.upstreamReviewNumber.');
+          }
+          return value.upstreamReviewNumber;
+        })()
+      : undefined,
+    upstreamReviewProvider: readEnumValue(value.upstreamReviewProvider, 'branchSource.upstreamReviewProvider', SCM_PROVIDERS, false),
     upstreamPrNumber: hasOwn(value, 'upstreamPrNumber')
       ? (() => {
           if (typeof value.upstreamPrNumber !== 'number' || !Number.isInteger(value.upstreamPrNumber) || value.upstreamPrNumber < 1) {

--- a/src/server/run-orchestrator.ts
+++ b/src/server/run-orchestrator.ts
@@ -14,8 +14,10 @@ import {
   type CodexRateLimitsResponse
 } from './codex-rate-limit';
 import { getRepoHost } from '../shared/scm';
+import { getRunReviewNumber, getRunReviewUrl } from '../shared/scm';
 import type { ScmAdapter, ScmAdapterCredential } from './scm/adapter';
 import { getScmAdapter } from './scm/registry';
+import { getScmSourceRefFetchSpec } from './scm/source-ref';
 
 type WorkflowBinding<T> = {
   create(options?: { id?: string; params?: T; retention?: { successRetention?: string | number; errorRetention?: string | number } }): Promise<{ id: string }>;
@@ -255,7 +257,7 @@ cat /workspace/task.txt | codex exec -m ${codexModel} -c model_reasoning_effort=
 
   try {
     const latestRun = await repoBoard.getRun(params.runId);
-    if (latestRun.prUrl && latestRun.prNumber) {
+    if (getRunReviewUrl(latestRun) && getRunReviewNumber(latestRun)) {
       await repoBoard.transitionRun(params.runId, {
         status: 'PR_OPEN',
         previewStatus: 'DISCOVERING',
@@ -265,6 +267,9 @@ cat /workspace/task.txt | codex exec -m ${codexModel} -c model_reasoning_effort=
       const pr = await scmAdapter.createReviewRequest(repo, detail.task, latestRun, scmCredential);
       await repoBoard.transitionRun(params.runId, {
         status: 'PR_OPEN',
+        reviewUrl: pr.url,
+        reviewNumber: pr.number,
+        reviewProvider: pr.provider,
         prNumber: pr.number,
         prUrl: pr.url,
         previewStatus: 'DISCOVERING',
@@ -339,7 +344,7 @@ npx -y playwright install chromium
 
   const updated = await repoBoard.storeArtifactManifest(runId);
   await persistArtifactManifest(env, updated.runId, updated.artifactManifest);
-  if (updated.prNumber) {
+  if (getRunReviewNumber(updated)) {
     const scmAdapter = getScmAdapter(repo);
     const scmCredential = await getScmCredential(env, board, repo, scmAdapter);
     await scmAdapter.upsertRunComment(repo, task, updated, scmCredential);
@@ -1294,7 +1299,7 @@ async function prepareRunBranchFromTaskSource(
   run: Awaited<ReturnType<RepoBoardDO['getRun']>>,
   scmAdapter: ScmAdapter
 ) {
-  if (run.changeRequest?.prompt && run.prUrl) {
+  if (run.changeRequest?.prompt && getRunReviewUrl(run)) {
     await repoBoard.appendRunLogs(runId, [
       buildRunLog(runId, `Preparing existing PR branch ${run.branchName} for a review change request.`, 'bootstrap')
     ]);
@@ -1357,7 +1362,7 @@ async function prepareRunBranchFromTaskSource(
     buildRunLog(runId, `Preparing run branch ${run.branchName} from explicit source ref ${normalized.label}.`, 'bootstrap')
   ]);
   const checkout = await sandbox.exec(
-    `cd /workspace/repo && git fetch origin ${shellEscape(normalized.fetchSpec)} && git checkout -B ${shellEscape(run.branchName)} FETCH_HEAD`
+    `cd /workspace/repo && git fetch origin ${shellEscape(getScmSourceRefFetchSpec(normalized))} && git checkout -B ${shellEscape(run.branchName)} FETCH_HEAD`
   );
   await appendCommandLogs(repoBoard, runId, 'bootstrap', checkout.stdout, checkout.stderr);
   if (!checkout.success) {

--- a/src/server/scm/adapter.ts
+++ b/src/server/scm/adapter.ts
@@ -1,15 +1,12 @@
 import type { AgentRun, Repo, ScmProvider, Task } from '../../ui/domain/types';
+import type { ScmSourceRef } from './source-ref';
 
 export type ScmAdapterCredential = {
   token: string;
 };
 
-export type NormalizedScmSourceRef = {
-  fetchSpec: string;
-  label: string;
-};
-
 export type ScmReviewRef = {
+  provider: ScmProvider;
   number: number;
   url: string;
 };
@@ -37,7 +34,7 @@ export type ScmCommitCheck = {
 
 export type ScmAdapter = {
   provider: ScmProvider;
-  normalizeSourceRef(sourceRef: string, repo: Repo): NormalizedScmSourceRef;
+  normalizeSourceRef(sourceRef: string, repo: Repo): ScmSourceRef;
   inferSourceRefFromTask(task: Pick<Task, 'sourceRef' | 'title' | 'description' | 'taskPrompt'>, repo: Repo): string | undefined;
   buildCloneUrl(repo: Repo, credential: ScmAdapterCredential): string;
   createReviewRequest(repo: Repo, task: Task, run: AgentRun, credential: ScmAdapterCredential): Promise<ScmReviewRef>;

--- a/src/server/scm/github.test.ts
+++ b/src/server/scm/github.test.ts
@@ -64,11 +64,15 @@ describe('GitHubScmAdapter', () => {
 
   it('keeps GitHub source-ref normalization behavior compatible', () => {
     expect(githubScmAdapter.normalizeSourceRef('https://github.com/acme/demo/pull/42', buildRepo())).toEqual({
-      fetchSpec: 'pull/42/head',
-      label: 'PR #42'
+      kind: 'review_head',
+      value: 'pull/42/head',
+      label: 'PR #42',
+      reviewNumber: 42,
+      reviewProvider: 'github'
     });
     expect(githubScmAdapter.normalizeSourceRef('https://github.com/acme/demo/tree/feature/minions', buildRepo())).toEqual({
-      fetchSpec: 'feature/minions',
+      kind: 'branch',
+      value: 'feature/minions',
       label: 'branch feature/minions'
     });
     expect(() => githubScmAdapter.normalizeSourceRef('https://github.com/other/repo/pull/1', buildRepo())).toThrow(
@@ -84,7 +88,7 @@ describe('GitHubScmAdapter', () => {
 
     const result = await githubScmAdapter.createReviewRequest(buildRepo(), buildTask(), buildRun(), { token: 'ghp_test' });
 
-    expect(result).toEqual({ number: 123, url: 'https://github.com/acme/demo/pull/123' });
+    expect(result).toEqual({ provider: 'github', number: 123, url: 'https://github.com/acme/demo/pull/123' });
     expect(fetchMock).toHaveBeenCalledWith(
       'https://api.github.com/repos/acme/demo/pulls',
       expect.objectContaining({

--- a/src/server/scm/github.ts
+++ b/src/server/scm/github.ts
@@ -1,19 +1,26 @@
 import { buildGithubApiBaseUrl, buildGithubGitUrl, getRepoProjectPath, getRepoScmBaseUrl } from '../../shared/scm';
 import type { AgentRun, Repo, Task } from '../../ui/domain/types';
-import type { NormalizedScmSourceRef, ScmAdapter, ScmAdapterCredential, ScmCommitCheck, ScmReviewRef, ScmReviewState } from './adapter';
+import type { ScmAdapter, ScmAdapterCredential, ScmCommitCheck, ScmReviewRef, ScmReviewState } from './adapter';
+import type { ScmSourceRef } from './source-ref';
 
 export class GitHubScmAdapter implements ScmAdapter {
   readonly provider = 'github' as const;
 
-  normalizeSourceRef(sourceRef: string, repo: Repo): NormalizedScmSourceRef {
+  normalizeSourceRef(sourceRef: string, repo: Repo): ScmSourceRef {
     const trimmed = sourceRef.trim();
     const pullHeadMatch = trimmed.match(/^(?:refs\/)?pull\/(\d+)\/head$/i);
     if (pullHeadMatch) {
-      return { fetchSpec: `pull/${pullHeadMatch[1]}/head`, label: `PR #${pullHeadMatch[1]}` };
+      return {
+        kind: 'review_head',
+        value: `pull/${pullHeadMatch[1]}/head`,
+        label: `PR #${pullHeadMatch[1]}`,
+        reviewNumber: Number.parseInt(pullHeadMatch[1], 10),
+        reviewProvider: this.provider
+      };
     }
 
     if (/^[0-9a-f]{7,40}$/i.test(trimmed)) {
-      return { fetchSpec: trimmed, label: `commit ${trimmed.slice(0, 7)}` };
+      return { kind: 'commit', value: trimmed, label: `commit ${trimmed.slice(0, 7)}` };
     }
 
     try {
@@ -34,22 +41,28 @@ export class GitHubScmAdapter implements ScmAdapter {
       }
 
       if (parts[2] === 'pull' && parts[3]) {
-        return { fetchSpec: `pull/${parts[3]}/head`, label: `PR #${parts[3]}` };
+        return {
+          kind: 'review_head',
+          value: `pull/${parts[3]}/head`,
+          label: `PR #${parts[3]}`,
+          reviewNumber: Number.parseInt(parts[3], 10),
+          reviewProvider: this.provider
+        };
       }
 
       if (parts[2] === 'tree' && parts.length >= 4) {
         const branch = decodeURIComponent(parts.slice(3).join('/'));
-        return { fetchSpec: branch, label: `branch ${branch}` };
+        return { kind: 'branch', value: branch, label: `branch ${branch}` };
       }
 
       if (parts[2] === 'commit' && parts[3]) {
-        return { fetchSpec: parts[3], label: `commit ${parts[3].slice(0, 7)}` };
+        return { kind: 'commit', value: parts[3], label: `commit ${parts[3].slice(0, 7)}` };
       }
 
       throw new Error(`Unsupported task source ref URL: ${trimmed}`);
     } catch (error) {
       if (error instanceof TypeError) {
-        return { fetchSpec: trimmed, label: trimmed };
+        return { kind: 'branch', value: trimmed, label: trimmed };
       }
 
       throw error;
@@ -105,11 +118,12 @@ export class GitHubScmAdapter implements ScmAdapter {
       throw new Error(`GitHub PR creation failed with status ${response.status}.`);
     }
     const payload = await response.json() as { number: number; html_url: string };
-    return { number: payload.number, url: payload.html_url };
+    return { provider: this.provider, number: payload.number, url: payload.html_url };
   }
 
   async upsertRunComment(repo: Repo, task: Task, run: AgentRun, credential: ScmAdapterCredential) {
-    if (!run.prNumber) {
+    const reviewNumber = run.reviewNumber ?? run.prNumber;
+    if (!reviewNumber) {
       return;
     }
 
@@ -126,7 +140,7 @@ export class GitHubScmAdapter implements ScmAdapter {
       run.artifactManifest?.video ? `Video: ${run.artifactManifest.video.key}` : undefined
     ].filter(Boolean).join('\n');
 
-    const commentsResponse = await githubRequest(repo, `/issues/${run.prNumber}/comments`, credential.token);
+    const commentsResponse = await githubRequest(repo, `/issues/${reviewNumber}/comments`, credential.token);
     const comments = await commentsResponse.json() as Array<{ id: number; body?: string }>;
     const existing = comments.find((comment) => comment.body?.includes(marker));
     if (existing) {
@@ -137,18 +151,19 @@ export class GitHubScmAdapter implements ScmAdapter {
       return;
     }
 
-    await githubRequest(repo, `/issues/${run.prNumber}/comments`, credential.token, {
+    await githubRequest(repo, `/issues/${reviewNumber}/comments`, credential.token, {
       method: 'POST',
       body: JSON.stringify({ body })
     });
   }
 
   async getReviewState(repo: Repo, run: AgentRun, credential: ScmAdapterCredential): Promise<ScmReviewState> {
-    if (!run.prNumber) {
+    const reviewNumber = run.reviewNumber ?? run.prNumber;
+    if (!reviewNumber) {
       return { exists: false };
     }
 
-    const response = await githubRequest(repo, `/pulls/${run.prNumber}`, credential.token);
+    const response = await githubRequest(repo, `/pulls/${reviewNumber}`, credential.token);
     if (response.status === 404) {
       return { exists: false };
     }

--- a/src/server/scm/source-ref.ts
+++ b/src/server/scm/source-ref.ts
@@ -1,0 +1,22 @@
+import type { ScmProvider } from '../../ui/domain/types';
+
+export type ScmSourceRef =
+  | { kind: 'branch'; value: string; label: string }
+  | { kind: 'commit'; value: string; label: string }
+  | { kind: 'review_head'; value: string; label: string; reviewNumber: number; reviewProvider?: ScmProvider };
+
+export type LegacyNormalizedScmSourceRef = {
+  fetchSpec: string;
+  label: string;
+};
+
+export function getScmSourceRefFetchSpec(sourceRef: ScmSourceRef) {
+  return sourceRef.value;
+}
+
+export function toLegacyNormalizedScmSourceRef(sourceRef: ScmSourceRef): LegacyNormalizedScmSourceRef {
+  return {
+    fetchSpec: getScmSourceRefFetchSpec(sourceRef),
+    label: sourceRef.label
+  };
+}

--- a/src/server/shared/dependency-readiness.ts
+++ b/src/server/shared/dependency-readiness.ts
@@ -1,4 +1,5 @@
 import type { AgentRun, Task } from '../../ui/domain/types';
+import { getRunReviewNumber, hasRunReview } from '../../shared/scm';
 
 const REVIEW_READY_RUN_STATUSES: Set<AgentRun['status']> = new Set([
   'PR_OPEN',
@@ -8,7 +9,7 @@ const REVIEW_READY_RUN_STATUSES: Set<AgentRun['status']> = new Set([
 ]);
 
 export function isDependencyMergedToDefaultBranch(task: Task, latestRun: AgentRun | undefined) {
-  return task.status === 'DONE' && Boolean(latestRun?.prUrl && latestRun.prNumber);
+  return task.status === 'DONE' && Boolean(latestRun && hasRunReview(latestRun) && getRunReviewNumber(latestRun));
 }
 
 export function isDependencyReviewReady(task: Task, latestRun: AgentRun | undefined) {
@@ -24,7 +25,7 @@ export function isDependencyReviewReady(task: Task, latestRun: AgentRun | undefi
     return true;
   }
 
-  return latestRun.status === 'FAILED' && Boolean(latestRun.prUrl);
+  return latestRun.status === 'FAILED' && hasRunReview(latestRun);
 }
 
 export function buildLatestRunsByTaskId(runs: AgentRun[]) {

--- a/src/server/shared/real-run.ts
+++ b/src/server/shared/real-run.ts
@@ -1,4 +1,5 @@
 import type { ArtifactManifest, AgentRun, Repo, RunError, RunLogEntry, RunStatus, Task } from '../../ui/domain/types';
+import { normalizeRunReviewMetadata } from '../../shared/scm';
 
 export type RunJobMode = 'full_run' | 'evidence_only' | 'preview_only';
 
@@ -13,6 +14,9 @@ export type RunTransitionPatch = {
   status?: RunStatus;
   branchName?: string;
   headSha?: string;
+  reviewUrl?: string;
+  reviewNumber?: number;
+  reviewProvider?: AgentRun['reviewProvider'];
   prUrl?: string;
   prNumber?: number;
   previewUrl?: string;
@@ -38,6 +42,9 @@ export type RunTransitionPatch = {
 
 type CreateRealRunOptions = {
   branchName?: string;
+  reviewUrl?: string;
+  reviewNumber?: number;
+  reviewProvider?: AgentRun['reviewProvider'];
   prUrl?: string;
   prNumber?: number;
   baseRunId?: string;
@@ -47,7 +54,7 @@ type CreateRealRunOptions = {
 
 export function createRealRun(task: Task, runId: string, now = new Date(), options?: CreateRealRunOptions): AgentRun {
   const nowIso = now.toISOString();
-  return {
+  return normalizeRunReviewMetadata({
     runId,
     taskId: task.taskId,
     repoId: task.repoId,
@@ -55,6 +62,9 @@ export function createRealRun(task: Task, runId: string, now = new Date(), optio
     branchName: options?.branchName ?? `agent/${task.taskId}/${runId}`,
     baseRunId: options?.baseRunId,
     changeRequest: options?.changeRequest,
+    reviewUrl: options?.reviewUrl,
+    reviewNumber: options?.reviewNumber,
+    reviewProvider: options?.reviewProvider,
     prUrl: options?.prUrl,
     prNumber: options?.prNumber,
     dependencyContext: options?.dependencyContext,
@@ -69,7 +79,7 @@ export function createRealRun(task: Task, runId: string, now = new Date(), optio
     executorType: 'sandbox',
     orchestrationMode: 'workflow',
     executionSummary: {}
-  };
+  });
 }
 
 export function applyRunTransition(run: AgentRun, patch: RunTransitionPatch, nowIso: string): AgentRun {
@@ -78,7 +88,7 @@ export function applyRunTransition(run: AgentRun, patch: RunTransitionPatch, now
     ? [...run.timeline, { status: nextStatus, at: nowIso, note: patch.appendTimelineNote }]
     : run.timeline;
 
-  return {
+  return normalizeRunReviewMetadata({
     ...run,
     ...patch,
     status: nextStatus,
@@ -89,7 +99,7 @@ export function applyRunTransition(run: AgentRun, patch: RunTransitionPatch, now
     artifacts: patch.artifacts ?? run.artifacts,
     errors: run.errors,
     pendingEvents: run.pendingEvents
-  };
+  });
 }
 
 export function appendRunError(run: AgentRun, error: RunError, nowIso: string): AgentRun {

--- a/src/server/shared/run-source-resolution.test.ts
+++ b/src/server/shared/run-source-resolution.test.ts
@@ -78,6 +78,8 @@ describe('resolveRunSource', () => {
       kind: 'dependency_review_head',
       upstreamTaskId: 'task_up',
       upstreamRunId: 'run_task_up',
+      upstreamReviewNumber: 7,
+      upstreamReviewProvider: 'github',
       upstreamPrNumber: 7,
       upstreamHeadSha: 'b'.repeat(40),
       resolvedRef: 'b'.repeat(40)
@@ -85,6 +87,8 @@ describe('resolveRunSource', () => {
     expect(source.dependencyContext).toMatchObject({
       sourceTaskId: 'task_up',
       sourceRunId: 'run_task_up',
+      sourceReviewNumber: 7,
+      sourceReviewProvider: 'github',
       sourcePrNumber: 7,
       sourceHeadSha: 'b'.repeat(40),
       sourceMode: 'dependency_review_head'
@@ -143,6 +147,7 @@ describe('resolveRunSource', () => {
     expect(source.branchSource).toMatchObject({
       kind: 'dependency_review_head',
       upstreamTaskId: 'task_up_2',
+      upstreamReviewNumber: 22,
       upstreamPrNumber: 22,
       upstreamHeadSha: 'f'.repeat(40)
     });

--- a/src/server/shared/run-source-resolution.ts
+++ b/src/server/shared/run-source-resolution.ts
@@ -1,4 +1,5 @@
 import type { AgentRun, Task, TaskBranchSource } from '../../ui/domain/types';
+import { getRunReviewNumber, getRunReviewProvider, getRunReviewUrl, normalizeDependencyReviewMetadata, normalizeTaskBranchSourceReviewMetadata } from '../../shared/scm';
 import { isDependencyMergedToDefaultBranch, isDependencyReviewReady } from './dependency-readiness';
 
 type ResolveRunSourceInput = {
@@ -72,27 +73,34 @@ function resolveDependencyReviewSource(task: Task, tasks: Task[], runs: AgentRun
     return undefined;
   }
 
-  if (!isDependencyReviewReady(upstreamTask, upstreamRun) || !upstreamRun.headSha || !upstreamRun.prNumber) {
+  const reviewNumber = getRunReviewNumber(upstreamRun);
+  if (!isDependencyReviewReady(upstreamTask, upstreamRun) || !upstreamRun.headSha || !reviewNumber) {
     return undefined;
   }
 
   return {
-    branchSource: {
+    branchSource: normalizeTaskBranchSourceReviewMetadata({
       kind: 'dependency_review_head',
       upstreamTaskId: upstreamTask.taskId,
       upstreamRunId: upstreamRun.runId,
-      upstreamPrNumber: upstreamRun.prNumber,
+      upstreamReviewUrl: getRunReviewUrl(upstreamRun),
+      upstreamReviewNumber: reviewNumber,
+      upstreamReviewProvider: getRunReviewProvider(upstreamRun),
+      upstreamPrNumber: reviewNumber,
       upstreamHeadSha: upstreamRun.headSha,
       resolvedRef: upstreamRun.headSha,
       resolvedAt
-    },
-    dependencyContext: {
+    }),
+    dependencyContext: normalizeDependencyReviewMetadata({
       sourceTaskId: upstreamTask.taskId,
       sourceRunId: upstreamRun.runId,
-      sourcePrNumber: upstreamRun.prNumber,
+      sourceReviewUrl: getRunReviewUrl(upstreamRun),
+      sourceReviewNumber: reviewNumber,
+      sourceReviewProvider: getRunReviewProvider(upstreamRun),
+      sourcePrNumber: reviewNumber,
       sourceHeadSha: upstreamRun.headSha,
       sourceMode: 'dependency_review_head'
-    }
+    })
   };
 }
 

--- a/src/server/shared/task-status.test.ts
+++ b/src/server/shared/task-status.test.ts
@@ -30,4 +30,8 @@ describe('deriveTaskStatusFromRun', () => {
   it('maps failed runs with a PR back to review', () => {
     expect(deriveTaskStatusFromRun(buildRun('FAILED', { prUrl: 'https://github.com/abuiles/minions-demo/pull/5' }), 'REVIEW')).toBe('REVIEW');
   });
+
+  it('maps failed runs with provider-neutral review metadata back to review', () => {
+    expect(deriveTaskStatusFromRun(buildRun('FAILED', { reviewUrl: 'https://gitlab.example.com/acme/demo/-/merge_requests/5' }), 'REVIEW')).toBe('REVIEW');
+  });
 });

--- a/src/server/shared/task-status.ts
+++ b/src/server/shared/task-status.ts
@@ -1,4 +1,5 @@
 import type { AgentRun, TaskStatus } from '../../ui/domain/types';
+import { hasRunReview } from '../../shared/scm';
 
 export function deriveTaskStatusFromRun(run: AgentRun, current: TaskStatus): TaskStatus {
   if (current === 'DONE' && !isExecutionPhase(run.status)) {
@@ -9,7 +10,7 @@ export function deriveTaskStatusFromRun(run: AgentRun, current: TaskStatus): Tas
     return 'REVIEW';
   }
   if (run.status === 'FAILED') {
-    return run.prUrl ? 'REVIEW' : 'FAILED';
+    return hasRunReview(run) ? 'REVIEW' : 'FAILED';
   }
   if (isExecutionPhase(run.status)) {
     return 'ACTIVE';

--- a/src/server/source-ref.test.ts
+++ b/src/server/source-ref.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { normalizeTaskSourceRef, resolveTaskSourceRef } from './source-ref';
+import { normalizeScmSourceRef, normalizeTaskSourceRef, resolveTaskSourceRef } from './source-ref';
 
 describe('source-ref', () => {
   it('resolves an explicit task source ref before context links', () => {
@@ -34,6 +34,27 @@ describe('source-ref', () => {
     expect(normalizeTaskSourceRef('https://github.com/abuiles/minions-demo/pull/4', 'abuiles/minions-demo')).toEqual({
       fetchSpec: 'pull/4/head',
       label: 'PR #4'
+    });
+  });
+
+  it('returns a provider-neutral review-head source ref for GitHub PR URLs', () => {
+    expect(normalizeScmSourceRef('https://github.com/abuiles/minions-demo/pull/4', {
+      repoId: 'repo_demo',
+      slug: 'abuiles/minions-demo',
+      scmProvider: 'github',
+      scmBaseUrl: 'https://github.com',
+      projectPath: 'abuiles/minions-demo',
+      defaultBranch: 'main',
+      baselineUrl: 'https://example.com',
+      enabled: true,
+      createdAt: '2026-03-02T00:00:00.000Z',
+      updatedAt: '2026-03-02T00:00:00.000Z'
+    })).toEqual({
+      kind: 'review_head',
+      value: 'pull/4/head',
+      label: 'PR #4',
+      reviewNumber: 4,
+      reviewProvider: 'github'
     });
   });
 

--- a/src/server/source-ref.ts
+++ b/src/server/source-ref.ts
@@ -1,13 +1,18 @@
 import type { Repo, Task } from '../ui/domain/types';
-import type { NormalizedScmSourceRef } from './scm/adapter';
 import { githubScmAdapter } from './scm/github';
+import type { LegacyNormalizedScmSourceRef, ScmSourceRef } from './scm/source-ref';
+import { toLegacyNormalizedScmSourceRef } from './scm/source-ref';
 
 export function resolveTaskSourceRef(task: Pick<Task, 'sourceRef' | 'title' | 'description' | 'taskPrompt'>) {
   return githubScmAdapter.inferSourceRefFromTask(task, buildLegacyGithubRepo('github.com/_'));
 }
 
-export function normalizeTaskSourceRef(sourceRef: string, expectedRepoSlug: string): NormalizedScmSourceRef {
-  return githubScmAdapter.normalizeSourceRef(sourceRef, buildLegacyGithubRepo(expectedRepoSlug));
+export function normalizeScmSourceRef(sourceRef: string, repo: Repo): ScmSourceRef {
+  return githubScmAdapter.normalizeSourceRef(sourceRef, repo);
+}
+
+export function normalizeTaskSourceRef(sourceRef: string, expectedRepoSlug: string): LegacyNormalizedScmSourceRef {
+  return toLegacyNormalizedScmSourceRef(normalizeScmSourceRef(sourceRef, buildLegacyGithubRepo(expectedRepoSlug)));
 }
 
 function buildLegacyGithubRepo(projectPath: string): Repo {

--- a/src/shared/scm.ts
+++ b/src/shared/scm.ts
@@ -1,4 +1,4 @@
-import type { Repo, ScmProvider } from '../ui/domain/types';
+import type { AgentRun, Repo, ScmProvider, TaskBranchSource } from '../ui/domain/types';
 
 export const SCM_PROVIDERS = new Set(['github', 'gitlab'] as const);
 
@@ -106,4 +106,79 @@ export function buildGithubGitUrl(repo: RepoScmLike, pat: string): string {
   }
 
   return `${baseUrl.protocol}//x-access-token:${encodeURIComponent(pat)}@${baseUrl.host}/${getRepoProjectPath(repo)}.git`;
+}
+
+type ReviewMetadataLike = {
+  reviewUrl?: string;
+  reviewNumber?: number;
+  reviewProvider?: ScmProvider;
+  prUrl?: string;
+  prNumber?: number;
+};
+
+type DependencyReviewMetadataLike = NonNullable<AgentRun['dependencyContext']>;
+type BranchSourceReviewMetadataLike = Extract<TaskBranchSource, { kind: 'dependency_review_head' }>;
+
+export function getRunReviewUrl(review: ReviewMetadataLike) {
+  return review.reviewUrl ?? review.prUrl;
+}
+
+export function getRunReviewNumber(review: ReviewMetadataLike) {
+  return review.reviewNumber ?? review.prNumber;
+}
+
+export function getRunReviewProvider(review: ReviewMetadataLike) {
+  return review.reviewProvider ?? (getRunReviewUrl(review) || getRunReviewNumber(review) ? 'github' : undefined);
+}
+
+export function hasRunReview(review: ReviewMetadataLike) {
+  return Boolean(getRunReviewUrl(review) || getRunReviewNumber(review));
+}
+
+export function normalizeRunReviewMetadata<T extends ReviewMetadataLike>(review: T): T {
+  const reviewUrl = getRunReviewUrl(review);
+  const reviewNumber = getRunReviewNumber(review);
+  const reviewProvider = getRunReviewProvider(review);
+  return {
+    ...review,
+    reviewUrl,
+    reviewNumber,
+    reviewProvider,
+    prUrl: review.prUrl ?? reviewUrl,
+    prNumber: review.prNumber ?? reviewNumber
+  };
+}
+
+export function normalizeDependencyReviewMetadata<T extends DependencyReviewMetadataLike>(dependencyContext: T): T {
+  const sourceReviewUrl = dependencyContext.sourceReviewUrl;
+  const sourceReviewNumber = dependencyContext.sourceReviewNumber ?? dependencyContext.sourcePrNumber;
+  const sourceReviewProvider = dependencyContext.sourceReviewProvider
+    ?? (sourceReviewUrl || sourceReviewNumber ? 'github' : undefined);
+
+  return {
+    ...dependencyContext,
+    sourceReviewUrl,
+    sourceReviewNumber,
+    sourceReviewProvider,
+    sourcePrNumber: dependencyContext.sourcePrNumber ?? sourceReviewNumber
+  };
+}
+
+export function normalizeTaskBranchSourceReviewMetadata<T extends TaskBranchSource>(branchSource: T): T {
+  if (branchSource.kind !== 'dependency_review_head') {
+    return branchSource;
+  }
+
+  const upstreamReviewUrl = branchSource.upstreamReviewUrl;
+  const upstreamReviewNumber = branchSource.upstreamReviewNumber ?? branchSource.upstreamPrNumber;
+  const upstreamReviewProvider = branchSource.upstreamReviewProvider
+    ?? (upstreamReviewUrl || upstreamReviewNumber ? 'github' : undefined);
+
+  return {
+    ...branchSource,
+    upstreamReviewUrl,
+    upstreamReviewNumber,
+    upstreamReviewProvider,
+    upstreamPrNumber: branchSource.upstreamPrNumber ?? upstreamReviewNumber
+  } as T;
 }

--- a/src/ui/domain/types.ts
+++ b/src/ui/domain/types.ts
@@ -17,6 +17,7 @@ export type SimulationProfile = 'happy_path' | 'fail_tests' | 'fail_preview';
 export type CodexModel = 'gpt-5.3-codex' | 'gpt-5.3-codex-spark' | 'gpt-5.1-codex-mini';
 export type CodexReasoningEffort = 'low' | 'medium' | 'high';
 export type ScmProvider = 'github' | 'gitlab';
+export type ReviewProvider = ScmProvider;
 
 export type RunEventType =
   | 'run.status_changed'
@@ -100,6 +101,9 @@ export type TaskBranchSource = {
   kind: 'explicit_source_ref' | 'dependency_review_head' | 'default_branch';
   upstreamTaskId?: string;
   upstreamRunId?: string;
+  upstreamReviewUrl?: string;
+  upstreamReviewNumber?: number;
+  upstreamReviewProvider?: ReviewProvider;
   upstreamPrNumber?: number;
   upstreamHeadSha?: string;
   resolvedRef: string;
@@ -248,6 +252,9 @@ export type AgentRun = {
     requestedAt: string;
   };
   headSha?: string;
+  reviewUrl?: string;
+  reviewNumber?: number;
+  reviewProvider?: ReviewProvider;
   prUrl?: string;
   prNumber?: number;
   previewUrl?: string;
@@ -267,6 +274,9 @@ export type AgentRun = {
   dependencyContext?: {
     sourceTaskId?: string;
     sourceRunId?: string;
+    sourceReviewUrl?: string;
+    sourceReviewNumber?: number;
+    sourceReviewProvider?: ReviewProvider;
     sourcePrNumber?: number;
     sourceHeadSha?: string;
     sourceMode: 'explicit_source_ref' | 'dependency_review_head' | 'default_branch';

--- a/tests/worker/stage-3-1-fanout.test.ts
+++ b/tests/worker/stage-3-1-fanout.test.ts
@@ -59,6 +59,8 @@ describe('Stage 3.1 fanout integration', () => {
       sourceMode: 'dependency_review_head',
       sourceTaskId: taskA.taskId,
       sourceRunId: runA.runId,
+      sourceReviewNumber: 101,
+      sourceReviewProvider: 'github',
       sourcePrNumber: 101,
       sourceHeadSha: sha('a')
     });
@@ -66,6 +68,8 @@ describe('Stage 3.1 fanout integration', () => {
       sourceMode: 'dependency_review_head',
       sourceTaskId: taskA.taskId,
       sourceRunId: runA.runId,
+      sourceReviewNumber: 101,
+      sourceReviewProvider: 'github',
       sourcePrNumber: 101,
       sourceHeadSha: sha('a')
     });
@@ -152,6 +156,8 @@ describe('Stage 3.1 fanout integration', () => {
       sourceMode: 'dependency_review_head',
       sourceTaskId: taskC.taskId,
       sourceRunId: runC.runId,
+      sourceReviewNumber: 203,
+      sourceReviewProvider: 'github',
       sourcePrNumber: 203,
       sourceHeadSha: sha('d')
     });

--- a/tests/worker/stage-3-5-scm-foundation.test.ts
+++ b/tests/worker/stage-3-5-scm-foundation.test.ts
@@ -66,4 +66,39 @@ describe('Stage 3.5 SCM foundation', () => {
     expect(updated.scmProvider).toBe('github');
     expect(updated.scmBaseUrl).toBe('https://github.com');
   });
+
+  it('persists provider-neutral review metadata while mirroring legacy PR aliases', async () => {
+    const board = env.BOARD_INDEX.getByName('agentboard');
+    const repo = await board.createRepo({
+      slug: 'acme/review-demo',
+      baselineUrl: 'https://review-demo.example.com',
+      defaultBranch: 'main'
+    });
+    const repoBoard = env.REPO_BOARD.getByName(repo.repoId);
+
+    const task = await repoBoard.createTask({
+      repoId: repo.repoId,
+      title: 'Review metadata',
+      taskPrompt: 'Track provider-neutral review refs.',
+      acceptanceCriteria: ['review metadata is stored'],
+      context: { links: [] },
+      status: 'READY'
+    });
+    const run = await repoBoard.startRun(task.taskId);
+    const updated = await repoBoard.transitionRun(run.runId, {
+      status: 'PR_OPEN',
+      reviewUrl: 'https://github.com/acme/review-demo/pull/12',
+      reviewNumber: 12,
+      reviewProvider: 'github',
+      headSha: 'a'.repeat(40)
+    });
+
+    expect(updated).toMatchObject({
+      reviewUrl: 'https://github.com/acme/review-demo/pull/12',
+      reviewNumber: 12,
+      reviewProvider: 'github',
+      prUrl: 'https://github.com/acme/review-demo/pull/12',
+      prNumber: 12
+    });
+  });
 });


### PR DESCRIPTION
Task: S35-03 Provider-neutral source refs and review fields

Normalize source-ref parsing and run metadata so Stage 3.1 can stop assuming GitHub PR-specific fields.


Acceptance criteria:
- Source-ref parsing is organized around provider-neutral SCM types rather than GitHub-only assumptions.
- Run metadata can represent review URL/number/provider in a provider-neutral way.
- Existing GitHub fields remain supported through a compatibility path.
- Stage 3.1 lineage metadata can continue to work without assuming PR-only terminology.

Run ID: run_repo_abuiles_minions_mm945tideka5