### PR TITLE
S35-06 Repo settings and API support for SCM provider selection

### DIFF
--- a/src/server/durable/board-index.ts
+++ b/src/server/durable/board-index.ts
@@ -78,7 +78,15 @@ export class BoardIndexDO extends DurableObject<Env> {
   async updateRepo(repoId: string, patch: UpdateRepoInput) {
     await this.ready;
     const existing = await this.getRepo(repoId);
-    const updated = buildRepoRecord({ ...existing, ...patch, repoId: existing.repoId, createdAt: existing.createdAt, updatedAt: existing.updatedAt });
+    const updated = buildRepoRecord({
+      ...existing,
+      ...patch,
+      slug: patch.slug ?? patch.projectPath ?? existing.slug,
+      projectPath: patch.projectPath ?? patch.slug ?? existing.projectPath,
+      repoId: existing.repoId,
+      createdAt: existing.createdAt,
+      updatedAt: existing.updatedAt
+    });
     if (
       this.repos.some((repo) => repo.repoId !== repoId && buildRepoScmKey(repo) === buildRepoScmKey(updated))
     ) {

--- a/src/server/http/validation.test.ts
+++ b/src/server/http/validation.test.ts
@@ -161,6 +161,15 @@ describe('repo validation', () => {
       })
     ).toThrow('Invalid repo patch payload: slug and projectPath must match when both are provided.');
   });
+
+  it('mirrors legacy slug-only repo patch payloads into projectPath', () => {
+    expect(parseUpdateRepoInput({
+      slug: 'acme/renamed'
+    })).toMatchObject({
+      slug: 'acme/renamed',
+      projectPath: 'acme/renamed'
+    });
+  });
 });
 
 describe('SCM credential validation', () => {

--- a/src/server/http/validation.ts
+++ b/src/server/http/validation.ts
@@ -267,6 +267,8 @@ export function parseUpdateRepoInput(body: unknown): UpdateRepoInput {
   if (patch.slug && patch.projectPath && patch.slug !== patch.projectPath) {
     throw badRequest('Invalid repo patch payload: slug and projectPath must match when both are provided.');
   }
+  if (patch.slug && !patch.projectPath) patch.projectPath = patch.slug;
+  if (patch.projectPath && !patch.slug) patch.slug = patch.projectPath;
   if (hasOwn(body, 'defaultBranch')) patch.defaultBranch = readTrimmedString(body.defaultBranch, 'defaultBranch', false);
   if (hasOwn(body, 'baselineUrl')) patch.baselineUrl = readTrimmedString(body.baselineUrl, 'baselineUrl', false);
   if (hasOwn(body, 'enabled')) patch.enabled = readBoolean(body.enabled, 'enabled', false);

--- a/src/ui/App.test.tsx
+++ b/src/ui/App.test.tsx
@@ -62,6 +62,42 @@ describe('App', () => {
     expect(await screen.findByText('Updated acme/site-marketing.')).toBeInTheDocument();
   });
 
+  it('edits repo SCM settings for a GitLab project without falling back to GitHub defaults', async () => {
+    const user = userEvent.setup();
+    const api = getLocalAgentBoardApi();
+    const gitlabRepo = await api.createRepo({
+      scmProvider: 'gitlab',
+      scmBaseUrl: 'https://gitlab.example.com',
+      projectPath: 'group/platform/demo',
+      baselineUrl: 'https://demo.example.com'
+    });
+
+    render(<App api={api} />);
+
+    const [repoFilter] = await screen.findAllByLabelText(/repo filter/i);
+    await user.selectOptions(repoFilter, gitlabRepo.repoId);
+    await waitFor(() => {
+      expect(repoFilter).toHaveValue(gitlabRepo.repoId);
+    });
+    await user.click(screen.getByRole('button', { name: 'Edit repo' }));
+
+    expect(screen.getByText('GitLab base URL')).toBeInTheDocument();
+    const projectPathInput = screen.getByPlaceholderText('group/subgroup/repo');
+    await user.clear(projectPathInput);
+    await user.type(projectPathInput, 'group/platform/renamed');
+
+    await user.click(screen.getByRole('button', { name: 'Save repo' }));
+
+    await waitFor(() => {
+      const repo = api.getSnapshot().repos.find((candidate) => candidate.repoId === gitlabRepo.repoId);
+      expect(repo?.scmProvider).toBe('gitlab');
+      expect(repo?.scmBaseUrl).toBe('https://gitlab.example.com');
+      expect(repo?.projectPath).toBe('group/platform/renamed');
+      expect(repo?.slug).toBe('group/platform/renamed');
+    });
+    expect(await screen.findByText('Updated group/platform/renamed.')).toBeInTheDocument();
+  });
+
   it('opens the task from the URL on load', async () => {
     window.history.replaceState({}, '', '/?taskId=task_kpi');
     localStorage.setItem('agentboard.ui-preferences.v1', JSON.stringify({ selectedRepoId: 'all', selectedTaskId: 'task_nav' }));

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -276,7 +276,7 @@ export default function App({ api: providedApi }: { api?: AgentBoardApi }) {
       ) : null}
 
       {repoToEdit ? (
-        <Modal title={`Edit ${repoToEdit.slug}`} onClose={() => setRepoToEditId(undefined)}>
+        <Modal title={`Edit ${repoToEdit.projectPath ?? repoToEdit.slug}`} onClose={() => setRepoToEditId(undefined)}>
           <RepoForm
             initialValues={{
               slug: repoToEdit.slug,
@@ -292,7 +292,7 @@ export default function App({ api: providedApi }: { api?: AgentBoardApi }) {
             onSubmit={async (input) => {
               await api.updateRepo(repoToEdit.repoId, input);
               setRepoToEditId(undefined);
-              setNotice(`Updated ${repoToEdit.slug}.`);
+              setNotice(`Updated ${input.projectPath ?? input.slug ?? repoToEdit.projectPath ?? repoToEdit.slug}.`);
             }}
           />
         </Modal>

--- a/src/ui/components/Forms.test.tsx
+++ b/src/ui/components/Forms.test.tsx
@@ -1,7 +1,11 @@
-import { render, screen } from '@testing-library/react';
+import { cleanup, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { RepoForm, TaskForm } from './Forms';
+
+afterEach(() => {
+  cleanup();
+});
 
 describe('RepoForm', () => {
   it('submits provider-neutral SCM repo fields', async () => {
@@ -11,7 +15,7 @@ describe('RepoForm', () => {
     render(<RepoForm onSubmit={onSubmit} />);
 
     const scmProviderField = screen.getByText('SCM provider').closest('label')?.querySelector('select');
-    const scmBaseUrlField = screen.getByText('SCM base URL').closest('label')?.querySelector('input');
+    const scmBaseUrlField = screen.getByDisplayValue('https://github.com');
     const projectPathField = screen.getByText('Project path').closest('label')?.querySelector('input');
     const baselineUrlField = screen.getByText('Baseline URL').closest('label')?.querySelector('input');
 
@@ -34,6 +38,23 @@ describe('RepoForm', () => {
       scmBaseUrl: 'https://gitlab.example.com',
       projectPath: 'group/platform/repo'
     }));
+  });
+
+  it('switches repo settings copy and defaults when GitLab is selected', async () => {
+    const user = userEvent.setup();
+    render(<RepoForm onSubmit={vi.fn()} />);
+
+    expect(screen.getAllByText('GitHub base URL')).toHaveLength(1);
+    expect(screen.getByPlaceholderText('owner/repo')).toBeInTheDocument();
+
+    const scmProviderField = screen.getByText('SCM provider').closest('label')?.querySelector('select');
+    expect(scmProviderField).not.toBeNull();
+    await user.selectOptions(scmProviderField! as unknown as Element, 'gitlab');
+
+    expect(screen.getByText('GitLab base URL')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('group/subgroup/repo')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('https://gitlab.com')).toBeInTheDocument();
+    expect(screen.getByText(/self-managed GitLab origin/i)).toBeInTheDocument();
   });
 });
 

--- a/src/ui/components/Forms.tsx
+++ b/src/ui/components/Forms.tsx
@@ -2,6 +2,11 @@ import { useEffect, useState } from 'react';
 import type { CreateRepoInput, CreateTaskInput } from '../domain/api';
 import type { CodexModel, CodexReasoningEffort, Repo, ScmProvider, TaskContextLink, TaskDependency, TaskStatus } from '../domain/types';
 
+const DEFAULT_SCM_BASE_URLS: Record<ScmProvider, string> = {
+  github: 'https://github.com',
+  gitlab: 'https://gitlab.com'
+};
+
 const CODEX_MODELS: Array<{ value: CodexModel; label: string }> = [
   { value: 'gpt-5.1-codex-mini', label: 'gpt-5.1-codex-mini (default)' },
   { value: 'gpt-5.3-codex', label: 'gpt-5.3-codex' },
@@ -47,16 +52,14 @@ export function RepoForm({
   initialValues?: Partial<CreateRepoInput>;
   submitLabel?: string;
 }) {
-  const initialSlug = initialValues?.slug ?? '';
   const initialScmProvider = initialValues?.scmProvider ?? 'github';
-  const initialScmBaseUrl = initialValues?.scmBaseUrl ?? 'https://github.com';
-  const initialProjectPath = initialValues?.projectPath ?? initialSlug;
+  const initialProjectPath = initialValues?.projectPath ?? initialValues?.slug ?? '';
+  const initialScmBaseUrl = initialValues?.scmBaseUrl ?? DEFAULT_SCM_BASE_URLS[initialScmProvider];
   const initialDefaultBranch = initialValues?.defaultBranch ?? 'main';
   const initialBaselineUrl = initialValues?.baselineUrl ?? '';
   const initialPreviewCheckName = initialValues?.previewCheckName ?? '';
   const initialCodexAuthBundleR2Key = initialValues?.codexAuthBundleR2Key ?? '';
 
-  const [slug, setSlug] = useState(initialSlug);
   const [scmProvider, setScmProvider] = useState<ScmProvider>(initialScmProvider);
   const [scmBaseUrl, setScmBaseUrl] = useState(initialScmBaseUrl);
   const [projectPath, setProjectPath] = useState(initialProjectPath);
@@ -66,7 +69,6 @@ export function RepoForm({
   const [codexAuthBundleR2Key, setCodexAuthBundleR2Key] = useState(initialCodexAuthBundleR2Key);
 
   useEffect(() => {
-    setSlug(initialSlug);
     setScmProvider(initialScmProvider);
     setScmBaseUrl(initialScmBaseUrl);
     setProjectPath(initialProjectPath);
@@ -74,7 +76,19 @@ export function RepoForm({
     setBaselineUrl(initialBaselineUrl);
     setPreviewCheckName(initialPreviewCheckName);
     setCodexAuthBundleR2Key(initialCodexAuthBundleR2Key);
-  }, [initialSlug, initialScmProvider, initialScmBaseUrl, initialProjectPath, initialDefaultBranch, initialBaselineUrl, initialPreviewCheckName, initialCodexAuthBundleR2Key]);
+  }, [initialScmProvider, initialScmBaseUrl, initialProjectPath, initialDefaultBranch, initialBaselineUrl, initialPreviewCheckName, initialCodexAuthBundleR2Key]);
+
+  const projectPathHint = scmProvider === 'gitlab'
+    ? 'Use the GitLab project path like group/subgroup/repo.'
+    : 'Use the GitHub repository path like owner/repo.';
+  const projectPathPlaceholder = scmProvider === 'gitlab' ? 'group/subgroup/repo' : 'owner/repo';
+  const scmBaseUrlLabel = scmProvider === 'gitlab' ? 'GitLab base URL' : 'GitHub base URL';
+  const scmBaseUrlHint = scmProvider === 'gitlab'
+    ? 'Use https://gitlab.com for hosted GitLab, or your self-managed GitLab origin.'
+    : 'Use the GitHub host origin for GitHub.com or GitHub Enterprise Server.';
+  const previewCheckHint = scmProvider === 'gitlab'
+    ? 'Optional check or pipeline name used to discover the Cloudflare preview URL.'
+    : 'Optional check name used to discover the Cloudflare preview URL.';
 
   return (
     <form
@@ -82,19 +96,18 @@ export function RepoForm({
       onSubmit={async (event) => {
         event.preventDefault();
         await onSubmit({
-          slug: projectPath || slug,
+          slug: projectPath,
           scmProvider,
           scmBaseUrl,
-          projectPath: projectPath || slug,
+          projectPath,
           defaultBranch,
           baselineUrl,
           enabled: true,
           previewCheckName: previewCheckName || undefined,
           codexAuthBundleR2Key: codexAuthBundleR2Key || undefined
         });
-        setSlug('');
         setScmProvider('github');
-        setScmBaseUrl('https://github.com');
+        setScmBaseUrl(DEFAULT_SCM_BASE_URLS.github);
         setProjectPath('');
         setDefaultBranch('main');
         setBaselineUrl('');
@@ -104,23 +117,40 @@ export function RepoForm({
     >
       <div className="grid gap-4 md:grid-cols-3">
         <FieldShell label="SCM provider">
-          <select className={inputClass()} value={scmProvider} onChange={(event) => setScmProvider(event.target.value as ScmProvider)}>
+          <select
+            className={inputClass()}
+            value={scmProvider}
+            onChange={(event) => {
+              const nextProvider = event.target.value as ScmProvider;
+              setScmProvider(nextProvider);
+              setScmBaseUrl((currentValue) => {
+                const normalizedValue = currentValue.trim();
+                if (!normalizedValue || normalizedValue === DEFAULT_SCM_BASE_URLS[scmProvider]) {
+                  return DEFAULT_SCM_BASE_URLS[nextProvider];
+                }
+                return currentValue;
+              });
+            }}
+          >
             <option value="github">GitHub</option>
             <option value="gitlab">GitLab</option>
           </select>
         </FieldShell>
-        <FieldShell label="SCM base URL" hint="Host base URL used for API and git operations.">
-          <input className={inputClass()} value={scmBaseUrl} onChange={(event) => setScmBaseUrl(event.target.value)} placeholder="https://github.com" required />
+        <FieldShell label={scmBaseUrlLabel} hint={scmBaseUrlHint}>
+          <input
+            className={inputClass()}
+            value={scmBaseUrl}
+            onChange={(event) => setScmBaseUrl(event.target.value)}
+            placeholder={DEFAULT_SCM_BASE_URLS[scmProvider]}
+            required
+          />
         </FieldShell>
-        <FieldShell label="Project path" hint="Use the provider project path like owner/name or group/subgroup/repo.">
+        <FieldShell label="Project path" hint={projectPathHint}>
           <input
             className={inputClass()}
             value={projectPath}
-            onChange={(event) => {
-              setProjectPath(event.target.value);
-              setSlug(event.target.value);
-            }}
-            placeholder="owner/name"
+            onChange={(event) => setProjectPath(event.target.value)}
+            placeholder={projectPathPlaceholder}
             required
           />
         </FieldShell>
@@ -132,7 +162,7 @@ export function RepoForm({
         <input className={inputClass()} value={baselineUrl} onChange={(event) => setBaselineUrl(event.target.value)} placeholder="https://example.com" required />
       </FieldShell>
       <div className="grid gap-4 md:grid-cols-2">
-        <FieldShell label="Preview check name" hint="Optional GitHub check name used to discover the Cloudflare preview URL.">
+        <FieldShell label="Preview check name" hint={previewCheckHint}>
           <input className={inputClass()} value={previewCheckName} onChange={(event) => setPreviewCheckName(event.target.value)} placeholder="Cloudflare Pages" />
         </FieldShell>
         <FieldShell label="Codex auth bundle key" hint="Optional R2 key for a `.codex` auth bundle tarball.">

--- a/tests/worker/stage-3-5-scm-foundation.test.ts
+++ b/tests/worker/stage-3-5-scm-foundation.test.ts
@@ -67,6 +67,23 @@ describe('Stage 3.5 SCM foundation', () => {
     expect(updated.scmBaseUrl).toBe('https://github.com');
   });
 
+  it('keeps legacy slug-only repo updates working after projectPath is stored', async () => {
+    const board = env.BOARD_INDEX.getByName('agentboard');
+    const repo = await board.createRepo({
+      slug: 'acme/original',
+      baselineUrl: 'https://original.example.com'
+    });
+
+    const updated = await board.updateRepo(repo.repoId, {
+      slug: 'acme/legacy-rename'
+    });
+
+    expect(updated.projectPath).toBe('acme/legacy-rename');
+    expect(updated.slug).toBe('acme/legacy-rename');
+    expect(updated.scmProvider).toBe('github');
+    expect(updated.scmBaseUrl).toBe('https://github.com');
+  });
+
   it('persists provider-neutral review metadata while mirroring legacy PR aliases', async () => {
     const board = env.BOARD_INDEX.getByName('agentboard');
     const repo = await board.createRepo({


### PR DESCRIPTION
Task: S35-06 Repo settings and API support for SCM provider selection

Expose the new SCM provider/base URL/project path settings through repo APIs and UI surfaces so GitLab repos can actually be configured.


Acceptance criteria:
- Repo APIs accept and return the SCM provider/base URL/project path fields.
- Repo settings UI can configure GitHub vs GitLab and GitLab host/project path details.
- Existing GitHub repos remain editable without breaking current behavior.
- The UI language stops assuming GitHub-only terminology for repo configuration.

Run ID: run_repo_abuiles_minions_mm964ysvd7ht