### PR TITLE
S35-05 Make Stage 3.1 merge readiness provider-neutral

### DIFF
--- a/src/server/durable/repo-board.ts
+++ b/src/server/durable/repo-board.ts
@@ -307,8 +307,12 @@ export class RepoBoardDO extends DurableObject<Env> {
       reviewUrl: existingRun.reviewUrl,
       reviewNumber: existingRun.reviewNumber,
       reviewProvider: existingRun.reviewProvider,
+      reviewState: existingRun.reviewState,
+      reviewMergedAt: existingRun.reviewMergedAt,
       prUrl: existingRun.prUrl,
       prNumber: existingRun.prNumber,
+      landedOnDefaultBranch: existingRun.landedOnDefaultBranch,
+      landedOnDefaultBranchAt: existingRun.landedOnDefaultBranchAt,
       baseRunId: existingRun.runId,
       dependencyContext: existingRun.dependencyContext,
       changeRequest: {
@@ -834,10 +838,6 @@ export class RepoBoardDO extends DurableObject<Env> {
     const tasksById = new Map(this.state.tasks.map((task) => [task.taskId, task]));
     const latestRunsByTaskId = buildLatestRunsByTaskId(this.state.runs);
     const runHistoryTaskIds = new Set(this.state.runs.map((run) => run.taskId));
-    const hasRepoActiveRun = this.state.runs.some((run) => run.repoId === repoId && !isTerminalRunStatus(run.status));
-    if (hasRepoActiveRun) {
-      return;
-    }
 
     for (const task of this.state.tasks) {
       if (task.repoId !== repoId || !candidateIds.has(task.taskId) || !isRunnableDependencyAutoStartTask(task)) {
@@ -864,7 +864,6 @@ export class RepoBoardDO extends DurableObject<Env> {
       }
 
       await this.startRun(task.taskId, { dependencyAutoStart: true });
-      return;
     }
   }
 }
@@ -988,6 +987,7 @@ function nextStatusChanged(previous: AgentRun, next: AgentRun, note?: string) {
 function isTerminalRunStatus(status: AgentRun['status']) {
   return status === 'DONE' || status === 'FAILED';
 }
+
 
 function getOperatorSessionName(run: AgentRun) {
   if (!run.operatorSession?.sessionName || run.operatorSession.sessionName === 'operator') {

--- a/src/server/run-orchestrator.ts
+++ b/src/server/run-orchestrator.ts
@@ -260,6 +260,9 @@ cat /workspace/task.txt | codex exec -m ${codexModel} -c model_reasoning_effort=
     if (getRunReviewUrl(latestRun) && getRunReviewNumber(latestRun)) {
       await repoBoard.transitionRun(params.runId, {
         status: 'PR_OPEN',
+        reviewState: 'open',
+        landedOnDefaultBranch: false,
+        landedOnDefaultBranchAt: undefined,
         previewStatus: 'DISCOVERING',
         appendTimelineNote: 'Existing pull request updated with requested changes.'
       });
@@ -270,8 +273,11 @@ cat /workspace/task.txt | codex exec -m ${codexModel} -c model_reasoning_effort=
         reviewUrl: pr.url,
         reviewNumber: pr.number,
         reviewProvider: pr.provider,
+        reviewState: 'open',
         prNumber: pr.number,
         prUrl: pr.url,
+        landedOnDefaultBranch: false,
+        landedOnDefaultBranchAt: undefined,
         previewStatus: 'DISCOVERING',
         appendTimelineNote: 'Pull request opened.'
       });

--- a/src/server/shared/dependency-readiness.ts
+++ b/src/server/shared/dependency-readiness.ts
@@ -1,5 +1,5 @@
 import type { AgentRun, Task } from '../../ui/domain/types';
-import { getRunReviewNumber, hasRunReview } from '../../shared/scm';
+import { getRunReviewNumber, getRunReviewProvider, hasRunReview } from '../../shared/scm';
 
 const REVIEW_READY_RUN_STATUSES: Set<AgentRun['status']> = new Set([
   'PR_OPEN',
@@ -9,7 +9,18 @@ const REVIEW_READY_RUN_STATUSES: Set<AgentRun['status']> = new Set([
 ]);
 
 export function isDependencyMergedToDefaultBranch(task: Task, latestRun: AgentRun | undefined) {
-  return task.status === 'DONE' && Boolean(latestRun && hasRunReview(latestRun) && getRunReviewNumber(latestRun));
+  if (task.status !== 'DONE' || !latestRun || !hasRunReview(latestRun)) {
+    return false;
+  }
+
+  // Provider-neutral merge readiness is explicit once review state/default-branch
+  // reachability have been resolved through the SCM adapter layer.
+  if (latestRun.reviewState || typeof latestRun.landedOnDefaultBranch === 'boolean') {
+    return latestRun.reviewState === 'merged' && latestRun.landedOnDefaultBranch === true;
+  }
+
+  // Preserve existing GitHub Stage 3.1 behavior for legacy runs that only stored PR metadata.
+  return getRunReviewProvider(latestRun) === 'github' && Boolean(getRunReviewNumber(latestRun));
 }
 
 export function isDependencyReviewReady(task: Task, latestRun: AgentRun | undefined) {

--- a/src/server/shared/dependency-state.test.ts
+++ b/src/server/shared/dependency-state.test.ts
@@ -110,6 +110,64 @@ describe('refreshDependencyStates', () => {
     });
   });
 
+  it('uses provider-neutral merged review state and default-branch reachability for GitLab fallback readiness', () => {
+    const upstream = buildTask('task_up', { status: 'DONE' });
+    const downstream = buildTask('task_down', {
+      dependencies: [{ upstreamTaskId: 'task_up', mode: 'review_ready' }]
+    });
+
+    const result = refreshDependencyStates(
+      [upstream, downstream],
+      [
+        buildRun('task_up', 'DONE', {
+          reviewUrl: 'https://gitlab.example.com/acme/repo/-/merge_requests/10',
+          reviewNumber: 10,
+          reviewProvider: 'gitlab',
+          reviewState: 'merged',
+          landedOnDefaultBranch: true
+        })
+      ],
+      '2026-03-02T01:20:00.000Z'
+    );
+    const refreshed = result.tasks.find((task) => task.taskId === 'task_down')!;
+
+    expect(refreshed.dependencyState?.blocked).toBe(false);
+    expect(refreshed.dependencyState?.reasons[0]).toMatchObject({
+      upstreamTaskId: 'task_up',
+      state: 'ready',
+      message: 'Upstream task task_up is merged into the default branch.'
+    });
+  });
+
+  it('does not treat merged review state without default-branch reachability as merged-to-default readiness', () => {
+    const upstream = buildTask('task_up', { status: 'DONE' });
+    const downstream = buildTask('task_down', {
+      dependencies: [{ upstreamTaskId: 'task_up', mode: 'review_ready' }]
+    });
+
+    const result = refreshDependencyStates(
+      [upstream, downstream],
+      [
+        buildRun('task_up', 'DONE', {
+          reviewUrl: 'https://gitlab.example.com/acme/repo/-/merge_requests/11',
+          reviewNumber: 11,
+          reviewProvider: 'gitlab',
+          reviewState: 'merged',
+          landedOnDefaultBranch: false
+        })
+      ],
+      '2026-03-02T01:25:00.000Z'
+    );
+    const refreshed = result.tasks.find((task) => task.taskId === 'task_down')!;
+
+    expect(refreshed.dependencyState?.blocked).toBe(false);
+    expect(refreshed.dependencyState?.reasons[0]).toMatchObject({
+      upstreamTaskId: 'task_up',
+      state: 'ready',
+      message: 'Upstream task task_up is review-ready.'
+    });
+  });
+
   it('preserves existing unblockedAt while still unblocked', () => {
     const upstream = buildTask('task_up', { status: 'REVIEW' });
     const downstream = buildTask('task_down', {

--- a/src/server/shared/real-run.ts
+++ b/src/server/shared/real-run.ts
@@ -17,8 +17,12 @@ export type RunTransitionPatch = {
   reviewUrl?: string;
   reviewNumber?: number;
   reviewProvider?: AgentRun['reviewProvider'];
+  reviewState?: AgentRun['reviewState'];
+  reviewMergedAt?: AgentRun['reviewMergedAt'];
   prUrl?: string;
   prNumber?: number;
+  landedOnDefaultBranch?: AgentRun['landedOnDefaultBranch'];
+  landedOnDefaultBranchAt?: AgentRun['landedOnDefaultBranchAt'];
   previewUrl?: string;
   previewStatus?: AgentRun['previewStatus'];
   evidenceStatus?: AgentRun['evidenceStatus'];
@@ -45,8 +49,12 @@ type CreateRealRunOptions = {
   reviewUrl?: string;
   reviewNumber?: number;
   reviewProvider?: AgentRun['reviewProvider'];
+  reviewState?: AgentRun['reviewState'];
+  reviewMergedAt?: AgentRun['reviewMergedAt'];
   prUrl?: string;
   prNumber?: number;
+  landedOnDefaultBranch?: AgentRun['landedOnDefaultBranch'];
+  landedOnDefaultBranchAt?: AgentRun['landedOnDefaultBranchAt'];
   baseRunId?: string;
   changeRequest?: AgentRun['changeRequest'];
   dependencyContext?: AgentRun['dependencyContext'];
@@ -65,8 +73,12 @@ export function createRealRun(task: Task, runId: string, now = new Date(), optio
     reviewUrl: options?.reviewUrl,
     reviewNumber: options?.reviewNumber,
     reviewProvider: options?.reviewProvider,
+    reviewState: options?.reviewState,
+    reviewMergedAt: options?.reviewMergedAt,
     prUrl: options?.prUrl,
     prNumber: options?.prNumber,
+    landedOnDefaultBranch: options?.landedOnDefaultBranch,
+    landedOnDefaultBranchAt: options?.landedOnDefaultBranchAt,
     dependencyContext: options?.dependencyContext,
     errors: [],
     startedAt: nowIso,

--- a/src/server/shared/run-source-resolution.test.ts
+++ b/src/server/shared/run-source-resolution.test.ts
@@ -190,4 +190,34 @@ describe('resolveRunSource', () => {
     expect(source.branchSource.resolvedRef).toBe('main');
     expect(source.dependencyContext.sourceMode).toBe('default_branch');
   });
+
+  it('uses default branch after a GitLab MR is merged and landed on the default branch', () => {
+    const upstreamTask = buildTask('task_up', { status: 'DONE' });
+    const downstreamTask = buildTask('task_down', {
+      dependencies: [{ upstreamTaskId: 'task_up', mode: 'review_ready' }]
+    });
+
+    const source = resolveRunSource({
+      task: downstreamTask,
+      tasks: [upstreamTask, downstreamTask],
+      runs: [
+        buildRun('task_up', 'DONE', {
+          headSha: 'b'.repeat(40),
+          reviewUrl: 'https://gitlab.example.com/acme/repo/-/merge_requests/45',
+          reviewNumber: 45,
+          reviewProvider: 'gitlab',
+          reviewState: 'merged',
+          reviewMergedAt: '2026-03-02T00:45:00.000Z',
+          landedOnDefaultBranch: true,
+          landedOnDefaultBranchAt: '2026-03-02T00:50:00.000Z'
+        })
+      ],
+      defaultBranch: 'main',
+      resolvedAt
+    });
+
+    expect(source.branchSource.kind).toBe('default_branch');
+    expect(source.branchSource.resolvedRef).toBe('main');
+    expect(source.dependencyContext.sourceMode).toBe('default_branch');
+  });
 });

--- a/src/ui/domain/types.ts
+++ b/src/ui/domain/types.ts
@@ -255,8 +255,12 @@ export type AgentRun = {
   reviewUrl?: string;
   reviewNumber?: number;
   reviewProvider?: ReviewProvider;
+  reviewState?: 'open' | 'merged' | 'closed';
+  reviewMergedAt?: string;
   prUrl?: string;
   prNumber?: number;
+  landedOnDefaultBranch?: boolean;
+  landedOnDefaultBranchAt?: string;
   previewUrl?: string;
   previewStatus?: 'UNKNOWN' | 'DISCOVERING' | 'READY' | 'FAILED';
   evidenceStatus?: 'NOT_STARTED' | 'RUNNING' | 'READY' | 'FAILED';

--- a/tests/worker/stage-3-1-fanout.test.ts
+++ b/tests/worker/stage-3-1-fanout.test.ts
@@ -187,4 +187,72 @@ describe('Stage 3.1 fanout integration', () => {
     expect(detailEPostMerge.latestRun?.dependencyContext?.sourceMode).toBe('dependency_review_head');
     expect(eRunCount).toBe(1);
   });
+
+  it('allows GitLab MRs to drive review fanout and merged-to-default fallback', async () => {
+    const board = env.BOARD_INDEX.getByName('agentboard');
+    const repo = await board.createRepo({
+      slug: 'group/project',
+      projectPath: 'group/project',
+      scmProvider: 'gitlab',
+      scmBaseUrl: 'https://gitlab.example.com',
+      baselineUrl: 'https://gitlab-fanout.example.com',
+      defaultBranch: 'main'
+    });
+    const repoBoard = env.REPO_BOARD.getByName(repo.repoId);
+
+    const taskA = await repoBoard.createTask(taskInput(repo.repoId, 'A', 'READY'));
+    const taskB = await repoBoard.createTask(taskInput(repo.repoId, 'B', 'INBOX'));
+    const taskC = await repoBoard.createTask(taskInput(repo.repoId, 'C', 'READY'));
+
+    await repoBoard.updateTask(taskB.taskId, {
+      dependencies: [{ upstreamTaskId: taskA.taskId, mode: 'review_ready' }],
+      automationState: { autoStartEligible: true }
+    });
+    await repoBoard.updateTask(taskC.taskId, {
+      dependencies: [{ upstreamTaskId: taskA.taskId, mode: 'review_ready' }],
+      automationState: { autoStartEligible: false }
+    });
+
+    const runA = await repoBoard.startRun(taskA.taskId);
+    await repoBoard.transitionRun(runA.runId, {
+      status: 'PR_OPEN',
+      reviewUrl: 'https://gitlab.example.com/group/project/-/merge_requests/301',
+      reviewNumber: 301,
+      reviewProvider: 'gitlab',
+      reviewState: 'open',
+      headSha: sha('g')
+    });
+
+    const detailB = await repoBoard.getTask(taskB.taskId);
+    expect(detailB.task.status).toBe('ACTIVE');
+    expect(detailB.latestRun?.dependencyContext).toMatchObject({
+      sourceMode: 'dependency_review_head',
+      sourceTaskId: taskA.taskId,
+      sourceRunId: runA.runId,
+      sourceReviewNumber: 301,
+      sourceReviewProvider: 'gitlab',
+      sourceHeadSha: sha('g')
+    });
+
+    await repoBoard.transitionRun(runA.runId, {
+      status: 'DONE',
+      reviewUrl: 'https://gitlab.example.com/group/project/-/merge_requests/301',
+      reviewNumber: 301,
+      reviewProvider: 'gitlab',
+      reviewState: 'merged',
+      reviewMergedAt: '2026-03-02T01:00:00.000Z',
+      landedOnDefaultBranch: true,
+      landedOnDefaultBranchAt: '2026-03-02T01:05:00.000Z',
+      headSha: sha('g')
+    });
+    await repoBoard.updateTask(taskA.taskId, { status: 'DONE' });
+    await repoBoard.updateTask(taskC.taskId, {
+      automationState: { autoStartEligible: true }
+    });
+
+    const detailC = await repoBoard.getTask(taskC.taskId);
+    expect(detailC.task.status).toBe('ACTIVE');
+    expect(detailC.latestRun?.dependencyContext?.sourceMode).toBe('default_branch');
+    expect(detailC.task.branchSource).toMatchObject({ kind: 'default_branch', resolvedRef: 'main' });
+  });
 });


### PR DESCRIPTION
Task: S35-05 Make Stage 3.1 merge readiness provider-neutral

Refactor dependency fanout and merged-to-default-branch fallback to work through SCM adapters so GitLab can participate in Stage 3.1 correctly.


Acceptance criteria:
- Stage 3.1 merge/readiness logic no longer depends on GitHub-only PR assumptions.
- An open GitHub PR or GitLab MR can drive downstream REVIEW-ready behavior.
- Merged-to-default-branch fallback works through provider-neutral review state and landed-on-default-branch checks.
- Existing GitHub Stage 3.1 behavior remains intact.

Run ID: run_repo_abuiles_minions_mm98gge7g1yi