### PR TITLE
S35-07 End-to-end GitLab dogfood and regression coverage

### DIFF
--- a/src/server/scm/registry.integration.test.ts
+++ b/src/server/scm/registry.integration.test.ts
@@ -1,0 +1,209 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { AgentRun, Repo, Task } from '../../ui/domain/types';
+import { getScmAdapter } from './registry';
+
+function buildGithubRepo(overrides: Partial<Repo> = {}): Repo {
+  return {
+    repoId: 'repo_github_demo',
+    slug: 'abuiles/minions',
+    scmProvider: 'github',
+    scmBaseUrl: 'https://github.com',
+    projectPath: 'abuiles/minions',
+    defaultBranch: 'main',
+    baselineUrl: 'https://minions.example.com',
+    enabled: true,
+    createdAt: '2026-03-02T00:00:00.000Z',
+    updatedAt: '2026-03-02T00:00:00.000Z',
+    ...overrides
+  };
+}
+
+function buildGitlabRepo(overrides: Partial<Repo> = {}): Repo {
+  return {
+    repoId: 'repo_gitlab_demo',
+    slug: 'group/platform/minions',
+    scmProvider: 'gitlab',
+    scmBaseUrl: 'https://gitlab.com',
+    projectPath: 'group/platform/minions',
+    defaultBranch: 'main',
+    baselineUrl: 'https://minions.example.com',
+    enabled: true,
+    createdAt: '2026-03-02T00:00:00.000Z',
+    updatedAt: '2026-03-02T00:00:00.000Z',
+    ...overrides
+  };
+}
+
+function buildTask(overrides: Partial<Task> = {}): Task {
+  return {
+    taskId: 'task_demo',
+    repoId: 'repo_demo',
+    title: 'SCM adapter integration',
+    taskPrompt: 'Validate the provider-neutral adapter path.',
+    acceptanceCriteria: ['adapter path works'],
+    context: { links: [] },
+    status: 'ACTIVE',
+    createdAt: '2026-03-02T00:00:00.000Z',
+    updatedAt: '2026-03-02T00:00:00.000Z',
+    ...overrides
+  };
+}
+
+function buildRun(overrides: Partial<AgentRun> = {}): AgentRun {
+  return {
+    runId: 'run_demo',
+    taskId: 'task_demo',
+    repoId: 'repo_demo',
+    status: 'PR_OPEN',
+    branchName: 'agent/run-demo',
+    previewStatus: 'UNKNOWN',
+    evidenceStatus: 'NOT_STARTED',
+    errors: [],
+    startedAt: '2026-03-02T00:00:00.000Z',
+    simulationProfile: 'happy_path',
+    timeline: [],
+    pendingEvents: [],
+    ...overrides
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe('SCM adapter registry integration', () => {
+  it('keeps GitHub regression behavior intact through the provider-neutral adapter layer', async () => {
+    const repo = buildGithubRepo();
+    const adapter = getScmAdapter(repo);
+
+    expect(adapter.normalizeSourceRef('https://github.com/abuiles/minions/pull/42', repo)).toEqual({
+      kind: 'review_head',
+      value: 'pull/42/head',
+      label: 'PR #42',
+      reviewNumber: 42,
+      reviewProvider: 'github'
+    });
+
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        number: 42,
+        html_url: 'https://github.com/abuiles/minions/pull/42'
+      }), { status: 201 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        number: 42,
+        html_url: 'https://github.com/abuiles/minions/pull/42',
+        state: 'closed',
+        merged_at: '2026-03-02T01:00:00.000Z',
+        head: { sha: 'a'.repeat(40) },
+        base: { ref: 'main' }
+      }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ status: 'identical' }), { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(adapter.createReviewRequest(repo, buildTask(), buildRun(), { token: 'ghp_test' })).resolves.toEqual({
+      provider: 'github',
+      number: 42,
+      url: 'https://github.com/abuiles/minions/pull/42'
+    });
+
+    await expect(adapter.getReviewState(repo, buildRun({ reviewNumber: 42 }), { token: 'ghp_test' })).resolves.toEqual({
+      exists: true,
+      state: 'merged',
+      url: 'https://github.com/abuiles/minions/pull/42',
+      number: 42,
+      headSha: 'a'.repeat(40),
+      baseBranch: 'main',
+      mergedAt: '2026-03-02T01:00:00.000Z'
+    });
+
+    await expect(adapter.isCommitOnDefaultBranch(repo, 'a'.repeat(40), { token: 'ghp_test' })).resolves.toBe(true);
+  });
+
+  it('supports hosted GitLab MR source refs and MR creation through the provider-neutral adapter layer', async () => {
+    const repo = buildGitlabRepo({
+      scmBaseUrl: 'https://gitlab.com'
+    });
+    const adapter = getScmAdapter(repo);
+
+    expect(adapter.normalizeSourceRef('https://gitlab.com/group/platform/minions/-/merge_requests/77', repo)).toEqual({
+      kind: 'review_head',
+      value: 'refs/merge-requests/77/head',
+      label: 'MR !77',
+      reviewNumber: 77,
+      reviewProvider: 'gitlab'
+    });
+
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        iid: 77,
+        web_url: 'https://gitlab.com/group/platform/minions/-/merge_requests/77'
+      }), { status: 201 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        iid: 77,
+        web_url: 'https://gitlab.com/group/platform/minions/-/merge_requests/77',
+        state: 'opened',
+        sha: 'b'.repeat(40),
+        target_branch: 'main'
+      }), { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(adapter.createReviewRequest(repo, buildTask(), buildRun(), { token: 'glpat_test' })).resolves.toEqual({
+      provider: 'gitlab',
+      number: 77,
+      url: 'https://gitlab.com/group/platform/minions/-/merge_requests/77'
+    });
+
+    await expect(adapter.getReviewState(repo, buildRun({ reviewNumber: 77 }), { token: 'glpat_test' })).resolves.toEqual({
+      exists: true,
+      state: 'open',
+      url: 'https://gitlab.com/group/platform/minions/-/merge_requests/77',
+      number: 77,
+      headSha: 'b'.repeat(40),
+      baseBranch: 'main',
+      mergedAt: undefined
+    });
+  });
+
+  it('supports self-managed GitLab subgroup source refs and merge readiness checks through the provider-neutral adapter layer', async () => {
+    const repo = buildGitlabRepo({
+      slug: 'group/subgroup/minions',
+      scmBaseUrl: 'https://gitlab.example.com',
+      projectPath: 'group/subgroup/minions'
+    });
+    const adapter = getScmAdapter(repo);
+
+    expect(adapter.normalizeSourceRef('https://gitlab.example.com/group/subgroup/minions/-/tree/feature%2Fadapter', repo)).toEqual({
+      kind: 'branch',
+      value: 'feature/adapter',
+      label: 'branch feature/adapter'
+    });
+    expect(adapter.normalizeSourceRef(
+      'https://gitlab.example.com/group/subgroup/minions/-/commit/0123456789abcdef0123456789abcdef01234567',
+      repo
+    )).toEqual({
+      kind: 'commit',
+      value: '0123456789abcdef0123456789abcdef01234567',
+      label: 'commit 0123456'
+    });
+
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        iid: 88,
+        web_url: 'https://gitlab.example.com/group/subgroup/minions/-/merge_requests/88'
+      }), { status: 201 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        compare_same_ref: false,
+        commits: [{ id: '1' }]
+      }), { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(adapter.createReviewRequest(repo, buildTask(), buildRun(), { token: 'glpat_self_managed' })).resolves.toEqual({
+      provider: 'gitlab',
+      number: 88,
+      url: 'https://gitlab.example.com/group/subgroup/minions/-/merge_requests/88'
+    });
+
+    await expect(adapter.isCommitOnDefaultBranch(repo, 'c'.repeat(40), { token: 'glpat_self_managed' })).resolves.toBe(true);
+  });
+});

--- a/tests/worker/stage-3-1-fanout.test.ts
+++ b/tests/worker/stage-3-1-fanout.test.ts
@@ -255,4 +255,64 @@ describe('Stage 3.1 fanout integration', () => {
     expect(detailC.latestRun?.dependencyContext?.sourceMode).toBe('default_branch');
     expect(detailC.task.branchSource).toMatchObject({ kind: 'default_branch', resolvedRef: 'main' });
   });
+
+  it('allows provider-neutral GitHub review metadata to drive review fanout and merged-to-default fallback', async () => {
+    const repo = await createRepo('github-provider-neutral');
+    const repoBoard = env.REPO_BOARD.getByName(repo.repoId);
+
+    const taskA = await repoBoard.createTask(taskInput(repo.repoId, 'A', 'READY'));
+    const taskB = await repoBoard.createTask(taskInput(repo.repoId, 'B', 'INBOX'));
+    const taskC = await repoBoard.createTask(taskInput(repo.repoId, 'C', 'READY'));
+
+    await repoBoard.updateTask(taskB.taskId, {
+      dependencies: [{ upstreamTaskId: taskA.taskId, mode: 'review_ready' }],
+      automationState: { autoStartEligible: true }
+    });
+    await repoBoard.updateTask(taskC.taskId, {
+      dependencies: [{ upstreamTaskId: taskA.taskId, mode: 'review_ready' }],
+      automationState: { autoStartEligible: false }
+    });
+
+    const runA = await repoBoard.startRun(taskA.taskId);
+    await repoBoard.transitionRun(runA.runId, {
+      status: 'PR_OPEN',
+      reviewUrl: 'https://github.com/acme/github-provider-neutral/pull/401',
+      reviewNumber: 401,
+      reviewProvider: 'github',
+      reviewState: 'open',
+      headSha: sha('h')
+    });
+
+    const detailB = await repoBoard.getTask(taskB.taskId);
+    expect(detailB.task.status).toBe('ACTIVE');
+    expect(detailB.latestRun?.dependencyContext).toMatchObject({
+      sourceMode: 'dependency_review_head',
+      sourceTaskId: taskA.taskId,
+      sourceRunId: runA.runId,
+      sourceReviewNumber: 401,
+      sourceReviewProvider: 'github',
+      sourceHeadSha: sha('h')
+    });
+
+    await repoBoard.transitionRun(runA.runId, {
+      status: 'DONE',
+      reviewUrl: 'https://github.com/acme/github-provider-neutral/pull/401',
+      reviewNumber: 401,
+      reviewProvider: 'github',
+      reviewState: 'merged',
+      reviewMergedAt: '2026-03-02T02:00:00.000Z',
+      landedOnDefaultBranch: true,
+      landedOnDefaultBranchAt: '2026-03-02T02:05:00.000Z',
+      headSha: sha('h')
+    });
+    await repoBoard.updateTask(taskA.taskId, { status: 'DONE' });
+    await repoBoard.updateTask(taskC.taskId, {
+      automationState: { autoStartEligible: true }
+    });
+
+    const detailC = await repoBoard.getTask(taskC.taskId);
+    expect(detailC.task.status).toBe('ACTIVE');
+    expect(detailC.latestRun?.dependencyContext?.sourceMode).toBe('default_branch');
+    expect(detailC.task.branchSource).toMatchObject({ kind: 'default_branch', resolvedRef: 'main' });
+  });
 });

--- a/tests/worker/stage-3-5-scm-dogfood.test.ts
+++ b/tests/worker/stage-3-5-scm-dogfood.test.ts
@@ -1,0 +1,196 @@
+import { env } from 'cloudflare:test';
+import { describe, expect, it } from 'vitest';
+import worker from '../../src/index';
+import { getScmAdapter } from '../../src/server/scm/registry';
+import type { Repo, ScmCredential, Task, TaskDetail } from '../../src/ui/domain/types';
+
+type JsonValue = Record<string, unknown>;
+
+function createExecutionContext(): ExecutionContext {
+  return {
+    waitUntil() {},
+    passThroughOnException() {}
+  } as ExecutionContext;
+}
+
+async function api<T>(path: string, init?: RequestInit): Promise<T> {
+  const request = new Request(`https://minions.example.test${path}`, {
+    ...init,
+    headers: {
+      'Content-Type': 'application/json',
+      ...(init?.headers ?? {})
+    }
+  });
+  const response = await worker.fetch(request, env, createExecutionContext());
+  if (!response.ok) {
+    throw new Error(`API ${init?.method ?? 'GET'} ${path} failed with status ${response.status}.`);
+  }
+  return await response.json() as T;
+}
+
+function taskInput(repoId: string, title: string, patch: Partial<JsonValue> = {}) {
+  return {
+    repoId,
+    title,
+    taskPrompt: `${title} prompt`,
+    acceptanceCriteria: [`${title} done`],
+    context: { links: [] },
+    status: 'READY',
+    ...patch
+  };
+}
+
+describe('Stage 3.5 SCM dogfood API coverage', () => {
+  it('dogfoods the GitHub repo/task/run APIs without regressing adapterized GitHub review behavior', async () => {
+    const repo = await api<Repo>('/api/repos', {
+      method: 'POST',
+      body: JSON.stringify({
+        slug: 'abuiles/minions-github-dogfood',
+        baselineUrl: 'https://github-dogfood.example.com',
+        defaultBranch: 'main'
+      })
+    });
+
+    const task = await api<Task>('/api/tasks', {
+      method: 'POST',
+      body: JSON.stringify(taskInput(repo.repoId, 'GitHub dogfood regression', {
+        sourceRef: 'https://github.com/abuiles/minions-github-dogfood/pull/42'
+      }))
+    });
+    const repoBoard = env.REPO_BOARD.getByName(repo.repoId);
+    const run = await repoBoard.startRun(task.taskId);
+    await repoBoard.transitionRun(run.runId, {
+      status: 'PR_OPEN',
+      reviewUrl: 'https://github.com/abuiles/minions-github-dogfood/pull/42',
+      reviewNumber: 42,
+      reviewProvider: 'github',
+      reviewState: 'open',
+      headSha: 'a'.repeat(40)
+    });
+
+    const detail = await api<TaskDetail>(`/api/tasks/${encodeURIComponent(task.taskId)}`);
+    const snapshot = await api<{ repos: Repo[]; tasks: Task[]; runs: Array<{ runId: string; reviewProvider?: string; prNumber?: number }> }>(
+      `/api/board?repoId=${encodeURIComponent(repo.repoId)}`
+    );
+
+    expect(detail.repo).toMatchObject({
+      repoId: repo.repoId,
+      scmProvider: 'github',
+      scmBaseUrl: 'https://github.com',
+      projectPath: 'abuiles/minions-github-dogfood'
+    });
+    expect(detail.latestRun).toMatchObject({
+      runId: run.runId,
+      reviewProvider: 'github',
+      reviewNumber: 42,
+      prNumber: 42
+    });
+    expect(getScmAdapter(detail.repo).normalizeSourceRef(detail.task.sourceRef!, detail.repo)).toEqual({
+      kind: 'review_head',
+      value: 'pull/42/head',
+      label: 'PR #42',
+      reviewNumber: 42,
+      reviewProvider: 'github'
+    });
+    expect(snapshot.repos.map((candidate) => candidate.repoId)).toContain(repo.repoId);
+    expect(snapshot.tasks.map((candidate) => candidate.taskId)).toContain(task.taskId);
+    expect(snapshot.runs.find((candidate) => candidate.runId === run.runId)).toMatchObject({
+      reviewProvider: 'github',
+      prNumber: 42
+    });
+  });
+
+  it('dogfoods hosted and self-managed GitLab configuration through the repo/task APIs', async () => {
+    const hostedRepo = await api<Repo>('/api/repos', {
+      method: 'POST',
+      body: JSON.stringify({
+        slug: 'group/platform/minions-hosted',
+        projectPath: 'group/platform/minions-hosted',
+        scmProvider: 'gitlab',
+        scmBaseUrl: 'https://gitlab.com',
+        baselineUrl: 'https://hosted-gitlab.example.com',
+        defaultBranch: 'main'
+      })
+    });
+    const selfManagedRepo = await api<Repo>('/api/repos', {
+      method: 'POST',
+      body: JSON.stringify({
+        slug: 'group/subgroup/minions-self-managed',
+        projectPath: 'group/subgroup/minions-self-managed',
+        scmProvider: 'gitlab',
+        scmBaseUrl: 'https://gitlab.example.com',
+        baselineUrl: 'https://self-managed-gitlab.example.com',
+        defaultBranch: 'main'
+      })
+    });
+    const credential = await api<ScmCredential>('/api/scm/credentials', {
+      method: 'POST',
+      body: JSON.stringify({
+        scmProvider: 'gitlab',
+        host: 'GitLab.EXAMPLE.com',
+        label: 'Self-managed GitLab',
+        token: 'glpat_secret'
+      })
+    });
+
+    const hostedTask = await api<Task>('/api/tasks', {
+      method: 'POST',
+      body: JSON.stringify(taskInput(hostedRepo.repoId, 'Hosted GitLab MR', {
+        sourceRef: 'https://gitlab.com/group/platform/minions-hosted/-/merge_requests/77'
+      }))
+    });
+    const selfManagedTask = await api<Task>('/api/tasks', {
+      method: 'POST',
+      body: JSON.stringify(taskInput(selfManagedRepo.repoId, 'Self-managed GitLab branch', {
+        sourceRef: 'https://gitlab.example.com/group/subgroup/minions-self-managed/-/tree/feature%2Fadapter'
+      }))
+    });
+
+    const hostedRun = await env.REPO_BOARD.getByName(hostedRepo.repoId).startRun(hostedTask.taskId);
+    await env.REPO_BOARD.getByName(hostedRepo.repoId).transitionRun(hostedRun.runId, {
+      status: 'PR_OPEN',
+      reviewUrl: 'https://gitlab.com/group/platform/minions-hosted/-/merge_requests/77',
+      reviewNumber: 77,
+      reviewProvider: 'gitlab',
+      reviewState: 'open',
+      headSha: 'b'.repeat(40)
+    });
+
+    const hostedDetail = await api<TaskDetail>(`/api/tasks/${encodeURIComponent(hostedTask.taskId)}`);
+    const selfManagedDetail = await api<TaskDetail>(`/api/tasks/${encodeURIComponent(selfManagedTask.taskId)}`);
+
+    expect(hostedDetail.repo).toMatchObject({
+      scmProvider: 'gitlab',
+      scmBaseUrl: 'https://gitlab.com',
+      projectPath: 'group/platform/minions-hosted'
+    });
+    expect(selfManagedDetail.repo).toMatchObject({
+      scmProvider: 'gitlab',
+      scmBaseUrl: 'https://gitlab.example.com',
+      projectPath: 'group/subgroup/minions-self-managed'
+    });
+    expect(credential).toMatchObject({
+      credentialId: 'gitlab:gitlab.example.com',
+      scmProvider: 'gitlab',
+      host: 'gitlab.example.com',
+      hasSecret: true
+    });
+    expect(hostedDetail.latestRun).toMatchObject({
+      reviewProvider: 'gitlab',
+      reviewNumber: 77,
+      prNumber: 77
+    });
+    expect(getScmAdapter(hostedDetail.repo).normalizeSourceRef(hostedDetail.task.sourceRef!, hostedDetail.repo)).toEqual({
+      kind: 'review_head',
+      value: 'refs/merge-requests/77/head',
+      label: 'MR !77',
+      reviewNumber: 77,
+      reviewProvider: 'gitlab'
+    });
+    expect(getScmAdapter(selfManagedDetail.repo).normalizeSourceRef(selfManagedDetail.task.sourceRef!, selfManagedDetail.repo)).toEqual({
+      kind: 'branch',
+      value: 'feature/adapter',
+      label: 'branch feature/adapter'
+    });
+  });
+});


### PR DESCRIPTION
Task: S35-07 End-to-end GitLab dogfood and regression coverage

Validate the new SCM adapter layer end to end for GitHub and GitLab, including Stage 3.1 fanout semantics and hosted GitLab configuration.


Acceptance criteria:
- GitHub regression coverage exists for the adapterized SCM path.
- GitLab coverage exists for hosted/self-managed source refs and MR flow.
- Stage 3.1 provider-neutral readiness behavior is validated for GitHub and GitLab.
- The SCM adapter stage can be considered complete from a test/validation perspective.

Run ID: run_repo_abuiles_minions_mm98tmnhckoe