### PR TITLE
S35-L1 Generic LLM types and compatibility aliases

### DIFF
--- a/src/server/durable/repo-board.ts
+++ b/src/server/durable/repo-board.ts
@@ -23,6 +23,7 @@ import { executeRunJob } from '../run-orchestrator';
 import { refreshDependencyStates } from '../shared/dependency-state';
 import { buildLatestRunsByTaskId, isDependencyMergedToDefaultBranch } from '../shared/dependency-readiness';
 import { resolveRunSource } from '../shared/run-source-resolution';
+import { buildTaskUiMeta, normalizeOperatorSession, normalizeRun, normalizeTask } from '../../shared/llm';
 import { hasRunReview, normalizeDependencyReviewMetadata, normalizeRunReviewMetadata, normalizeTaskBranchSourceReviewMetadata } from '../../shared/scm';
 
 const STORAGE_KEY = 'repo-board-state';
@@ -121,11 +122,14 @@ export class RepoBoardDO extends DurableObject<Env> {
       status: input.status ?? 'INBOX',
       createdAt: now,
       updatedAt: now,
-      uiMeta: {
-        simulationProfile: input.simulationProfile ?? 'happy_path',
-        codexModel: input.codexModel ?? 'gpt-5.1-codex-mini',
-        codexReasoningEffort: input.codexReasoningEffort ?? 'medium'
-      }
+      uiMeta: buildTaskUiMeta({
+        simulationProfile: input.simulationProfile,
+        llmAdapter: input.llmAdapter,
+        llmModel: input.llmModel,
+        llmReasoningEffort: input.llmReasoningEffort,
+        codexModel: input.codexModel,
+        codexReasoningEffort: input.codexReasoningEffort
+      })
     };
 
     this.state = {
@@ -167,11 +171,14 @@ export class RepoBoardDO extends DurableObject<Env> {
       sourceRef: patch.sourceRef ?? existing.sourceRef,
       context: patch.context ?? existing.context,
       acceptanceCriteria: patch.acceptanceCriteria ?? existing.acceptanceCriteria,
-      uiMeta: {
-        simulationProfile: patch.simulationProfile ?? existing.uiMeta?.simulationProfile ?? 'happy_path',
-        codexModel: patch.codexModel ?? existing.uiMeta?.codexModel ?? 'gpt-5.1-codex-mini',
-        codexReasoningEffort: patch.codexReasoningEffort ?? existing.uiMeta?.codexReasoningEffort ?? 'medium'
-      },
+      uiMeta: buildTaskUiMeta({
+        simulationProfile: patch.simulationProfile ?? existing.uiMeta?.simulationProfile,
+        llmAdapter: patch.llmAdapter ?? existing.uiMeta?.llmAdapter,
+        llmModel: patch.llmModel ?? existing.uiMeta?.llmModel,
+        llmReasoningEffort: patch.llmReasoningEffort ?? existing.uiMeta?.llmReasoningEffort,
+        codexModel: patch.codexModel ?? existing.uiMeta?.codexModel,
+        codexReasoningEffort: patch.codexReasoningEffort ?? existing.uiMeta?.codexReasoningEffort
+      }),
       updatedAt: new Date().toISOString()
     };
 
@@ -571,10 +578,13 @@ export class RepoBoardDO extends DurableObject<Env> {
   async updateOperatorSession(runId: string, session?: OperatorSession) {
     await this.ready;
     const run = await this.getRun(runId);
+    const nextSession = normalizeOperatorSession(session, run);
     const updated = {
-      ...run,
-      operatorSession: session,
-      latestCodexResumeCommand: session?.codexResumeCommand ?? run.latestCodexResumeCommand
+      ...normalizeRun(run),
+      operatorSession: nextSession,
+      llmSessionId: nextSession?.llmSessionId ?? run.llmSessionId,
+      llmResumeCommand: nextSession?.llmResumeCommand ?? run.llmResumeCommand,
+      latestCodexResumeCommand: nextSession?.codexResumeCommand ?? run.latestCodexResumeCommand
     };
     this.state = {
       ...this.state,
@@ -582,7 +592,7 @@ export class RepoBoardDO extends DurableObject<Env> {
     };
     await this.persist();
     await this.emit({ type: 'run.updated', payload: { run: updated } }, updated.repoId);
-    await this.emit({ type: 'run.operator_session_updated', payload: { runId, session } }, updated.repoId);
+    await this.emit({ type: 'run.operator_session_updated', payload: { runId, session: nextSession } }, updated.repoId);
     return updated;
   }
 
@@ -602,6 +612,7 @@ export class RepoBoardDO extends DurableObject<Env> {
         reason: 'sandbox_missing',
         cols: 120,
         rows: 32,
+        llmResumeCommand: run.llmResumeCommand,
         codexResumeCommand: run.latestCodexResumeCommand
       };
     }
@@ -619,6 +630,7 @@ export class RepoBoardDO extends DurableObject<Env> {
         cols: 120,
         rows: 32,
         session: run.operatorSession,
+        llmResumeCommand: run.llmResumeCommand,
         codexResumeCommand: run.latestCodexResumeCommand
       };
     }
@@ -635,6 +647,7 @@ export class RepoBoardDO extends DurableObject<Env> {
       cols: 120,
       rows: 32,
       session: run.operatorSession,
+      llmResumeCommand: run.llmResumeCommand,
       codexResumeCommand: run.latestCodexResumeCommand
     };
   }
@@ -648,7 +661,7 @@ export class RepoBoardDO extends DurableObject<Env> {
 
     const now = new Date().toISOString();
     const sessionName = getOperatorSessionName(run);
-    const session = run.operatorSession ?? {
+    const session = normalizeOperatorSession(run.operatorSession, run) ?? {
       id: `${runId}:${sessionName}`,
       runId,
       sandboxId: run.sandboxId,
@@ -658,6 +671,9 @@ export class RepoBoardDO extends DurableObject<Env> {
       actorLabel: actor.actorLabel,
       connectionState: 'open' as const,
       takeoverState: 'observing' as const,
+      llmAdapter: run.llmAdapter,
+      llmSessionId: run.llmSessionId,
+      llmResumeCommand: run.llmResumeCommand,
       codexThreadId: undefined,
       codexResumeCommand: run.latestCodexResumeCommand
     };
@@ -665,17 +681,19 @@ export class RepoBoardDO extends DurableObject<Env> {
       ...session,
       actorId: actor.actorId,
       actorLabel: actor.actorLabel,
-      takeoverState: run.latestCodexResumeCommand ? 'resumable' : 'operator_control',
+      takeoverState: run.llmResumeCommand ? 'resumable' : 'operator_control',
       connectionState: session.connectionState === 'failed' ? 'failed' : 'open'
     };
 
-    const updated = {
+    const updated = normalizeRun({
       ...run,
       status: 'OPERATOR_CONTROLLED' as const,
       codexProcessId: undefined,
       currentCommandId: undefined,
+      llmSessionId: nextSession.llmSessionId ?? run.llmSessionId,
+      llmResumeCommand: nextSession.llmResumeCommand ?? run.llmResumeCommand,
       operatorSession: nextSession
-    };
+    });
     const task = this.state.tasks.find((candidate) => candidate.taskId === run.taskId);
     if (!task) {
       throw notFound(`Task ${run.taskId} not found.`, { taskId: run.taskId, runId });
@@ -689,10 +707,10 @@ export class RepoBoardDO extends DurableObject<Env> {
     const events: RunEvent[] = [
       buildRunEvent(updated, 'operator', 'operator.takeover_started', 'Operator took control of the live sandbox session and stopped Codex execution.', { sessionName: nextSession.sessionName })
     ];
-    if (updated.latestCodexResumeCommand) {
+    if (updated.llmResumeCommand) {
       events.push(
         buildRunEvent(updated, 'system', 'codex.resume_available', 'Codex resume command is available for this run.', {
-          command: updated.latestCodexResumeCommand
+          command: updated.llmResumeCommand
         })
       );
     }
@@ -999,7 +1017,7 @@ function getOperatorSessionName(run: AgentRun) {
 
 function cloneRepoBoardState(state: RepoBoardState): RepoBoardState {
   return {
-    tasks: state.tasks.map((task) => ({
+    tasks: state.tasks.map((task) => normalizeTask({
       ...task,
       dependencies: cloneTaskDependencies(task.dependencies),
       dependencyState: cloneTaskDependencyState(task.dependencyState),
@@ -1008,7 +1026,7 @@ function cloneRepoBoardState(state: RepoBoardState): RepoBoardState {
       context: { ...task.context, links: task.context.links.map((link) => ({ ...link })) },
       uiMeta: task.uiMeta ? { ...task.uiMeta } : undefined
     })),
-    runs: state.runs.map((run) => ({
+    runs: state.runs.map((run) => normalizeRun({
       ...normalizeRunReviewMetadata(run),
       codexProcessId: run.codexProcessId,
       changeRequest: run.changeRequest ? { ...run.changeRequest } : undefined,
@@ -1041,11 +1059,11 @@ function cloneRepoBoardState(state: RepoBoardState): RepoBoardState {
 
 function normalizeRepoBoardState(state?: Partial<RepoBoardState> | null): RepoBoardState {
   return {
-    tasks: (state?.tasks ?? []).map((task) => ({
+    tasks: (state?.tasks ?? []).map((task) => normalizeTask({
       ...task,
       branchSource: cloneTaskBranchSource(task.branchSource)
     })),
-    runs: (state?.runs ?? []).map((run) => ({
+    runs: (state?.runs ?? []).map((run) => normalizeRun({
       ...normalizeRunReviewMetadata(run),
       dependencyContext: run.dependencyContext ? normalizeDependencyReviewMetadata({ ...run.dependencyContext }) : undefined
     })),

--- a/src/server/http/validation.test.ts
+++ b/src/server/http/validation.test.ts
@@ -101,6 +101,38 @@ describe('task validation', () => {
       })
     ).toThrow('Invalid branchSource.upstreamReviewNumber.');
   });
+
+  it('accepts provider-neutral llm task fields', () => {
+    const parsed = parseCreateTaskInput(
+      createTaskPayload({
+        llmAdapter: 'cursor_cli',
+        llmModel: 'cursor-fast',
+        llmReasoningEffort: 'high'
+      })
+    );
+
+    expect(parsed).toMatchObject({
+      llmAdapter: 'cursor_cli',
+      llmModel: 'cursor-fast',
+      llmReasoningEffort: 'high',
+      codexModel: undefined,
+      codexReasoningEffort: undefined
+    });
+  });
+
+  it('maps legacy codex task fields to provider-neutral llm fields', () => {
+    const parsed = parseUpdateTaskInput({
+      codexModel: 'gpt-5.3-codex-spark',
+      codexReasoningEffort: 'high'
+    });
+
+    expect(parsed).toMatchObject({
+      llmModel: 'gpt-5.3-codex-spark',
+      llmReasoningEffort: 'high',
+      codexModel: 'gpt-5.3-codex-spark',
+      codexReasoningEffort: 'high'
+    });
+  });
 });
 
 describe('repo validation', () => {

--- a/src/server/http/validation.ts
+++ b/src/server/http/validation.ts
@@ -1,9 +1,7 @@
 import type { CreateRepoInput, CreateTaskInput, UpdateRepoInput, UpdateTaskInput, UpsertScmCredentialInput } from '../../ui/domain/api';
 import { badRequest } from './errors';
+import { CODEX_MODELS, LLM_ADAPTERS, LLM_REASONING_EFFORTS } from '../../shared/llm';
 import { SCM_PROVIDERS } from '../../shared/scm';
-
-const CODEX_MODELS = new Set(['gpt-5.1-codex-mini', 'gpt-5.3-codex', 'gpt-5.3-codex-spark'] as const);
-const CODEX_REASONING_EFFORTS = new Set(['low', 'medium', 'high'] as const);
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
@@ -298,6 +296,12 @@ export function parseCreateTaskInput(body: unknown): CreateTaskInput {
     throw badRequest('Invalid task payload.');
   }
 
+  const llmAdapter = readEnumValue(body.llmAdapter, 'llmAdapter', LLM_ADAPTERS, false);
+  const llmModel = readTrimmedString(body.llmModel, 'llmModel', false);
+  const llmReasoningEffort = readEnumValue(body.llmReasoningEffort, 'llmReasoningEffort', LLM_REASONING_EFFORTS, false);
+  const codexModel = readEnumValue(body.codexModel, 'codexModel', CODEX_MODELS, false);
+  const codexReasoningEffort = readEnumValue(body.codexReasoningEffort, 'codexReasoningEffort', LLM_REASONING_EFFORTS, false);
+
   return {
     repoId: readString(body.repoId, 'repoId')!,
     title: readString(body.title, 'title')!,
@@ -313,8 +317,11 @@ export function parseCreateTaskInput(body: unknown): CreateTaskInput {
     baselineUrlOverride: readString(body.baselineUrlOverride, 'baselineUrlOverride', false),
     status: readString(body.status, 'status', false) as CreateTaskInput['status'],
     simulationProfile: readString(body.simulationProfile, 'simulationProfile', false) as CreateTaskInput['simulationProfile'],
-    codexModel: readEnumValue(body.codexModel, 'codexModel', CODEX_MODELS, false),
-    codexReasoningEffort: readEnumValue(body.codexReasoningEffort, 'codexReasoningEffort', CODEX_REASONING_EFFORTS, false)
+    llmAdapter,
+    llmModel: llmModel ?? codexModel,
+    llmReasoningEffort: llmReasoningEffort ?? codexReasoningEffort,
+    codexModel,
+    codexReasoningEffort
   };
 }
 
@@ -324,6 +331,11 @@ export function parseUpdateTaskInput(body: unknown): UpdateTaskInput {
   }
 
   const patch: UpdateTaskInput = {};
+  const llmAdapter = readEnumValue(body.llmAdapter, 'llmAdapter', LLM_ADAPTERS, false);
+  const llmModel = readTrimmedString(body.llmModel, 'llmModel', false);
+  const llmReasoningEffort = readEnumValue(body.llmReasoningEffort, 'llmReasoningEffort', LLM_REASONING_EFFORTS, false);
+  const codexModel = readEnumValue(body.codexModel, 'codexModel', CODEX_MODELS, false);
+  const codexReasoningEffort = readEnumValue(body.codexReasoningEffort, 'codexReasoningEffort', LLM_REASONING_EFFORTS, false);
   if (hasOwn(body, 'repoId')) patch.repoId = readString(body.repoId, 'repoId', false);
   if (hasOwn(body, 'title')) patch.title = readString(body.title, 'title', false);
   if (hasOwn(body, 'description')) patch.description = readString(body.description, 'description', false);
@@ -338,8 +350,11 @@ export function parseUpdateTaskInput(body: unknown): UpdateTaskInput {
   if (hasOwn(body, 'baselineUrlOverride')) patch.baselineUrlOverride = readString(body.baselineUrlOverride, 'baselineUrlOverride', false);
   if (hasOwn(body, 'status')) patch.status = readString(body.status, 'status', false) as UpdateTaskInput['status'];
   if (hasOwn(body, 'simulationProfile')) patch.simulationProfile = readString(body.simulationProfile, 'simulationProfile', false) as UpdateTaskInput['simulationProfile'];
-  if (hasOwn(body, 'codexModel')) patch.codexModel = readEnumValue(body.codexModel, 'codexModel', CODEX_MODELS, false);
-  if (hasOwn(body, 'codexReasoningEffort')) patch.codexReasoningEffort = readEnumValue(body.codexReasoningEffort, 'codexReasoningEffort', CODEX_REASONING_EFFORTS, false);
+  if (hasOwn(body, 'llmAdapter')) patch.llmAdapter = llmAdapter;
+  if (hasOwn(body, 'llmModel') || hasOwn(body, 'codexModel')) patch.llmModel = llmModel ?? codexModel;
+  if (hasOwn(body, 'llmReasoningEffort') || hasOwn(body, 'codexReasoningEffort')) patch.llmReasoningEffort = llmReasoningEffort ?? codexReasoningEffort;
+  if (hasOwn(body, 'codexModel')) patch.codexModel = codexModel;
+  if (hasOwn(body, 'codexReasoningEffort')) patch.codexReasoningEffort = codexReasoningEffort;
   if (hasOwn(body, 'runId')) patch.runId = readString(body.runId, 'runId', false);
   return patch;
 }

--- a/src/server/router.ts
+++ b/src/server/router.ts
@@ -248,6 +248,9 @@ export async function handleApiRequest(request: Request, env: Env, ctx: Executio
         actorLabel: run.operatorSession?.actorLabel ?? 'Operator',
         connectionState: 'connecting' as const,
         takeoverState: run.operatorSession?.takeoverState ?? 'observing',
+        llmAdapter: run.operatorSession?.llmAdapter ?? run.llmAdapter,
+        llmSessionId: run.operatorSession?.llmSessionId ?? run.llmSessionId ?? run.operatorSession?.codexThreadId,
+        llmResumeCommand: run.operatorSession?.llmResumeCommand ?? run.llmResumeCommand ?? run.operatorSession?.codexResumeCommand ?? run.latestCodexResumeCommand,
         codexThreadId: run.operatorSession?.codexThreadId,
         codexResumeCommand: run.operatorSession?.codexResumeCommand ?? run.latestCodexResumeCommand
       };

--- a/src/server/run-orchestrator.ts
+++ b/src/server/run-orchestrator.ts
@@ -3,6 +3,7 @@ import type { RepoBoardDO } from './durable/repo-board';
 import type { BoardIndexDO } from './durable/board-index';
 import type { Repo, RunCommand, RunCommandPhase, RunEvent, Task } from '../ui/domain/types';
 import { buildRunLog, type RunJobParams } from './shared/real-run';
+import { getTaskLlmConfig } from '../shared/llm';
 import { NonRetryableError } from 'cloudflare:workflows';
 import { inspectPreviewDiscovery } from './preview-discovery';
 import { LineLogBuffer } from './line-log-buffer';
@@ -59,8 +60,9 @@ export async function executeRunJob(env: Env, params: RunJobParams, sleepFn: Sle
   }
   const repo = await board.getRepo(params.repoId);
   const scmAdapter = getScmAdapter(repo);
-  const codexModel = detail.task.uiMeta?.codexModel ?? 'gpt-5.1-codex-mini';
-  const codexReasoningEffort = detail.task.uiMeta?.codexReasoningEffort ?? 'medium';
+  const llmConfig = getTaskLlmConfig(detail.task);
+  const codexModel = llmConfig.codexModel;
+  const codexReasoningEffort = llmConfig.codexReasoningEffort;
 
   if (params.mode === 'evidence_only') {
     if (!shouldRunEvidence(repo)) {
@@ -968,10 +970,17 @@ async function execStreamWithLogs(
           if (resumeMatch.resumeCommand && resumeMatch.resumeCommand !== latestResumeCommand) {
             latestResumeCommand = resumeMatch.resumeCommand;
             const latestRun = await repoBoard.getRun(runId);
-            await repoBoard.transitionRun(runId, { latestCodexResumeCommand: latestResumeCommand });
+            await repoBoard.transitionRun(runId, {
+              llmSessionId: latestThreadId,
+              llmResumeCommand: latestResumeCommand,
+              latestCodexResumeCommand: latestResumeCommand
+            });
             if (latestRun.operatorSession) {
               await repoBoard.updateOperatorSession(runId, {
                 ...latestRun.operatorSession,
+                llmAdapter: latestRun.llmAdapter ?? 'codex',
+                llmSessionId: latestThreadId,
+                llmResumeCommand: latestResumeCommand,
                 codexResumeCommand: latestResumeCommand,
                 codexThreadId: latestThreadId,
                 takeoverState: latestRun.operatorSession.takeoverState === 'operator_control' ? 'resumable' : latestRun.operatorSession.takeoverState
@@ -1153,10 +1162,17 @@ async function runCodexProcessWithLogs(
           if (resumeMatch.resumeCommand && resumeMatch.resumeCommand !== latestResumeCommand) {
             latestResumeCommand = resumeMatch.resumeCommand;
             const latestRun = await repoBoard.getRun(runId);
-            await repoBoard.transitionRun(runId, { latestCodexResumeCommand: latestResumeCommand });
+            await repoBoard.transitionRun(runId, {
+              llmSessionId: latestThreadId,
+              llmResumeCommand: latestResumeCommand,
+              latestCodexResumeCommand: latestResumeCommand
+            });
             if (latestRun.operatorSession) {
               await repoBoard.updateOperatorSession(runId, {
                 ...latestRun.operatorSession,
+                llmAdapter: latestRun.llmAdapter ?? 'codex',
+                llmSessionId: latestThreadId,
+                llmResumeCommand: latestResumeCommand,
                 codexResumeCommand: latestResumeCommand,
                 codexThreadId: latestThreadId,
                 takeoverState: latestRun.operatorSession.takeoverState === 'operator_control' ? 'resumable' : latestRun.operatorSession.takeoverState

--- a/src/server/shared/real-run.ts
+++ b/src/server/shared/real-run.ts
@@ -1,4 +1,5 @@
 import type { ArtifactManifest, AgentRun, Repo, RunError, RunLogEntry, RunStatus, Task } from '../../ui/domain/types';
+import { buildRunLlmState, normalizeRun } from '../../shared/llm';
 import { normalizeRunReviewMetadata } from '../../shared/scm';
 
 export type RunJobMode = 'full_run' | 'evidence_only' | 'preview_only';
@@ -34,6 +35,11 @@ export type RunTransitionPatch = {
   commitMessage?: string;
   codexProcessId?: string;
   currentCommandId?: string;
+  llmAdapter?: AgentRun['llmAdapter'];
+  llmModel?: AgentRun['llmModel'];
+  llmReasoningEffort?: AgentRun['llmReasoningEffort'];
+  llmResumeCommand?: AgentRun['llmResumeCommand'];
+  llmSessionId?: AgentRun['llmSessionId'];
   latestCodexResumeCommand?: string;
   operatorSession?: AgentRun['operatorSession'];
   artifactManifest?: ArtifactManifest;
@@ -62,7 +68,8 @@ type CreateRealRunOptions = {
 
 export function createRealRun(task: Task, runId: string, now = new Date(), options?: CreateRealRunOptions): AgentRun {
   const nowIso = now.toISOString();
-  return normalizeRunReviewMetadata({
+  return normalizeRun(
+    normalizeRunReviewMetadata({
     runId,
     taskId: task.taskId,
     repoId: task.repoId,
@@ -90,8 +97,10 @@ export function createRealRun(task: Task, runId: string, now = new Date(), optio
     evidenceStatus: 'NOT_STARTED',
     executorType: 'sandbox',
     orchestrationMode: 'workflow',
-    executionSummary: {}
-  });
+    executionSummary: {},
+    ...buildRunLlmState(task)
+    })
+  );
 }
 
 export function applyRunTransition(run: AgentRun, patch: RunTransitionPatch, nowIso: string): AgentRun {
@@ -100,7 +109,8 @@ export function applyRunTransition(run: AgentRun, patch: RunTransitionPatch, now
     ? [...run.timeline, { status: nextStatus, at: nowIso, note: patch.appendTimelineNote }]
     : run.timeline;
 
-  return normalizeRunReviewMetadata({
+  return normalizeRun(
+    normalizeRunReviewMetadata({
     ...run,
     ...patch,
     status: nextStatus,
@@ -111,7 +121,8 @@ export function applyRunTransition(run: AgentRun, patch: RunTransitionPatch, now
     artifacts: patch.artifacts ?? run.artifacts,
     errors: run.errors,
     pendingEvents: run.pendingEvents
-  });
+    })
+  );
 }
 
 export function appendRunError(run: AgentRun, error: RunError, nowIso: string): AgentRun {

--- a/src/shared/llm.ts
+++ b/src/shared/llm.ts
@@ -1,0 +1,122 @@
+import type { AgentRun, CodexModel, LlmAdapterKind, LlmReasoningEffort, OperatorSession, Task, TaskUiMeta } from '../ui/domain/types';
+
+export const LLM_ADAPTERS = new Set(['codex', 'cursor_cli'] as const);
+export const LLM_REASONING_EFFORTS = new Set(['low', 'medium', 'high'] as const);
+export const CODEX_MODELS = new Set(['gpt-5.1-codex-mini', 'gpt-5.3-codex', 'gpt-5.3-codex-spark'] as const);
+
+export const DEFAULT_LLM_ADAPTER: LlmAdapterKind = 'codex';
+export const DEFAULT_CODEX_MODEL: CodexModel = 'gpt-5.1-codex-mini';
+export const DEFAULT_LLM_REASONING_EFFORT: LlmReasoningEffort = 'medium';
+
+function resolveAdapter(input?: { llmAdapter?: LlmAdapterKind; codexModel?: string; codexReasoningEffort?: string; llmModel?: string; llmReasoningEffort?: string }): LlmAdapterKind | undefined {
+  if (input?.llmAdapter) {
+    return input.llmAdapter;
+  }
+
+  if (input?.codexModel || input?.codexReasoningEffort) {
+    return 'codex';
+  }
+
+  if (input?.llmModel || input?.llmReasoningEffort) {
+    return DEFAULT_LLM_ADAPTER;
+  }
+
+  return undefined;
+}
+
+export function buildTaskUiMeta(input?: Partial<TaskUiMeta>): TaskUiMeta {
+  const adapter = resolveAdapter(input) ?? DEFAULT_LLM_ADAPTER;
+  const llmModel = input?.llmModel ?? input?.codexModel ?? DEFAULT_CODEX_MODEL;
+  const llmReasoningEffort = input?.llmReasoningEffort ?? input?.codexReasoningEffort ?? DEFAULT_LLM_REASONING_EFFORT;
+
+  return {
+    simulationProfile: input?.simulationProfile ?? 'happy_path',
+    llmAdapter: adapter,
+    llmModel,
+    llmReasoningEffort,
+    codexModel: adapter === 'codex' ? (llmModel as CodexModel) : undefined,
+    codexReasoningEffort: adapter === 'codex' ? llmReasoningEffort : undefined
+  };
+}
+
+export function normalizeTask(task: Task): Task {
+  return {
+    ...task,
+    uiMeta: task.uiMeta ? buildTaskUiMeta(task.uiMeta) : undefined
+  };
+}
+
+export function getTaskLlmConfig(task: Pick<Task, 'uiMeta'> | { uiMeta?: TaskUiMeta | undefined }) {
+  const uiMeta = buildTaskUiMeta(task.uiMeta);
+  return {
+    llmAdapter: uiMeta.llmAdapter ?? DEFAULT_LLM_ADAPTER,
+    llmModel: uiMeta.llmModel ?? DEFAULT_CODEX_MODEL,
+    llmReasoningEffort: uiMeta.llmReasoningEffort ?? DEFAULT_LLM_REASONING_EFFORT,
+    codexModel: uiMeta.codexModel ?? DEFAULT_CODEX_MODEL,
+    codexReasoningEffort: uiMeta.codexReasoningEffort ?? DEFAULT_LLM_REASONING_EFFORT
+  };
+}
+
+export function normalizeOperatorSession(session?: OperatorSession, defaults?: Partial<Pick<AgentRun, 'llmAdapter' | 'llmSessionId' | 'llmResumeCommand' | 'latestCodexResumeCommand'>>): OperatorSession | undefined {
+  if (!session) {
+    return undefined;
+  }
+
+  const llmAdapter = session.llmAdapter ?? defaults?.llmAdapter ?? (session.codexThreadId || session.codexResumeCommand || defaults?.latestCodexResumeCommand ? 'codex' : undefined);
+  const llmSessionId = session.llmSessionId ?? session.codexThreadId ?? defaults?.llmSessionId;
+  const llmResumeCommand = session.llmResumeCommand ?? session.codexResumeCommand ?? defaults?.llmResumeCommand ?? defaults?.latestCodexResumeCommand;
+
+  return {
+    ...session,
+    llmAdapter,
+    llmSessionId,
+    llmResumeCommand,
+    codexThreadId: llmAdapter === 'codex' ? llmSessionId : undefined,
+    codexResumeCommand: llmAdapter === 'codex' ? llmResumeCommand : undefined
+  };
+}
+
+export function normalizeRun(run: AgentRun): AgentRun {
+  const taskLlm = run.llmAdapter || run.llmModel || run.llmReasoningEffort
+    ? {
+        llmAdapter: run.llmAdapter,
+        llmModel: run.llmModel,
+        llmReasoningEffort: run.llmReasoningEffort
+      }
+    : undefined;
+  const fallbackAdapter = run.operatorSession?.llmAdapter ?? (run.operatorSession?.codexThreadId ? 'codex' : undefined);
+  const adapter = resolveAdapter({
+    llmAdapter: taskLlm?.llmAdapter,
+    llmModel: taskLlm?.llmModel,
+    llmReasoningEffort: taskLlm?.llmReasoningEffort,
+    codexModel: run.latestCodexResumeCommand,
+    codexReasoningEffort: undefined
+  }) ?? fallbackAdapter ?? (run.latestCodexResumeCommand ? 'codex' : undefined);
+  const llmResumeCommand = run.llmResumeCommand ?? run.latestCodexResumeCommand ?? run.operatorSession?.llmResumeCommand ?? run.operatorSession?.codexResumeCommand;
+  const llmSessionId = run.llmSessionId ?? run.operatorSession?.llmSessionId ?? run.operatorSession?.codexThreadId;
+
+  return {
+    ...run,
+    llmAdapter: taskLlm?.llmAdapter ?? run.llmAdapter ?? run.operatorSession?.llmAdapter ?? (llmResumeCommand || llmSessionId ? 'codex' : undefined),
+    llmModel: run.llmModel,
+    llmReasoningEffort: run.llmReasoningEffort,
+    llmResumeCommand,
+    llmSessionId,
+    latestCodexResumeCommand: (adapter ?? run.llmAdapter) === 'codex' ? llmResumeCommand : undefined,
+    operatorSession: normalizeOperatorSession(run.operatorSession, {
+      llmAdapter: run.llmAdapter ?? adapter,
+      llmSessionId,
+      llmResumeCommand,
+      latestCodexResumeCommand: run.latestCodexResumeCommand
+    })
+  };
+}
+
+export function buildRunLlmState(task: Pick<Task, 'uiMeta'>) {
+  const config = getTaskLlmConfig(task);
+  return {
+    llmAdapter: config.llmAdapter,
+    llmModel: config.llmModel,
+    llmReasoningEffort: config.llmReasoningEffort
+  };
+}

--- a/src/ui/api/http-agent-board-api.ts
+++ b/src/ui/api/http-agent-board-api.ts
@@ -1,7 +1,7 @@
 import type { AgentBoardApi, CreateRepoInput, CreateTaskInput, RequestRunChangesInput, UpdateRepoInput, UpdateTaskInput, UpsertScmCredentialInput } from '../domain/api';
 import type { AgentRun, BoardSnapshotV1, OperatorSession, Repo, RunCommand, RunEvent, RunLogEntry, ScmCredential, Task, TaskDetail, TerminalBootstrap } from '../domain/types';
 import { getTaskDetail } from '../domain/selectors';
-import { parseBoardSnapshot } from '../store/board-snapshot';
+import { normalizeBoardSnapshot, parseBoardSnapshot } from '../store/board-snapshot';
 import { UiPreferencesStore } from '../store/ui-preferences-store';
 
 const EMPTY_SNAPSHOT: BoardSnapshotV1 = {
@@ -232,7 +232,7 @@ export class HttpAgentBoardApi implements AgentBoardApi {
   private composeSnapshot(snapshot: BoardSnapshotV1): BoardSnapshotV1 {
     const ui = this.preferences.getSnapshot();
     return {
-      ...snapshot,
+      ...normalizeBoardSnapshot(snapshot),
       ui: {
         selectedRepoId: ui.selectedRepoId,
         selectedTaskId: ui.selectedTaskId,

--- a/src/ui/domain/api.ts
+++ b/src/ui/domain/api.ts
@@ -3,6 +3,8 @@ import type {
   BoardSnapshotV1,
   CodexModel,
   CodexReasoningEffort,
+  LlmAdapterKind,
+  LlmReasoningEffort,
   Repo,
   RunCommand,
   RunEvent,
@@ -54,6 +56,9 @@ export type CreateTaskInput = {
   baselineUrlOverride?: string;
   status?: TaskStatus;
   simulationProfile?: SimulationProfile;
+  llmAdapter?: LlmAdapterKind;
+  llmModel?: string;
+  llmReasoningEffort?: LlmReasoningEffort;
   codexModel?: CodexModel;
   codexReasoningEffort?: CodexReasoningEffort;
 };

--- a/src/ui/domain/types.ts
+++ b/src/ui/domain/types.ts
@@ -14,8 +14,10 @@ export type RunStatus =
   | 'FAILED';
 
 export type SimulationProfile = 'happy_path' | 'fail_tests' | 'fail_preview';
+export type LlmAdapterKind = 'codex' | 'cursor_cli';
+export type LlmReasoningEffort = 'low' | 'medium' | 'high';
 export type CodexModel = 'gpt-5.3-codex' | 'gpt-5.3-codex-spark' | 'gpt-5.1-codex-mini';
-export type CodexReasoningEffort = 'low' | 'medium' | 'high';
+export type CodexReasoningEffort = LlmReasoningEffort;
 export type ScmProvider = 'github' | 'gitlab';
 export type ReviewProvider = ScmProvider;
 
@@ -112,6 +114,9 @@ export type TaskBranchSource = {
 
 export type TaskUiMeta = {
   simulationProfile?: SimulationProfile;
+  llmAdapter?: LlmAdapterKind;
+  llmModel?: string;
+  llmReasoningEffort?: LlmReasoningEffort;
   codexModel?: CodexModel;
   codexReasoningEffort?: CodexReasoningEffort;
 };
@@ -180,6 +185,9 @@ export type OperatorSession = {
   actorLabel: string;
   connectionState: 'connecting' | 'open' | 'closed' | 'failed';
   takeoverState: 'codex_control' | 'observing' | 'operator_control' | 'resumable';
+  llmAdapter?: LlmAdapterKind;
+  llmSessionId?: string;
+  llmResumeCommand?: string;
   codexThreadId?: string;
   codexResumeCommand?: string;
   closeReason?: string;
@@ -198,6 +206,7 @@ export type TerminalBootstrap = {
   cols: number;
   rows: number;
   session?: OperatorSession;
+  llmResumeCommand?: string;
   codexResumeCommand?: string;
 };
 
@@ -271,6 +280,11 @@ export type AgentRun = {
   evidenceSandboxId?: string;
   commitSha?: string;
   commitMessage?: string;
+  llmAdapter?: LlmAdapterKind;
+  llmModel?: string;
+  llmReasoningEffort?: LlmReasoningEffort;
+  llmResumeCommand?: string;
+  llmSessionId?: string;
   codexProcessId?: string;
   currentCommandId?: string;
   latestCodexResumeCommand?: string;

--- a/src/ui/mock/local-agent-board-api.ts
+++ b/src/ui/mock/local-agent-board-api.ts
@@ -4,6 +4,7 @@ import { getTaskDetail, getTasksForRepo } from '../domain/selectors';
 import { LocalBoardStore } from '../store/local-board-store';
 import { parseImportedBoard } from '../store/import-export';
 import { RunSimulator } from './run-simulator';
+import { buildTaskUiMeta, normalizeOperatorSession, normalizeRun, normalizeTask } from '../../shared/llm';
 import { normalizeCredentialHost, normalizeRepo } from '../../shared/scm';
 
 function nowIso() {
@@ -140,11 +141,14 @@ export class LocalAgentBoardApi implements AgentBoardApi {
       status: input.status ?? 'INBOX',
       createdAt: timestamp,
       updatedAt: timestamp,
-      uiMeta: {
-        simulationProfile: input.simulationProfile ?? 'happy_path',
-        codexModel: input.codexModel ?? 'gpt-5.1-codex-mini',
-        codexReasoningEffort: input.codexReasoningEffort ?? 'medium'
-      }
+      uiMeta: buildTaskUiMeta({
+        simulationProfile: input.simulationProfile,
+        llmAdapter: input.llmAdapter,
+        llmModel: input.llmModel,
+        llmReasoningEffort: input.llmReasoningEffort,
+        codexModel: input.codexModel,
+        codexReasoningEffort: input.codexReasoningEffort
+      })
     };
 
     this.store.update((snapshot) => ({
@@ -178,19 +182,22 @@ export class LocalAgentBoardApi implements AgentBoardApi {
           return task;
         }
 
-        updatedTask = {
+        updatedTask = normalizeTask({
           ...task,
           ...patch,
           sourceRef: patch.sourceRef ?? task.sourceRef,
           context: patch.context ?? task.context,
           acceptanceCriteria: patch.acceptanceCriteria ?? task.acceptanceCriteria,
-          uiMeta: {
-            simulationProfile: patch.simulationProfile ?? task.uiMeta?.simulationProfile ?? 'happy_path',
-            codexModel: patch.codexModel ?? task.uiMeta?.codexModel ?? 'gpt-5.1-codex-mini',
-            codexReasoningEffort: patch.codexReasoningEffort ?? task.uiMeta?.codexReasoningEffort ?? 'medium'
-          },
+          uiMeta: buildTaskUiMeta({
+            simulationProfile: patch.simulationProfile ?? task.uiMeta?.simulationProfile,
+            llmAdapter: patch.llmAdapter ?? task.uiMeta?.llmAdapter,
+            llmModel: patch.llmModel ?? task.uiMeta?.llmModel,
+            llmReasoningEffort: patch.llmReasoningEffort ?? task.uiMeta?.llmReasoningEffort,
+            codexModel: patch.codexModel ?? task.uiMeta?.codexModel,
+            codexReasoningEffort: patch.codexReasoningEffort ?? task.uiMeta?.codexReasoningEffort
+          }),
           updatedAt: nowIso()
-        };
+        });
         return updatedTask;
       })
     }));
@@ -290,15 +297,15 @@ export class LocalAgentBoardApi implements AgentBoardApi {
           return run;
         }
 
-        updatedRun = {
+        updatedRun = normalizeRun({
           ...run,
           status: 'OPERATOR_CONTROLLED',
           codexProcessId: undefined,
           currentCommandId: undefined,
-          operatorSession: run.operatorSession
+          operatorSession: normalizeOperatorSession(run.operatorSession, run)
             ? {
-                ...run.operatorSession,
-                takeoverState: run.latestCodexResumeCommand ? 'resumable' : 'operator_control',
+                ...normalizeOperatorSession(run.operatorSession, run)!,
+                takeoverState: run.llmResumeCommand ? 'resumable' : 'operator_control',
                 connectionState: 'open'
               }
             : {
@@ -310,10 +317,13 @@ export class LocalAgentBoardApi implements AgentBoardApi {
                 actorId: 'same-session',
                 actorLabel: 'Operator',
                 connectionState: 'open',
-                takeoverState: run.latestCodexResumeCommand ? 'resumable' : 'operator_control',
+                takeoverState: run.llmResumeCommand ? 'resumable' : 'operator_control',
+                llmAdapter: run.llmAdapter,
+                llmSessionId: run.llmSessionId,
+                llmResumeCommand: run.llmResumeCommand,
                 codexResumeCommand: run.latestCodexResumeCommand
               }
-        };
+        });
         return updatedRun;
       })
     }));
@@ -353,6 +363,7 @@ export class LocalAgentBoardApi implements AgentBoardApi {
         cols: 120,
         rows: 32,
         session: run.operatorSession,
+        llmResumeCommand: run.llmResumeCommand,
         codexResumeCommand: run.latestCodexResumeCommand
       };
     }
@@ -369,6 +380,7 @@ export class LocalAgentBoardApi implements AgentBoardApi {
       cols: 120,
       rows: 32,
       session: run.operatorSession,
+      llmResumeCommand: run.llmResumeCommand,
       codexResumeCommand: run.latestCodexResumeCommand
     };
   }

--- a/src/ui/mock/run-simulator.test.ts
+++ b/src/ui/mock/run-simulator.test.ts
@@ -23,6 +23,7 @@ describe('run simulator', () => {
 
     expect(bootstrap.attachable).toBe(true);
     expect(bootstrap.sessionName).toBe('operator');
+    expect(bootstrap.llmResumeCommand).toBeUndefined();
 
     const updatedRun = await api.takeOverRun(run.runId);
     expect(updatedRun.operatorSession?.takeoverState).toBe('operator_control');

--- a/src/ui/mock/run-simulator.ts
+++ b/src/ui/mock/run-simulator.ts
@@ -3,6 +3,7 @@ import { buildLogsForStatus } from './log-builder';
 import { buildSimulationPlan } from './run-templates';
 import { getBaselineUrl } from '../domain/selectors';
 import { LocalBoardStore } from '../store/local-board-store';
+import { buildRunLlmState, normalizeRun } from '../../shared/llm';
 
 const terminalStatuses: RunStatus[] = ['DONE', 'FAILED'];
 
@@ -66,7 +67,8 @@ export class RunSimulator {
       startedAt: startedAt.toISOString(),
       timeline: [],
       simulationProfile: profile,
-      pendingEvents: buildSimulationPlan(startedAt, profile)
+      pendingEvents: buildSimulationPlan(startedAt, profile),
+      ...buildRunLlmState(task)
     };
 
     this.store.update((snapshot) => ({
@@ -158,14 +160,14 @@ export class RunSimulator {
       }
 
       const pendingEvents = run.pendingEvents.filter((event) => !(event.status === status && event.note === note));
-      const nextRun: AgentRun = {
+      const nextRun: AgentRun = normalizeRun({
         ...run,
         status,
         pendingEvents,
-      currentStepStartedAt: now,
-      currentCommandId: undefined,
-      timeline: [...run.timeline, { status, at: now, note }]
-    };
+        currentStepStartedAt: now,
+        currentCommandId: undefined,
+        timeline: [...run.timeline, { status, at: now, note }]
+      });
 
       if (status === 'PR_OPEN') {
         nextRun.prNumber = nextRun.prNumber ?? Math.floor((Date.now() / 1_000) % 10_000);

--- a/src/ui/store/board-snapshot.test.ts
+++ b/src/ui/store/board-snapshot.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import { parseBoardSnapshot } from './board-snapshot';
+
+describe('board snapshot normalization', () => {
+  it('normalizes legacy codex task and run fields into generic llm aliases', () => {
+    const snapshot = parseBoardSnapshot(JSON.stringify({
+      version: 1,
+      repos: [],
+      tasks: [
+        {
+          taskId: 'task_1',
+          repoId: 'repo_1',
+          title: 'Legacy task',
+          taskPrompt: 'Do the thing',
+          acceptanceCriteria: ['done'],
+          context: { links: [] },
+          status: 'READY',
+          createdAt: '2026-03-02T00:00:00.000Z',
+          updatedAt: '2026-03-02T00:00:00.000Z',
+          uiMeta: {
+            simulationProfile: 'happy_path',
+            codexModel: 'gpt-5.3-codex',
+            codexReasoningEffort: 'medium'
+          }
+        }
+      ],
+      runs: [
+        {
+          runId: 'run_1',
+          taskId: 'task_1',
+          repoId: 'repo_1',
+          status: 'OPERATOR_CONTROLLED',
+          branchName: 'agent/task_1/run_1',
+          latestCodexResumeCommand: 'codex resume thread_123',
+          operatorSession: {
+            id: 'session_1',
+            runId: 'run_1',
+            sandboxId: 'run_1',
+            sessionName: 'operator-run_1',
+            startedAt: '2026-03-02T00:00:00.000Z',
+            actorId: 'same-session',
+            actorLabel: 'Operator',
+            connectionState: 'open',
+            takeoverState: 'resumable',
+            codexThreadId: 'thread_123',
+            codexResumeCommand: 'codex resume thread_123'
+          },
+          errors: [],
+          startedAt: '2026-03-02T00:00:00.000Z',
+          timeline: [],
+          simulationProfile: 'happy_path',
+          pendingEvents: []
+        }
+      ],
+      logs: [],
+      events: [],
+      commands: [],
+      ui: {
+        selectedRepoId: 'all',
+        seeded: false
+      }
+    }));
+
+    expect(snapshot.tasks[0]?.uiMeta).toMatchObject({
+      llmAdapter: 'codex',
+      llmModel: 'gpt-5.3-codex',
+      llmReasoningEffort: 'medium',
+      codexModel: 'gpt-5.3-codex',
+      codexReasoningEffort: 'medium'
+    });
+    expect(snapshot.runs[0]).toMatchObject({
+      llmAdapter: 'codex',
+      llmResumeCommand: 'codex resume thread_123',
+      llmSessionId: 'thread_123',
+      latestCodexResumeCommand: 'codex resume thread_123'
+    });
+    expect(snapshot.runs[0]?.operatorSession).toMatchObject({
+      llmAdapter: 'codex',
+      llmSessionId: 'thread_123',
+      llmResumeCommand: 'codex resume thread_123',
+      codexThreadId: 'thread_123',
+      codexResumeCommand: 'codex resume thread_123'
+    });
+  });
+});

--- a/src/ui/store/board-snapshot.ts
+++ b/src/ui/store/board-snapshot.ts
@@ -1,4 +1,5 @@
 import type { BoardSnapshotV1 } from '../domain/types';
+import { normalizeRun, normalizeTask } from '../../shared/llm';
 
 export const BOARD_STORAGE_KEY = 'agentboard.snapshot.v1';
 
@@ -23,5 +24,13 @@ export function parseBoardSnapshot(serialized: string): BoardSnapshotV1 {
     throw new Error('Invalid AgentsKanban snapshot.');
   }
 
-  return parsed;
+  return normalizeBoardSnapshot(parsed);
+}
+
+export function normalizeBoardSnapshot(snapshot: BoardSnapshotV1): BoardSnapshotV1 {
+  return {
+    ...snapshot,
+    tasks: snapshot.tasks.map((task) => normalizeTask(task)),
+    runs: snapshot.runs.map((run) => normalizeRun(run))
+  };
 }

--- a/tests/worker/stage-3-5-scm-foundation.test.ts
+++ b/tests/worker/stage-3-5-scm-foundation.test.ts
@@ -118,4 +118,73 @@ describe('Stage 3.5 SCM foundation', () => {
       prNumber: 12
     });
   });
+
+  it('stores generic llm run and operator session fields while preserving codex aliases', async () => {
+    const board = env.BOARD_INDEX.getByName('agentboard');
+    const repo = await board.createRepo({
+      slug: 'acme/llm-demo',
+      baselineUrl: 'https://llm-demo.example.com',
+      defaultBranch: 'main'
+    });
+    const repoBoard = env.REPO_BOARD.getByName(repo.repoId);
+
+    const task = await repoBoard.createTask({
+      repoId: repo.repoId,
+      title: 'LLM aliases',
+      taskPrompt: 'Use the generic llm metadata.',
+      acceptanceCriteria: ['llm metadata is stored'],
+      context: { links: [] },
+      llmAdapter: 'codex',
+      llmModel: 'gpt-5.3-codex',
+      llmReasoningEffort: 'high',
+      status: 'READY'
+    });
+    const run = await repoBoard.startRun(task.taskId);
+
+    expect(task.uiMeta).toMatchObject({
+      llmAdapter: 'codex',
+      llmModel: 'gpt-5.3-codex',
+      llmReasoningEffort: 'high',
+      codexModel: 'gpt-5.3-codex',
+      codexReasoningEffort: 'high'
+    });
+    expect(run).toMatchObject({
+      llmAdapter: 'codex',
+      llmModel: 'gpt-5.3-codex',
+      llmReasoningEffort: 'high'
+    });
+
+    const updated = await repoBoard.updateOperatorSession(run.runId, {
+      id: `${run.runId}:operator`,
+      runId: run.runId,
+      sandboxId: 'sandbox_1',
+      sessionName: 'operator',
+      startedAt: '2026-03-02T00:00:00.000Z',
+      actorId: 'same-session',
+      actorLabel: 'Operator',
+      connectionState: 'open',
+      takeoverState: 'resumable',
+      codexThreadId: 'thread_456',
+      codexResumeCommand: 'codex resume thread_456'
+    });
+    const bootstrap = await repoBoard.getTerminalBootstrap(run.runId);
+
+    expect(updated).toMatchObject({
+      llmAdapter: 'codex',
+      llmSessionId: 'thread_456',
+      llmResumeCommand: 'codex resume thread_456',
+      latestCodexResumeCommand: 'codex resume thread_456'
+    });
+    expect(updated.operatorSession).toMatchObject({
+      llmAdapter: 'codex',
+      llmSessionId: 'thread_456',
+      llmResumeCommand: 'codex resume thread_456',
+      codexThreadId: 'thread_456',
+      codexResumeCommand: 'codex resume thread_456'
+    });
+    expect(bootstrap).toMatchObject({
+      llmResumeCommand: 'codex resume thread_456',
+      codexResumeCommand: 'codex resume thread_456'
+    });
+  });
 });


### PR DESCRIPTION
Task: S35-L1 Generic LLM types and compatibility aliases

Introduce provider-neutral LLM configuration and run/session fields while preserving current Codex behavior through compatibility aliases.


Acceptance criteria:
- Task and run models support generic LLM adapter/model/reasoning fields.
- Existing Codex-specific fields continue to work through compatibility aliases.
- Operator session and run metadata can represent executor-neutral resume/session information.
- No current Codex behavior regresses while the generic types are introduced.

Run ID: run_repo_abuiles_minions_mm9ajvnt9qb3