### PR TITLE
S35-L1 Generic LLM types and compatibility aliases

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6196,16 +6196,6 @@
         "@poppinss/exception": "^1.2.2",
         "error-stack-parser-es": "^1.0.5"
       }
-    },
-    "node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "extraneous": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
     }
   }
 }

--- a/src/server/durable/repo-board.ts
+++ b/src/server/durable/repo-board.ts
@@ -23,6 +23,7 @@ import { executeRunJob } from '../run-orchestrator';
 import { refreshDependencyStates } from '../shared/dependency-state';
 import { buildLatestRunsByTaskId, isDependencyMergedToDefaultBranch } from '../shared/dependency-readiness';
 import { resolveRunSource } from '../shared/run-source-resolution';
+import { normalizeOperatorSession, normalizeRunLlmState, normalizeTaskUiMeta } from '../../shared/llm';
 import { hasRunReview, normalizeDependencyReviewMetadata, normalizeRunReviewMetadata, normalizeTaskBranchSourceReviewMetadata } from '../../shared/scm';
 
 const STORAGE_KEY = 'repo-board-state';
@@ -121,11 +122,14 @@ export class RepoBoardDO extends DurableObject<Env> {
       status: input.status ?? 'INBOX',
       createdAt: now,
       updatedAt: now,
-      uiMeta: {
+      uiMeta: normalizeTaskUiMeta({
         simulationProfile: input.simulationProfile ?? 'happy_path',
-        codexModel: input.codexModel ?? 'gpt-5.1-codex-mini',
-        codexReasoningEffort: input.codexReasoningEffort ?? 'medium'
-      }
+        llmAdapter: input.llmAdapter,
+        llmModel: input.llmModel,
+        llmReasoningEffort: input.llmReasoningEffort,
+        codexModel: input.codexModel,
+        codexReasoningEffort: input.codexReasoningEffort
+      })
     };
 
     this.state = {
@@ -167,11 +171,14 @@ export class RepoBoardDO extends DurableObject<Env> {
       sourceRef: patch.sourceRef ?? existing.sourceRef,
       context: patch.context ?? existing.context,
       acceptanceCriteria: patch.acceptanceCriteria ?? existing.acceptanceCriteria,
-      uiMeta: {
+      uiMeta: normalizeTaskUiMeta({
         simulationProfile: patch.simulationProfile ?? existing.uiMeta?.simulationProfile ?? 'happy_path',
-        codexModel: patch.codexModel ?? existing.uiMeta?.codexModel ?? 'gpt-5.1-codex-mini',
-        codexReasoningEffort: patch.codexReasoningEffort ?? existing.uiMeta?.codexReasoningEffort ?? 'medium'
-      },
+        llmAdapter: patch.llmAdapter ?? existing.uiMeta?.llmAdapter,
+        llmModel: patch.llmModel ?? existing.uiMeta?.llmModel,
+        llmReasoningEffort: patch.llmReasoningEffort ?? existing.uiMeta?.llmReasoningEffort,
+        codexModel: patch.codexModel ?? existing.uiMeta?.codexModel,
+        codexReasoningEffort: patch.codexReasoningEffort ?? existing.uiMeta?.codexReasoningEffort
+      }),
       updatedAt: new Date().toISOString()
     };
 
@@ -571,18 +578,22 @@ export class RepoBoardDO extends DurableObject<Env> {
   async updateOperatorSession(runId: string, session?: OperatorSession) {
     await this.ready;
     const run = await this.getRun(runId);
-    const updated = {
+    const normalizedSession = normalizeOperatorSession(session);
+    const updated = normalizeRunLlmState({
       ...run,
-      operatorSession: session,
-      latestCodexResumeCommand: session?.codexResumeCommand ?? run.latestCodexResumeCommand
-    };
+      operatorSession: normalizedSession,
+      llmAdapter: normalizedSession?.llmAdapter ?? run.llmAdapter,
+      llmResumeCommand: normalizedSession?.llmResumeCommand ?? run.llmResumeCommand,
+      llmSessionId: normalizedSession?.llmSessionId ?? run.llmSessionId,
+      latestCodexResumeCommand: normalizedSession?.codexResumeCommand ?? run.latestCodexResumeCommand
+    });
     this.state = {
       ...this.state,
       runs: this.state.runs.map((candidate) => (candidate.runId === runId ? updated : candidate))
     };
     await this.persist();
     await this.emit({ type: 'run.updated', payload: { run: updated } }, updated.repoId);
-    await this.emit({ type: 'run.operator_session_updated', payload: { runId, session } }, updated.repoId);
+    await this.emit({ type: 'run.operator_session_updated', payload: { runId, session: normalizedSession } }, updated.repoId);
     return updated;
   }
 
@@ -602,6 +613,7 @@ export class RepoBoardDO extends DurableObject<Env> {
         reason: 'sandbox_missing',
         cols: 120,
         rows: 32,
+        llmResumeCommand: run.llmResumeCommand ?? run.latestCodexResumeCommand,
         codexResumeCommand: run.latestCodexResumeCommand
       };
     }
@@ -619,6 +631,7 @@ export class RepoBoardDO extends DurableObject<Env> {
         cols: 120,
         rows: 32,
         session: run.operatorSession,
+        llmResumeCommand: run.llmResumeCommand ?? run.latestCodexResumeCommand,
         codexResumeCommand: run.latestCodexResumeCommand
       };
     }
@@ -635,6 +648,7 @@ export class RepoBoardDO extends DurableObject<Env> {
       cols: 120,
       rows: 32,
       session: run.operatorSession,
+      llmResumeCommand: run.llmResumeCommand ?? run.latestCodexResumeCommand,
       codexResumeCommand: run.latestCodexResumeCommand
     };
   }
@@ -658,24 +672,27 @@ export class RepoBoardDO extends DurableObject<Env> {
       actorLabel: actor.actorLabel,
       connectionState: 'open' as const,
       takeoverState: 'observing' as const,
+      llmAdapter: run.llmAdapter ?? 'codex',
+      llmSessionId: run.llmSessionId,
+      llmResumeCommand: run.llmResumeCommand ?? run.latestCodexResumeCommand,
       codexThreadId: undefined,
       codexResumeCommand: run.latestCodexResumeCommand
     };
-    const nextSession: OperatorSession = {
+    const nextSession: OperatorSession = normalizeOperatorSession({
       ...session,
       actorId: actor.actorId,
       actorLabel: actor.actorLabel,
       takeoverState: run.latestCodexResumeCommand ? 'resumable' : 'operator_control',
       connectionState: session.connectionState === 'failed' ? 'failed' : 'open'
-    };
+    })!;
 
-    const updated = {
+    const updated = normalizeRunLlmState({
       ...run,
       status: 'OPERATOR_CONTROLLED' as const,
       codexProcessId: undefined,
       currentCommandId: undefined,
       operatorSession: nextSession
-    };
+    });
     const task = this.state.tasks.find((candidate) => candidate.taskId === run.taskId);
     if (!task) {
       throw notFound(`Task ${run.taskId} not found.`, { taskId: run.taskId, runId });
@@ -1006,20 +1023,20 @@ function cloneRepoBoardState(state: RepoBoardState): RepoBoardState {
       automationState: cloneTaskAutomationState(task.automationState),
       branchSource: cloneTaskBranchSource(task.branchSource),
       context: { ...task.context, links: task.context.links.map((link) => ({ ...link })) },
-      uiMeta: task.uiMeta ? { ...task.uiMeta } : undefined
+      uiMeta: normalizeTaskUiMeta(task.uiMeta ? { ...task.uiMeta } : undefined)
     })),
     runs: state.runs.map((run) => ({
-      ...normalizeRunReviewMetadata(run),
+      ...normalizeRunLlmState(normalizeRunReviewMetadata(run)),
       codexProcessId: run.codexProcessId,
       changeRequest: run.changeRequest ? { ...run.changeRequest } : undefined,
       dependencyContext: run.dependencyContext ? normalizeDependencyReviewMetadata({ ...run.dependencyContext }) : undefined,
-      operatorSession: run.operatorSession ? { ...run.operatorSession } : undefined,
+      operatorSession: normalizeOperatorSession(run.operatorSession ? { ...run.operatorSession } : undefined),
       errors: run.errors.map((error) => ({ ...error })),
       timeline: run.timeline.map((entry) => ({ ...entry })),
       pendingEvents: run.pendingEvents.map((event) => ({ ...event })),
       executionSummary: run.executionSummary ? { ...run.executionSummary } : undefined,
       artifacts: run.artifacts ? [...run.artifacts] : undefined,
-      latestCodexResumeCommand: run.latestCodexResumeCommand,
+      latestCodexResumeCommand: run.latestCodexResumeCommand ?? run.llmResumeCommand,
       currentCommandId: run.currentCommandId,
       artifactManifest: run.artifactManifest
         ? {
@@ -1043,10 +1060,11 @@ function normalizeRepoBoardState(state?: Partial<RepoBoardState> | null): RepoBo
   return {
     tasks: (state?.tasks ?? []).map((task) => ({
       ...task,
-      branchSource: cloneTaskBranchSource(task.branchSource)
+      branchSource: cloneTaskBranchSource(task.branchSource),
+      uiMeta: normalizeTaskUiMeta(task.uiMeta)
     })),
     runs: (state?.runs ?? []).map((run) => ({
-      ...normalizeRunReviewMetadata(run),
+      ...normalizeRunLlmState(normalizeRunReviewMetadata(run)),
       dependencyContext: run.dependencyContext ? normalizeDependencyReviewMetadata({ ...run.dependencyContext }) : undefined
     })),
     logs: (state?.logs ?? [])

--- a/src/server/http/validation.test.ts
+++ b/src/server/http/validation.test.ts
@@ -52,6 +52,39 @@ describe('task validation', () => {
     expect(parsed.branchSource?.upstreamReviewProvider).toBe('gitlab');
   });
 
+  it('parses generic llm task fields and mirrors codex aliases', () => {
+    const parsed = parseCreateTaskInput(
+      createTaskPayload({
+        llmAdapter: 'codex',
+        llmModel: 'gpt-5.3-codex-spark',
+        llmReasoningEffort: 'high'
+      })
+    );
+
+    expect(parsed).toMatchObject({
+      llmAdapter: 'codex',
+      llmModel: 'gpt-5.3-codex-spark',
+      llmReasoningEffort: 'high',
+      codexModel: 'gpt-5.3-codex-spark',
+      codexReasoningEffort: 'high'
+    });
+  });
+
+  it('accepts codex compatibility fields without explicit llmAdapter', () => {
+    const parsed = parseCreateTaskInput(
+      createTaskPayload({
+        codexModel: 'gpt-5.3-codex-spark',
+        codexReasoningEffort: 'high'
+      })
+    );
+
+    expect(parsed).toMatchObject({
+      llmAdapter: 'codex',
+      llmModel: 'gpt-5.3-codex-spark',
+      llmReasoningEffort: 'high'
+    });
+  });
+
   it('rejects create payload with multiple primary dependencies', () => {
     expect(() =>
       parseCreateTaskInput(
@@ -100,6 +133,24 @@ describe('task validation', () => {
         }
       })
     ).toThrow('Invalid branchSource.upstreamReviewNumber.');
+  });
+
+  it('rejects mismatched llm and codex compatibility fields', () => {
+    expect(() =>
+      parseUpdateTaskInput({
+        llmModel: 'gpt-5.3-codex',
+        codexModel: 'gpt-5.3-codex-spark'
+      })
+    ).toThrow('Invalid LLM payload: llmModel and codexModel must match when both are provided.');
+  });
+
+  it('rejects codex compatibility fields for non-codex adapters', () => {
+    expect(() =>
+      parseUpdateTaskInput({
+        llmAdapter: 'cursor_cli',
+        codexModel: 'gpt-5.3-codex'
+      })
+    ).toThrow('Invalid LLM payload: codex compatibility fields require llmAdapter "codex".');
   });
 });
 

--- a/src/server/http/validation.ts
+++ b/src/server/http/validation.ts
@@ -4,6 +4,7 @@ import { SCM_PROVIDERS } from '../../shared/scm';
 
 const CODEX_MODELS = new Set(['gpt-5.1-codex-mini', 'gpt-5.3-codex', 'gpt-5.3-codex-spark'] as const);
 const CODEX_REASONING_EFFORTS = new Set(['low', 'medium', 'high'] as const);
+const LLM_ADAPTERS = new Set(['codex', 'cursor_cli'] as const);
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
@@ -216,6 +217,60 @@ function readBranchSource(value: unknown, required = true): CreateTaskInput['bra
   };
 }
 
+function readTaskLlmFields(body: Record<string, unknown>, mode: 'create' | 'update') {
+  const hasField = (key: string) => mode === 'create' || hasOwn(body, key);
+
+  const llmAdapter = hasField('llmAdapter')
+    ? readEnumValue(body.llmAdapter, 'llmAdapter', LLM_ADAPTERS, false)
+    : undefined;
+  const llmModel = hasField('llmModel')
+    ? readTrimmedString(body.llmModel, 'llmModel', false)
+    : undefined;
+  const llmReasoningEffort = hasField('llmReasoningEffort')
+    ? readEnumValue(body.llmReasoningEffort, 'llmReasoningEffort', CODEX_REASONING_EFFORTS, false)
+    : undefined;
+  const codexModel = hasField('codexModel')
+    ? readEnumValue(body.codexModel, 'codexModel', CODEX_MODELS, false)
+    : undefined;
+  const codexReasoningEffort = hasField('codexReasoningEffort')
+    ? readEnumValue(body.codexReasoningEffort, 'codexReasoningEffort', CODEX_REASONING_EFFORTS, false)
+    : undefined;
+
+  if (llmAdapter && llmAdapter !== 'codex' && (typeof codexModel !== 'undefined' || typeof codexReasoningEffort !== 'undefined')) {
+    throw badRequest('Invalid LLM payload: codex compatibility fields require llmAdapter "codex".');
+  }
+
+  if (llmModel && codexModel && llmModel !== codexModel) {
+    throw badRequest('Invalid LLM payload: llmModel and codexModel must match when both are provided.');
+  }
+
+  if (llmReasoningEffort && codexReasoningEffort && llmReasoningEffort !== codexReasoningEffort) {
+    throw badRequest('Invalid LLM payload: llmReasoningEffort and codexReasoningEffort must match when both are provided.');
+  }
+
+  const effectiveAdapter = llmAdapter ?? ((typeof codexModel !== 'undefined' || typeof codexReasoningEffort !== 'undefined') ? 'codex' : undefined);
+  const effectiveModel = llmModel ?? codexModel;
+  const effectiveReasoningEffort = llmReasoningEffort ?? codexReasoningEffort;
+  const normalizedCodexModel = (effectiveAdapter ?? 'codex') === 'codex'
+    ? readEnumValue(codexModel ?? effectiveModel, 'llmModel', CODEX_MODELS, false)
+    : codexModel;
+  const normalizedCodexReasoningEffort = (effectiveAdapter ?? 'codex') === 'codex'
+    ? readEnumValue(codexReasoningEffort ?? effectiveReasoningEffort, 'llmReasoningEffort', CODEX_REASONING_EFFORTS, false)
+    : codexReasoningEffort;
+
+  if ((effectiveAdapter ?? 'codex') === 'codex' && effectiveModel) {
+    readEnumValue(effectiveModel, 'llmModel', CODEX_MODELS, true);
+  }
+
+  return {
+    llmAdapter: effectiveAdapter,
+    llmModel: effectiveModel,
+    llmReasoningEffort: effectiveReasoningEffort,
+    codexModel: normalizedCodexModel,
+    codexReasoningEffort: normalizedCodexReasoningEffort
+  };
+}
+
 export async function readJson(request: Request) {
   try {
     return (await request.json()) as unknown;
@@ -298,6 +353,7 @@ export function parseCreateTaskInput(body: unknown): CreateTaskInput {
     throw badRequest('Invalid task payload.');
   }
 
+  const llmFields = readTaskLlmFields(body, 'create');
   return {
     repoId: readString(body.repoId, 'repoId')!,
     title: readString(body.title, 'title')!,
@@ -313,8 +369,7 @@ export function parseCreateTaskInput(body: unknown): CreateTaskInput {
     baselineUrlOverride: readString(body.baselineUrlOverride, 'baselineUrlOverride', false),
     status: readString(body.status, 'status', false) as CreateTaskInput['status'],
     simulationProfile: readString(body.simulationProfile, 'simulationProfile', false) as CreateTaskInput['simulationProfile'],
-    codexModel: readEnumValue(body.codexModel, 'codexModel', CODEX_MODELS, false),
-    codexReasoningEffort: readEnumValue(body.codexReasoningEffort, 'codexReasoningEffort', CODEX_REASONING_EFFORTS, false)
+    ...llmFields
   };
 }
 
@@ -324,6 +379,7 @@ export function parseUpdateTaskInput(body: unknown): UpdateTaskInput {
   }
 
   const patch: UpdateTaskInput = {};
+  const llmFields = readTaskLlmFields(body, 'update');
   if (hasOwn(body, 'repoId')) patch.repoId = readString(body.repoId, 'repoId', false);
   if (hasOwn(body, 'title')) patch.title = readString(body.title, 'title', false);
   if (hasOwn(body, 'description')) patch.description = readString(body.description, 'description', false);
@@ -338,8 +394,15 @@ export function parseUpdateTaskInput(body: unknown): UpdateTaskInput {
   if (hasOwn(body, 'baselineUrlOverride')) patch.baselineUrlOverride = readString(body.baselineUrlOverride, 'baselineUrlOverride', false);
   if (hasOwn(body, 'status')) patch.status = readString(body.status, 'status', false) as UpdateTaskInput['status'];
   if (hasOwn(body, 'simulationProfile')) patch.simulationProfile = readString(body.simulationProfile, 'simulationProfile', false) as UpdateTaskInput['simulationProfile'];
-  if (hasOwn(body, 'codexModel')) patch.codexModel = readEnumValue(body.codexModel, 'codexModel', CODEX_MODELS, false);
-  if (hasOwn(body, 'codexReasoningEffort')) patch.codexReasoningEffort = readEnumValue(body.codexReasoningEffort, 'codexReasoningEffort', CODEX_REASONING_EFFORTS, false);
+  if (hasOwn(body, 'llmAdapter') || hasOwn(body, 'codexModel') || hasOwn(body, 'codexReasoningEffort')) patch.llmAdapter = llmFields.llmAdapter;
+  if (hasOwn(body, 'llmModel') || hasOwn(body, 'codexModel')) {
+    patch.llmModel = llmFields.llmModel;
+    patch.codexModel = llmFields.codexModel;
+  }
+  if (hasOwn(body, 'llmReasoningEffort') || hasOwn(body, 'codexReasoningEffort')) {
+    patch.llmReasoningEffort = llmFields.llmReasoningEffort;
+    patch.codexReasoningEffort = llmFields.codexReasoningEffort;
+  }
   if (hasOwn(body, 'runId')) patch.runId = readString(body.runId, 'runId', false);
   return patch;
 }

--- a/src/server/router.ts
+++ b/src/server/router.ts
@@ -248,6 +248,9 @@ export async function handleApiRequest(request: Request, env: Env, ctx: Executio
         actorLabel: run.operatorSession?.actorLabel ?? 'Operator',
         connectionState: 'connecting' as const,
         takeoverState: run.operatorSession?.takeoverState ?? 'observing',
+        llmAdapter: run.operatorSession?.llmAdapter ?? run.llmAdapter ?? 'codex',
+        llmSessionId: run.operatorSession?.llmSessionId ?? run.operatorSession?.codexThreadId ?? run.llmSessionId,
+        llmResumeCommand: run.operatorSession?.llmResumeCommand ?? run.operatorSession?.codexResumeCommand ?? run.llmResumeCommand ?? run.latestCodexResumeCommand,
         codexThreadId: run.operatorSession?.codexThreadId,
         codexResumeCommand: run.operatorSession?.codexResumeCommand ?? run.latestCodexResumeCommand
       };

--- a/src/server/run-orchestrator.ts
+++ b/src/server/run-orchestrator.ts
@@ -968,10 +968,17 @@ async function execStreamWithLogs(
           if (resumeMatch.resumeCommand && resumeMatch.resumeCommand !== latestResumeCommand) {
             latestResumeCommand = resumeMatch.resumeCommand;
             const latestRun = await repoBoard.getRun(runId);
-            await repoBoard.transitionRun(runId, { latestCodexResumeCommand: latestResumeCommand });
+            await repoBoard.transitionRun(runId, {
+              llmResumeCommand: latestResumeCommand,
+              llmSessionId: latestThreadId,
+              latestCodexResumeCommand: latestResumeCommand
+            });
             if (latestRun.operatorSession) {
               await repoBoard.updateOperatorSession(runId, {
                 ...latestRun.operatorSession,
+                llmAdapter: latestRun.operatorSession.llmAdapter ?? latestRun.llmAdapter ?? 'codex',
+                llmResumeCommand: latestResumeCommand,
+                llmSessionId: latestThreadId,
                 codexResumeCommand: latestResumeCommand,
                 codexThreadId: latestThreadId,
                 takeoverState: latestRun.operatorSession.takeoverState === 'operator_control' ? 'resumable' : latestRun.operatorSession.takeoverState
@@ -1153,10 +1160,17 @@ async function runCodexProcessWithLogs(
           if (resumeMatch.resumeCommand && resumeMatch.resumeCommand !== latestResumeCommand) {
             latestResumeCommand = resumeMatch.resumeCommand;
             const latestRun = await repoBoard.getRun(runId);
-            await repoBoard.transitionRun(runId, { latestCodexResumeCommand: latestResumeCommand });
+            await repoBoard.transitionRun(runId, {
+              llmResumeCommand: latestResumeCommand,
+              llmSessionId: latestThreadId,
+              latestCodexResumeCommand: latestResumeCommand
+            });
             if (latestRun.operatorSession) {
               await repoBoard.updateOperatorSession(runId, {
                 ...latestRun.operatorSession,
+                llmAdapter: latestRun.operatorSession.llmAdapter ?? latestRun.llmAdapter ?? 'codex',
+                llmResumeCommand: latestResumeCommand,
+                llmSessionId: latestThreadId,
                 codexResumeCommand: latestResumeCommand,
                 codexThreadId: latestThreadId,
                 takeoverState: latestRun.operatorSession.takeoverState === 'operator_control' ? 'resumable' : latestRun.operatorSession.takeoverState

--- a/src/server/shared/llm.test.ts
+++ b/src/server/shared/llm.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeOperatorSession, normalizeRunLlmState, normalizeTaskUiMeta } from '../../shared/llm';
+
+describe('llm compatibility normalization', () => {
+  it('hydrates generic task llm fields from codex aliases', () => {
+    expect(normalizeTaskUiMeta({
+      simulationProfile: 'happy_path',
+      codexModel: 'gpt-5.3-codex-spark',
+      codexReasoningEffort: 'high'
+    })).toMatchObject({
+      llmAdapter: 'codex',
+      llmModel: 'gpt-5.3-codex-spark',
+      llmReasoningEffort: 'high',
+      codexModel: 'gpt-5.3-codex-spark',
+      codexReasoningEffort: 'high'
+    });
+  });
+
+  it('hydrates generic run and operator session fields from codex aliases', () => {
+    const session = normalizeOperatorSession({
+      id: 'session_1',
+      runId: 'run_1',
+      sandboxId: 'sandbox_1',
+      sessionName: 'operator-run_1',
+      startedAt: '2026-03-02T00:00:00.000Z',
+      actorId: 'same-session',
+      actorLabel: 'Operator',
+      connectionState: 'open',
+      takeoverState: 'resumable',
+      codexThreadId: 'thread_1',
+      codexResumeCommand: 'codex resume thread_1'
+    });
+
+    const run = normalizeRunLlmState({
+      runId: 'run_1',
+      taskId: 'task_1',
+      repoId: 'repo_1',
+      status: 'OPERATOR_CONTROLLED',
+      branchName: 'agent/task_1/run_1',
+      latestCodexResumeCommand: 'codex resume thread_1',
+      operatorSession: session,
+      errors: [],
+      startedAt: '2026-03-02T00:00:00.000Z',
+      timeline: [],
+      simulationProfile: 'happy_path',
+      pendingEvents: []
+    });
+
+    expect(run).toMatchObject({
+      llmAdapter: 'codex',
+      llmResumeCommand: 'codex resume thread_1',
+      llmSessionId: 'thread_1',
+      latestCodexResumeCommand: 'codex resume thread_1'
+    });
+    expect(run.operatorSession).toMatchObject({
+      llmAdapter: 'codex',
+      llmSessionId: 'thread_1',
+      llmResumeCommand: 'codex resume thread_1'
+    });
+  });
+});

--- a/src/server/shared/real-run.ts
+++ b/src/server/shared/real-run.ts
@@ -1,4 +1,5 @@
 import type { ArtifactManifest, AgentRun, Repo, RunError, RunLogEntry, RunStatus, Task } from '../../ui/domain/types';
+import { normalizeRunLlmState, normalizeTaskUiMeta } from '../../shared/llm';
 import { normalizeRunReviewMetadata } from '../../shared/scm';
 
 export type RunJobMode = 'full_run' | 'evidence_only' | 'preview_only';
@@ -34,6 +35,11 @@ export type RunTransitionPatch = {
   commitMessage?: string;
   codexProcessId?: string;
   currentCommandId?: string;
+  llmAdapter?: AgentRun['llmAdapter'];
+  llmModel?: AgentRun['llmModel'];
+  llmReasoningEffort?: AgentRun['llmReasoningEffort'];
+  llmResumeCommand?: AgentRun['llmResumeCommand'];
+  llmSessionId?: AgentRun['llmSessionId'];
   latestCodexResumeCommand?: string;
   operatorSession?: AgentRun['operatorSession'];
   artifactManifest?: ArtifactManifest;
@@ -62,7 +68,8 @@ type CreateRealRunOptions = {
 
 export function createRealRun(task: Task, runId: string, now = new Date(), options?: CreateRealRunOptions): AgentRun {
   const nowIso = now.toISOString();
-  return normalizeRunReviewMetadata({
+  const taskUiMeta = normalizeTaskUiMeta(task.uiMeta);
+  return normalizeRunLlmState(normalizeRunReviewMetadata({
     runId,
     taskId: task.taskId,
     repoId: task.repoId,
@@ -90,8 +97,11 @@ export function createRealRun(task: Task, runId: string, now = new Date(), optio
     evidenceStatus: 'NOT_STARTED',
     executorType: 'sandbox',
     orchestrationMode: 'workflow',
+    llmAdapter: taskUiMeta?.llmAdapter ?? 'codex',
+    llmModel: taskUiMeta?.llmModel,
+    llmReasoningEffort: taskUiMeta?.llmReasoningEffort,
     executionSummary: {}
-  });
+  }));
 }
 
 export function applyRunTransition(run: AgentRun, patch: RunTransitionPatch, nowIso: string): AgentRun {
@@ -100,7 +110,7 @@ export function applyRunTransition(run: AgentRun, patch: RunTransitionPatch, now
     ? [...run.timeline, { status: nextStatus, at: nowIso, note: patch.appendTimelineNote }]
     : run.timeline;
 
-  return normalizeRunReviewMetadata({
+  return normalizeRunLlmState(normalizeRunReviewMetadata({
     ...run,
     ...patch,
     status: nextStatus,
@@ -111,7 +121,7 @@ export function applyRunTransition(run: AgentRun, patch: RunTransitionPatch, now
     artifacts: patch.artifacts ?? run.artifacts,
     errors: run.errors,
     pendingEvents: run.pendingEvents
-  });
+  }));
 }
 
 export function appendRunError(run: AgentRun, error: RunError, nowIso: string): AgentRun {

--- a/src/shared/llm.ts
+++ b/src/shared/llm.ts
@@ -1,0 +1,68 @@
+import type { AgentRun, CodexModel, CodexReasoningEffort, LlmAdapter, LlmReasoningEffort, OperatorSession, TaskUiMeta } from '../ui/domain/types';
+
+export const DEFAULT_LLM_ADAPTER: LlmAdapter = 'codex';
+export const DEFAULT_CODEX_MODEL: CodexModel = 'gpt-5.1-codex-mini';
+export const DEFAULT_REASONING_EFFORT: CodexReasoningEffort = 'medium';
+
+export function normalizeTaskUiMeta(uiMeta?: TaskUiMeta): TaskUiMeta | undefined {
+  if (!uiMeta) {
+    return undefined;
+  }
+
+  const llmAdapter = uiMeta.llmAdapter ?? DEFAULT_LLM_ADAPTER;
+  const llmModel = uiMeta.llmModel ?? uiMeta.codexModel ?? (llmAdapter === 'codex' ? DEFAULT_CODEX_MODEL : undefined);
+  const llmReasoningEffort = uiMeta.llmReasoningEffort
+    ?? uiMeta.codexReasoningEffort
+    ?? (llmAdapter === 'codex' ? DEFAULT_REASONING_EFFORT : undefined);
+
+  return {
+    ...uiMeta,
+    llmAdapter,
+    llmModel,
+    llmReasoningEffort,
+    codexModel: llmAdapter === 'codex' ? (uiMeta.codexModel ?? llmModel as CodexModel | undefined) : uiMeta.codexModel,
+    codexReasoningEffort: llmAdapter === 'codex'
+      ? (uiMeta.codexReasoningEffort ?? llmReasoningEffort as CodexReasoningEffort | undefined)
+      : uiMeta.codexReasoningEffort
+  };
+}
+
+export function normalizeOperatorSession(session?: OperatorSession): OperatorSession | undefined {
+  if (!session) {
+    return undefined;
+  }
+
+  const llmAdapter = session.llmAdapter ?? DEFAULT_LLM_ADAPTER;
+  const llmSessionId = session.llmSessionId ?? session.codexThreadId;
+  const llmResumeCommand = session.llmResumeCommand ?? session.codexResumeCommand;
+
+  return {
+    ...session,
+    llmAdapter,
+    llmSessionId,
+    llmResumeCommand,
+    codexThreadId: llmAdapter === 'codex' ? (session.codexThreadId ?? llmSessionId) : session.codexThreadId,
+    codexResumeCommand: llmAdapter === 'codex' ? (session.codexResumeCommand ?? llmResumeCommand) : session.codexResumeCommand
+  };
+}
+
+export function normalizeRunLlmState(run: AgentRun): AgentRun {
+  const operatorSession = normalizeOperatorSession(run.operatorSession);
+  const llmAdapter = run.llmAdapter ?? operatorSession?.llmAdapter ?? DEFAULT_LLM_ADAPTER;
+  const llmResumeCommand = run.llmResumeCommand
+    ?? run.latestCodexResumeCommand
+    ?? operatorSession?.llmResumeCommand
+    ?? operatorSession?.codexResumeCommand;
+  const llmSessionId = run.llmSessionId ?? operatorSession?.llmSessionId ?? operatorSession?.codexThreadId;
+
+  return {
+    ...run,
+    operatorSession,
+    llmAdapter,
+    llmResumeCommand,
+    llmSessionId,
+    latestCodexResumeCommand: llmAdapter === 'codex' ? (run.latestCodexResumeCommand ?? llmResumeCommand) : run.latestCodexResumeCommand,
+    llmModel: run.llmModel,
+    llmReasoningEffort: run.llmReasoningEffort as LlmReasoningEffort | undefined
+  };
+}

--- a/src/ui/domain/api.ts
+++ b/src/ui/domain/api.ts
@@ -3,6 +3,8 @@ import type {
   BoardSnapshotV1,
   CodexModel,
   CodexReasoningEffort,
+  LlmAdapter,
+  LlmReasoningEffort,
   Repo,
   RunCommand,
   RunEvent,
@@ -54,6 +56,9 @@ export type CreateTaskInput = {
   baselineUrlOverride?: string;
   status?: TaskStatus;
   simulationProfile?: SimulationProfile;
+  llmAdapter?: LlmAdapter;
+  llmModel?: string;
+  llmReasoningEffort?: LlmReasoningEffort;
   codexModel?: CodexModel;
   codexReasoningEffort?: CodexReasoningEffort;
 };

--- a/src/ui/domain/types.ts
+++ b/src/ui/domain/types.ts
@@ -16,6 +16,8 @@ export type RunStatus =
 export type SimulationProfile = 'happy_path' | 'fail_tests' | 'fail_preview';
 export type CodexModel = 'gpt-5.3-codex' | 'gpt-5.3-codex-spark' | 'gpt-5.1-codex-mini';
 export type CodexReasoningEffort = 'low' | 'medium' | 'high';
+export type LlmAdapter = 'codex' | 'cursor_cli';
+export type LlmReasoningEffort = 'low' | 'medium' | 'high';
 export type ScmProvider = 'github' | 'gitlab';
 export type ReviewProvider = ScmProvider;
 
@@ -112,6 +114,9 @@ export type TaskBranchSource = {
 
 export type TaskUiMeta = {
   simulationProfile?: SimulationProfile;
+  llmAdapter?: LlmAdapter;
+  llmModel?: string;
+  llmReasoningEffort?: LlmReasoningEffort;
   codexModel?: CodexModel;
   codexReasoningEffort?: CodexReasoningEffort;
 };
@@ -180,6 +185,9 @@ export type OperatorSession = {
   actorLabel: string;
   connectionState: 'connecting' | 'open' | 'closed' | 'failed';
   takeoverState: 'codex_control' | 'observing' | 'operator_control' | 'resumable';
+  llmAdapter?: LlmAdapter;
+  llmSessionId?: string;
+  llmResumeCommand?: string;
   codexThreadId?: string;
   codexResumeCommand?: string;
   closeReason?: string;
@@ -198,6 +206,7 @@ export type TerminalBootstrap = {
   cols: number;
   rows: number;
   session?: OperatorSession;
+  llmResumeCommand?: string;
   codexResumeCommand?: string;
 };
 
@@ -273,6 +282,11 @@ export type AgentRun = {
   commitMessage?: string;
   codexProcessId?: string;
   currentCommandId?: string;
+  llmAdapter?: LlmAdapter;
+  llmModel?: string;
+  llmReasoningEffort?: LlmReasoningEffort;
+  llmResumeCommand?: string;
+  llmSessionId?: string;
   latestCodexResumeCommand?: string;
   operatorSession?: OperatorSession;
   dependencyContext?: {

--- a/src/ui/mock/local-agent-board-api.ts
+++ b/src/ui/mock/local-agent-board-api.ts
@@ -4,6 +4,7 @@ import { getTaskDetail, getTasksForRepo } from '../domain/selectors';
 import { LocalBoardStore } from '../store/local-board-store';
 import { parseImportedBoard } from '../store/import-export';
 import { RunSimulator } from './run-simulator';
+import { normalizeOperatorSession, normalizeRunLlmState, normalizeTaskUiMeta } from '../../shared/llm';
 import { normalizeCredentialHost, normalizeRepo } from '../../shared/scm';
 
 function nowIso() {
@@ -140,11 +141,14 @@ export class LocalAgentBoardApi implements AgentBoardApi {
       status: input.status ?? 'INBOX',
       createdAt: timestamp,
       updatedAt: timestamp,
-      uiMeta: {
+      uiMeta: normalizeTaskUiMeta({
         simulationProfile: input.simulationProfile ?? 'happy_path',
-        codexModel: input.codexModel ?? 'gpt-5.1-codex-mini',
-        codexReasoningEffort: input.codexReasoningEffort ?? 'medium'
-      }
+        llmAdapter: input.llmAdapter,
+        llmModel: input.llmModel,
+        llmReasoningEffort: input.llmReasoningEffort,
+        codexModel: input.codexModel,
+        codexReasoningEffort: input.codexReasoningEffort
+      })
     };
 
     this.store.update((snapshot) => ({
@@ -184,11 +188,14 @@ export class LocalAgentBoardApi implements AgentBoardApi {
           sourceRef: patch.sourceRef ?? task.sourceRef,
           context: patch.context ?? task.context,
           acceptanceCriteria: patch.acceptanceCriteria ?? task.acceptanceCriteria,
-          uiMeta: {
+          uiMeta: normalizeTaskUiMeta({
             simulationProfile: patch.simulationProfile ?? task.uiMeta?.simulationProfile ?? 'happy_path',
-            codexModel: patch.codexModel ?? task.uiMeta?.codexModel ?? 'gpt-5.1-codex-mini',
-            codexReasoningEffort: patch.codexReasoningEffort ?? task.uiMeta?.codexReasoningEffort ?? 'medium'
-          },
+            llmAdapter: patch.llmAdapter ?? task.uiMeta?.llmAdapter,
+            llmModel: patch.llmModel ?? task.uiMeta?.llmModel,
+            llmReasoningEffort: patch.llmReasoningEffort ?? task.uiMeta?.llmReasoningEffort,
+            codexModel: patch.codexModel ?? task.uiMeta?.codexModel,
+            codexReasoningEffort: patch.codexReasoningEffort ?? task.uiMeta?.codexReasoningEffort
+          }),
           updatedAt: nowIso()
         };
         return updatedTask;
@@ -290,18 +297,18 @@ export class LocalAgentBoardApi implements AgentBoardApi {
           return run;
         }
 
-        updatedRun = {
+        updatedRun = normalizeRunLlmState({
           ...run,
           status: 'OPERATOR_CONTROLLED',
           codexProcessId: undefined,
           currentCommandId: undefined,
           operatorSession: run.operatorSession
-            ? {
+            ? normalizeOperatorSession({
                 ...run.operatorSession,
                 takeoverState: run.latestCodexResumeCommand ? 'resumable' : 'operator_control',
                 connectionState: 'open'
-              }
-            : {
+              })
+            : normalizeOperatorSession({
                 id: `session_${runId}`,
                 runId,
                 sandboxId: run.sandboxId ?? `mock-${runId}`,
@@ -311,9 +318,12 @@ export class LocalAgentBoardApi implements AgentBoardApi {
                 actorLabel: 'Operator',
                 connectionState: 'open',
                 takeoverState: run.latestCodexResumeCommand ? 'resumable' : 'operator_control',
+                llmAdapter: run.llmAdapter ?? 'codex',
+                llmSessionId: run.llmSessionId,
+                llmResumeCommand: run.llmResumeCommand ?? run.latestCodexResumeCommand,
                 codexResumeCommand: run.latestCodexResumeCommand
-              }
-        };
+              })
+        });
         return updatedRun;
       })
     }));
@@ -353,6 +363,7 @@ export class LocalAgentBoardApi implements AgentBoardApi {
         cols: 120,
         rows: 32,
         session: run.operatorSession,
+        llmResumeCommand: run.llmResumeCommand ?? run.latestCodexResumeCommand,
         codexResumeCommand: run.latestCodexResumeCommand
       };
     }
@@ -369,6 +380,7 @@ export class LocalAgentBoardApi implements AgentBoardApi {
       cols: 120,
       rows: 32,
       session: run.operatorSession,
+      llmResumeCommand: run.llmResumeCommand ?? run.latestCodexResumeCommand,
       codexResumeCommand: run.latestCodexResumeCommand
     };
   }

--- a/src/ui/mock/run-simulator.ts
+++ b/src/ui/mock/run-simulator.ts
@@ -3,6 +3,7 @@ import { buildLogsForStatus } from './log-builder';
 import { buildSimulationPlan } from './run-templates';
 import { getBaselineUrl } from '../domain/selectors';
 import { LocalBoardStore } from '../store/local-board-store';
+import { normalizeRunLlmState, normalizeTaskUiMeta } from '../../shared/llm';
 
 const terminalStatuses: RunStatus[] = ['DONE', 'FAILED'];
 
@@ -50,8 +51,9 @@ export class RunSimulator {
   createRun(task: Task, options?: { branchName?: string; prUrl?: string; prNumber?: number; baseRunId?: string; changeRequest?: AgentRun['changeRequest'] }): AgentRun {
     const startedAt = new Date();
     const runId = `run_${task.taskId}_${startedAt.getTime()}`;
-    const profile = task.uiMeta?.simulationProfile ?? 'happy_path';
-    const run: AgentRun = {
+    const taskUiMeta = normalizeTaskUiMeta(task.uiMeta);
+    const profile = taskUiMeta?.simulationProfile ?? 'happy_path';
+    const run: AgentRun = normalizeRunLlmState({
       runId,
       taskId: task.taskId,
       repoId: task.repoId,
@@ -65,9 +67,12 @@ export class RunSimulator {
       errors: [],
       startedAt: startedAt.toISOString(),
       timeline: [],
+      llmAdapter: taskUiMeta?.llmAdapter ?? 'codex',
+      llmModel: taskUiMeta?.llmModel,
+      llmReasoningEffort: taskUiMeta?.llmReasoningEffort,
       simulationProfile: profile,
       pendingEvents: buildSimulationPlan(startedAt, profile)
-    };
+    });
 
     this.store.update((snapshot) => ({
       ...snapshot,


### PR DESCRIPTION
Task: S35-L1 Generic LLM types and compatibility aliases

Introduce provider-neutral LLM configuration and run/session fields while preserving current Codex behavior through compatibility aliases.


Acceptance criteria:
- Task and run models support generic LLM adapter/model/reasoning fields.
- Existing Codex-specific fields continue to work through compatibility aliases.
- Operator session and run metadata can represent executor-neutral resume/session information.
- No current Codex behavior regresses while the generic types are introduced.

Run ID: run_repo_abuiles_minions_mm9alf26zkyn