### PR TITLE
S35-L2 LLM adapter registry and capability model

### DIFF
--- a/src/server/llm/adapter.ts
+++ b/src/server/llm/adapter.ts
@@ -1,0 +1,57 @@
+import type { getSandbox } from '@cloudflare/sandbox';
+import type { RepoBoardDO } from '../durable/repo-board';
+import type { AgentRun, LlmAdapter as LlmAdapterKind, LlmReasoningEffort, Repo, Task } from '../../ui/domain/types';
+
+export type SandboxHandle = ReturnType<typeof getSandbox>;
+export type RepoBoardHandle = DurableObjectStub<RepoBoardDO>;
+
+export type SleepFn = (name: string, duration: number | `${number} ${string}`) => Promise<void>;
+
+export type LlmExecutionRequest = {
+  repo: Repo;
+  task: Task;
+  run: AgentRun;
+  cwd: string;
+  prompt: string;
+  model: string;
+  reasoningEffort?: LlmReasoningEffort;
+};
+
+export type LlmExecutionResult = {
+  success: boolean;
+  stoppedForTakeover?: boolean;
+  stderr?: string;
+  resumeCommand?: string;
+  sessionId?: string;
+};
+
+export type LlmSessionState = {
+  sessionId?: string;
+  resumeCommand?: string;
+};
+
+export type LlmAdapterCapabilities = {
+  supportsResume: boolean;
+  supportsTakeover: boolean;
+  resumeCommandLabel?: string;
+};
+
+export type LlmRuntimeContext = {
+  env: Env;
+  sandbox: SandboxHandle;
+  repoBoard: RepoBoardHandle;
+  runId: string;
+};
+
+export type LlmAdapter = {
+  kind: LlmAdapterKind;
+  capabilities: LlmAdapterCapabilities;
+
+  ensureInstalled(context: LlmRuntimeContext): Promise<void>;
+  restoreAuth(context: LlmRuntimeContext & { repo: Repo }): Promise<void>;
+  logDiagnostics(context: LlmRuntimeContext, request: LlmExecutionRequest): Promise<void>;
+  waitForCapacityIfNeeded?(context: LlmRuntimeContext, request: LlmExecutionRequest, sleepFn: SleepFn): Promise<void>;
+  run(context: LlmRuntimeContext, request: LlmExecutionRequest): Promise<LlmExecutionResult>;
+
+  extractSessionState?(chunk: string, fallbackSessionId?: string): LlmSessionState;
+};

--- a/src/server/llm/codex.ts
+++ b/src/server/llm/codex.ts
@@ -1,0 +1,42 @@
+import type { LlmAdapter } from './adapter';
+
+export const codexLlmAdapter: LlmAdapter = {
+  kind: 'codex',
+  capabilities: {
+    supportsResume: true,
+    supportsTakeover: true,
+    resumeCommandLabel: 'Codex resume command'
+  },
+
+  async ensureInstalled() {
+    throw new Error('Codex adapter ensureInstalled is not wired yet.');
+  },
+
+  async restoreAuth() {
+    throw new Error('Codex adapter restoreAuth is not wired yet.');
+  },
+
+  async logDiagnostics() {
+    throw new Error('Codex adapter logDiagnostics is not wired yet.');
+  },
+
+  async waitForCapacityIfNeeded() {
+    throw new Error('Codex adapter waitForCapacityIfNeeded is not wired yet.');
+  },
+
+  async run() {
+    throw new Error('Codex adapter run is not wired yet.');
+  },
+
+  extractSessionState(chunk: string, fallbackSessionId?: string) {
+    const sessionMatch = chunk.match(/"thread_id":"([^"]+)"/);
+    const sessionId = sessionMatch?.[1] ?? fallbackSessionId;
+    const resumeMatch = chunk.match(/codex resume ([a-z0-9-]+)/i);
+    const resumeCommand = resumeMatch?.[1] ? `codex resume ${resumeMatch[1]}` : undefined;
+
+    return {
+      sessionId,
+      resumeCommand
+    };
+  }
+};

--- a/src/server/llm/cursor-cli.ts
+++ b/src/server/llm/cursor-cli.ts
@@ -1,0 +1,25 @@
+import type { LlmAdapter } from './adapter';
+
+export const cursorCliLlmAdapter: LlmAdapter = {
+  kind: 'cursor_cli',
+  capabilities: {
+    supportsResume: false,
+    supportsTakeover: false
+  },
+
+  async ensureInstalled() {
+    throw new Error('Cursor CLI adapter is not implemented yet.');
+  },
+
+  async restoreAuth() {
+    throw new Error('Cursor CLI adapter is not implemented yet.');
+  },
+
+  async logDiagnostics() {
+    throw new Error('Cursor CLI adapter is not implemented yet.');
+  },
+
+  async run() {
+    throw new Error('Cursor CLI adapter is not implemented yet.');
+  }
+};

--- a/src/server/llm/registry.test.ts
+++ b/src/server/llm/registry.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { getLlmAdapter, getLlmAdapterCapabilities, resolveLlmAdapterKind } from './registry';
+
+describe('LLM adapter registry', () => {
+  it('resolves adapter implementations generically by kind', () => {
+    expect(getLlmAdapter('codex').kind).toBe('codex');
+    expect(getLlmAdapter('cursor_cli').kind).toBe('cursor_cli');
+  });
+
+  it('resolves codex by default when no adapter is configured', () => {
+    const kind = resolveLlmAdapterKind({ uiMeta: undefined });
+    expect(kind).toBe('codex');
+  });
+
+  it('exposes executor capabilities including resume/takeover support', () => {
+    expect(getLlmAdapterCapabilities('codex')).toMatchObject({
+      supportsResume: true,
+      supportsTakeover: true,
+      resumeCommandLabel: 'Codex resume command'
+    });
+
+    expect(getLlmAdapterCapabilities('cursor_cli')).toMatchObject({
+      supportsResume: false,
+      supportsTakeover: false
+    });
+  });
+
+  it('parses codex resume/session data through the adapter', () => {
+    const parsed = getLlmAdapter('codex').extractSessionState?.(
+      '{"thread_id":"thread-123"}\nUse this to continue later: codex resume thread-123'
+    );
+
+    expect(parsed).toEqual({
+      sessionId: 'thread-123',
+      resumeCommand: 'codex resume thread-123'
+    });
+  });
+});

--- a/src/server/llm/registry.ts
+++ b/src/server/llm/registry.ts
@@ -1,0 +1,26 @@
+import type { LlmAdapter as LlmAdapterKind, Task } from '../../ui/domain/types';
+import { DEFAULT_LLM_ADAPTER } from '../../shared/llm';
+import type { LlmAdapter, LlmAdapterCapabilities } from './adapter';
+import { codexLlmAdapter } from './codex';
+import { cursorCliLlmAdapter } from './cursor-cli';
+
+const LLM_ADAPTERS: Record<LlmAdapterKind, LlmAdapter> = {
+  codex: codexLlmAdapter,
+  cursor_cli: cursorCliLlmAdapter
+};
+
+export function resolveLlmAdapterKind(task: Pick<Task, 'uiMeta'>, runAdapter?: LlmAdapterKind): LlmAdapterKind {
+  return runAdapter ?? task.uiMeta?.llmAdapter ?? DEFAULT_LLM_ADAPTER;
+}
+
+export function getLlmAdapter(kind: LlmAdapterKind): LlmAdapter {
+  const adapter = LLM_ADAPTERS[kind];
+  if (!adapter) {
+    throw new Error(`LLM adapter ${kind} is not supported yet.`);
+  }
+  return adapter;
+}
+
+export function getLlmAdapterCapabilities(kind: LlmAdapterKind): LlmAdapterCapabilities {
+  return getLlmAdapter(kind).capabilities;
+}

--- a/src/server/run-orchestrator.ts
+++ b/src/server/run-orchestrator.ts
@@ -18,6 +18,8 @@ import { getRunReviewNumber, getRunReviewUrl } from '../shared/scm';
 import type { ScmAdapter, ScmAdapterCredential } from './scm/adapter';
 import { getScmAdapter } from './scm/registry';
 import { getScmSourceRefFetchSpec } from './scm/source-ref';
+import type { LlmAdapter as LlmExecutorAdapter } from './llm/adapter';
+import { getLlmAdapter, resolveLlmAdapterKind } from './llm/registry';
 
 type WorkflowBinding<T> = {
   create(options?: { id?: string; params?: T; retention?: { successRetention?: string | number; errorRetention?: string | number } }): Promise<{ id: string }>;
@@ -59,6 +61,8 @@ export async function executeRunJob(env: Env, params: RunJobParams, sleepFn: Sle
   }
   const repo = await board.getRepo(params.repoId);
   const scmAdapter = getScmAdapter(repo);
+  const llmAdapterKind = resolveLlmAdapterKind(detail.task, run.llmAdapter);
+  const llmAdapter = getLlmAdapter(llmAdapterKind);
   const codexModel = detail.task.uiMeta?.codexModel ?? 'gpt-5.1-codex-mini';
   const codexReasoningEffort = detail.task.uiMeta?.codexReasoningEffort ?? 'medium';
 
@@ -89,6 +93,10 @@ export async function executeRunJob(env: Env, params: RunJobParams, sleepFn: Sle
 
   const scmCredential = await getScmCredential(env as Stage3Env, board, repo, scmAdapter);
   const sandbox = getSandbox(env.Sandbox, params.runId);
+
+  if (llmAdapter.kind !== 'codex') {
+    throw new NonRetryableError(`LLM adapter ${llmAdapter.kind} is registered but not wired into sandbox execution yet.`);
+  }
 
   await repoBoard.appendRunLogs(params.runId, [buildRunLog(params.runId, `Starting sandbox run for ${repo.slug}.`, 'bootstrap')]);
   await repoBoard.transitionRun(params.runId, { status: 'BOOTSTRAPPING', sandboxId: params.runId, appendTimelineNote: 'Sandbox bootstrapped.' });
@@ -134,6 +142,7 @@ export async function executeRunJob(env: Env, params: RunJobParams, sleepFn: Sle
       repoBoard,
       params.runId,
       'codex',
+      llmAdapter,
       `bash -lc ${shellQuote(`set -euo pipefail
 export HOME="\${HOME:-/root}"
 cd /workspace/repo
@@ -911,6 +920,7 @@ async function execStreamWithLogs(
   repoBoard: DurableObjectStub<RepoBoardDO>,
   runId: string,
   phase: NonNullable<ReturnType<typeof buildRunLog>['phase']>,
+  llmAdapter: LlmExecutorAdapter,
   command: string,
   options?: StreamOptions
 ): Promise<ExecResult> {
@@ -963,10 +973,10 @@ async function execStreamWithLogs(
         case 'stdout': {
           const chunk = event.data ?? '';
           stdoutChunks.push(chunk);
-          const resumeMatch = extractCodexResumeState(chunk, latestThreadId);
-          latestThreadId = resumeMatch.threadId ?? latestThreadId;
-          if (resumeMatch.resumeCommand && resumeMatch.resumeCommand !== latestResumeCommand) {
-            latestResumeCommand = resumeMatch.resumeCommand;
+          const sessionState = extractLlmSessionState(llmAdapter, chunk, latestThreadId);
+          latestThreadId = sessionState.sessionId ?? latestThreadId;
+          if (sessionState.resumeCommand && sessionState.resumeCommand !== latestResumeCommand) {
+            latestResumeCommand = sessionState.resumeCommand;
             const latestRun = await repoBoard.getRun(runId);
             await repoBoard.transitionRun(runId, {
               llmResumeCommand: latestResumeCommand,
@@ -976,7 +986,7 @@ async function execStreamWithLogs(
             if (latestRun.operatorSession) {
               await repoBoard.updateOperatorSession(runId, {
                 ...latestRun.operatorSession,
-                llmAdapter: latestRun.operatorSession.llmAdapter ?? latestRun.llmAdapter ?? 'codex',
+                llmAdapter: latestRun.operatorSession.llmAdapter ?? latestRun.llmAdapter ?? llmAdapter.kind,
                 llmResumeCommand: latestResumeCommand,
                 llmSessionId: latestThreadId,
                 codexResumeCommand: latestResumeCommand,
@@ -989,7 +999,7 @@ async function execStreamWithLogs(
                 await repoBoard.getRun(runId),
                 'system',
                 'codex.resume_available',
-                'Codex resume command is available for this run.',
+                `${llmAdapter.capabilities.resumeCommandLabel ?? 'Resume command'} is available for this run.`,
                 { command: latestResumeCommand }
               )
             ]);
@@ -1089,6 +1099,7 @@ async function runCodexProcessWithLogs(
   repoBoard: DurableObjectStub<RepoBoardDO>,
   runId: string,
   phase: NonNullable<ReturnType<typeof buildRunLog>['phase']>,
+  llmAdapter: LlmExecutorAdapter,
   command: string
 ): Promise<ManagedExecResult> {
   const commandId = buildRunCommandId(runId, phase);
@@ -1155,10 +1166,10 @@ async function runCodexProcessWithLogs(
         case 'stdout': {
           const chunk = typeof event.data === 'string' ? event.data : '';
           stdoutChunks.push(chunk);
-          const resumeMatch = extractCodexResumeState(chunk, latestThreadId);
-          latestThreadId = resumeMatch.threadId ?? latestThreadId;
-          if (resumeMatch.resumeCommand && resumeMatch.resumeCommand !== latestResumeCommand) {
-            latestResumeCommand = resumeMatch.resumeCommand;
+          const sessionState = extractLlmSessionState(llmAdapter, chunk, latestThreadId);
+          latestThreadId = sessionState.sessionId ?? latestThreadId;
+          if (sessionState.resumeCommand && sessionState.resumeCommand !== latestResumeCommand) {
+            latestResumeCommand = sessionState.resumeCommand;
             const latestRun = await repoBoard.getRun(runId);
             await repoBoard.transitionRun(runId, {
               llmResumeCommand: latestResumeCommand,
@@ -1168,7 +1179,7 @@ async function runCodexProcessWithLogs(
             if (latestRun.operatorSession) {
               await repoBoard.updateOperatorSession(runId, {
                 ...latestRun.operatorSession,
-                llmAdapter: latestRun.operatorSession.llmAdapter ?? latestRun.llmAdapter ?? 'codex',
+                llmAdapter: latestRun.operatorSession.llmAdapter ?? latestRun.llmAdapter ?? llmAdapter.kind,
                 llmResumeCommand: latestResumeCommand,
                 llmSessionId: latestThreadId,
                 codexResumeCommand: latestResumeCommand,
@@ -1181,7 +1192,7 @@ async function runCodexProcessWithLogs(
                 await repoBoard.getRun(runId),
                 'system',
                 'codex.resume_available',
-                'Codex resume command is available for this run.',
+                `${llmAdapter.capabilities.resumeCommandLabel ?? 'Resume command'} is available for this run.`,
                 { command: latestResumeCommand }
               )
             ]);
@@ -1424,17 +1435,12 @@ function summarizeOutput(output?: string) {
   return compact.length > 240 ? `${compact.slice(0, 237)}...` : compact;
 }
 
-function extractCodexResumeState(chunk: string, fallbackThreadId?: string) {
-  const threadMatch = chunk.match(/"thread_id":"([^"]+)"/);
-  const threadId = threadMatch?.[1] ?? fallbackThreadId;
-  const resumeMatch = chunk.match(/codex resume ([a-z0-9-]+)/i);
-  const resumeCommand = resumeMatch?.[1]
-    ? `codex resume ${resumeMatch[1]}`
-    : threadId
-      ? undefined
-      : undefined;
-
-  return { threadId, resumeCommand };
+function extractLlmSessionState(llmAdapter: LlmExecutorAdapter, chunk: string, fallbackSessionId?: string) {
+  if (!llmAdapter.capabilities.supportsResume || !llmAdapter.extractSessionState) {
+    return { sessionId: fallbackSessionId, resumeCommand: undefined };
+  }
+  const state = llmAdapter.extractSessionState(chunk, fallbackSessionId);
+  return { sessionId: state.sessionId ?? fallbackSessionId, resumeCommand: state.resumeCommand };
 }
 
 function shellQuote(value: string) {


### PR DESCRIPTION
Task: S35-L2 LLM adapter registry and capability model

Add the generic LLM adapter seam and capability model that orchestration can depend on before moving Codex-specific logic out of run-orchestrator.


Acceptance criteria:
- A generic LLM adapter interface exists for install/auth/diagnostics/run behavior.
- The registry can resolve adapter implementations generically.
- Resume/takeover capability is represented as executor capability rather than Codex-only assumption.
- The change is additive and does not yet require Cursor CLI support.

Run ID: run_repo_abuiles_minions_mm9b9f1uq4rg