### PR TITLE
S35-L4 Provider-neutral run/session persistence for executor metadata

### DIFF
--- a/src/server/durable/repo-board.ts
+++ b/src/server/durable/repo-board.ts
@@ -583,6 +583,7 @@ export class RepoBoardDO extends DurableObject<Env> {
       ...run,
       operatorSession: normalizedSession,
       llmAdapter: normalizedSession?.llmAdapter ?? run.llmAdapter,
+      llmSupportsResume: normalizedSession?.llmSupportsResume ?? run.llmSupportsResume,
       llmResumeCommand: normalizedSession?.llmResumeCommand ?? run.llmResumeCommand,
       llmSessionId: normalizedSession?.llmSessionId ?? run.llmSessionId,
       latestCodexResumeCommand: normalizedSession?.codexResumeCommand ?? run.latestCodexResumeCommand
@@ -613,6 +614,7 @@ export class RepoBoardDO extends DurableObject<Env> {
         reason: 'sandbox_missing',
         cols: 120,
         rows: 32,
+        llmSupportsResume: run.llmSupportsResume,
         llmResumeCommand: run.llmResumeCommand ?? run.latestCodexResumeCommand,
         codexResumeCommand: run.latestCodexResumeCommand
       };
@@ -631,6 +633,7 @@ export class RepoBoardDO extends DurableObject<Env> {
         cols: 120,
         rows: 32,
         session: run.operatorSession,
+        llmSupportsResume: run.llmSupportsResume,
         llmResumeCommand: run.llmResumeCommand ?? run.latestCodexResumeCommand,
         codexResumeCommand: run.latestCodexResumeCommand
       };
@@ -648,6 +651,7 @@ export class RepoBoardDO extends DurableObject<Env> {
       cols: 120,
       rows: 32,
       session: run.operatorSession,
+      llmSupportsResume: run.llmSupportsResume,
       llmResumeCommand: run.llmResumeCommand ?? run.latestCodexResumeCommand,
       codexResumeCommand: run.latestCodexResumeCommand
     };
@@ -673,6 +677,7 @@ export class RepoBoardDO extends DurableObject<Env> {
       connectionState: 'open' as const,
       takeoverState: 'observing' as const,
       llmAdapter: run.llmAdapter ?? 'codex',
+      llmSupportsResume: run.llmSupportsResume,
       llmSessionId: run.llmSessionId,
       llmResumeCommand: run.llmResumeCommand ?? run.latestCodexResumeCommand,
       codexThreadId: undefined,
@@ -682,7 +687,7 @@ export class RepoBoardDO extends DurableObject<Env> {
       ...session,
       actorId: actor.actorId,
       actorLabel: actor.actorLabel,
-      takeoverState: run.latestCodexResumeCommand ? 'resumable' : 'operator_control',
+      takeoverState: run.llmSupportsResume && run.llmResumeCommand ? 'resumable' : 'operator_control',
       connectionState: session.connectionState === 'failed' ? 'failed' : 'open'
     })!;
 
@@ -1036,7 +1041,9 @@ function cloneRepoBoardState(state: RepoBoardState): RepoBoardState {
       pendingEvents: run.pendingEvents.map((event) => ({ ...event })),
       executionSummary: run.executionSummary ? { ...run.executionSummary } : undefined,
       artifacts: run.artifacts ? [...run.artifacts] : undefined,
-      latestCodexResumeCommand: run.latestCodexResumeCommand ?? run.llmResumeCommand,
+      latestCodexResumeCommand: (run.llmAdapter ?? run.operatorSession?.llmAdapter ?? 'codex') === 'codex'
+        ? (run.latestCodexResumeCommand ?? run.llmResumeCommand)
+        : run.latestCodexResumeCommand,
       currentCommandId: run.currentCommandId,
       artifactManifest: run.artifactManifest
         ? {

--- a/src/server/router.ts
+++ b/src/server/router.ts
@@ -249,6 +249,7 @@ export async function handleApiRequest(request: Request, env: Env, ctx: Executio
         connectionState: 'connecting' as const,
         takeoverState: run.operatorSession?.takeoverState ?? 'observing',
         llmAdapter: run.operatorSession?.llmAdapter ?? run.llmAdapter ?? 'codex',
+        llmSupportsResume: run.operatorSession?.llmSupportsResume ?? run.llmSupportsResume,
         llmSessionId: run.operatorSession?.llmSessionId ?? run.operatorSession?.codexThreadId ?? run.llmSessionId,
         llmResumeCommand: run.operatorSession?.llmResumeCommand ?? run.operatorSession?.codexResumeCommand ?? run.llmResumeCommand ?? run.latestCodexResumeCommand,
         codexThreadId: run.operatorSession?.codexThreadId,

--- a/src/server/run-orchestrator.ts
+++ b/src/server/run-orchestrator.ts
@@ -99,7 +99,13 @@ export async function executeRunJob(env: Env, params: RunJobParams, sleepFn: Sle
   }
 
   await repoBoard.appendRunLogs(params.runId, [buildRunLog(params.runId, `Starting sandbox run for ${repo.slug}.`, 'bootstrap')]);
-  await repoBoard.transitionRun(params.runId, { status: 'BOOTSTRAPPING', sandboxId: params.runId, appendTimelineNote: 'Sandbox bootstrapped.' });
+  await repoBoard.transitionRun(params.runId, {
+    status: 'BOOTSTRAPPING',
+    sandboxId: params.runId,
+    llmAdapter: llmAdapter.kind,
+    llmSupportsResume: llmAdapter.capabilities.supportsResume,
+    appendTimelineNote: 'Sandbox bootstrapped.'
+  });
 
   try {
     await emitCommandLifecycle(repoBoard, params.runId, 'bootstrap', 'mkdir -p /workspace/repo', () => sandbox.exec('mkdir -p /workspace/repo'));
@@ -979,6 +985,8 @@ async function execStreamWithLogs(
             latestResumeCommand = sessionState.resumeCommand;
             const latestRun = await repoBoard.getRun(runId);
             await repoBoard.transitionRun(runId, {
+              llmAdapter: llmAdapter.kind,
+              llmSupportsResume: llmAdapter.capabilities.supportsResume,
               llmResumeCommand: latestResumeCommand,
               llmSessionId: latestThreadId,
               latestCodexResumeCommand: latestResumeCommand
@@ -987,6 +995,7 @@ async function execStreamWithLogs(
               await repoBoard.updateOperatorSession(runId, {
                 ...latestRun.operatorSession,
                 llmAdapter: latestRun.operatorSession.llmAdapter ?? latestRun.llmAdapter ?? llmAdapter.kind,
+                llmSupportsResume: latestRun.operatorSession.llmSupportsResume ?? latestRun.llmSupportsResume ?? llmAdapter.capabilities.supportsResume,
                 llmResumeCommand: latestResumeCommand,
                 llmSessionId: latestThreadId,
                 codexResumeCommand: latestResumeCommand,
@@ -1172,6 +1181,8 @@ async function runCodexProcessWithLogs(
             latestResumeCommand = sessionState.resumeCommand;
             const latestRun = await repoBoard.getRun(runId);
             await repoBoard.transitionRun(runId, {
+              llmAdapter: llmAdapter.kind,
+              llmSupportsResume: llmAdapter.capabilities.supportsResume,
               llmResumeCommand: latestResumeCommand,
               llmSessionId: latestThreadId,
               latestCodexResumeCommand: latestResumeCommand
@@ -1180,6 +1191,7 @@ async function runCodexProcessWithLogs(
               await repoBoard.updateOperatorSession(runId, {
                 ...latestRun.operatorSession,
                 llmAdapter: latestRun.operatorSession.llmAdapter ?? latestRun.llmAdapter ?? llmAdapter.kind,
+                llmSupportsResume: latestRun.operatorSession.llmSupportsResume ?? latestRun.llmSupportsResume ?? llmAdapter.capabilities.supportsResume,
                 llmResumeCommand: latestResumeCommand,
                 llmSessionId: latestThreadId,
                 codexResumeCommand: latestResumeCommand,

--- a/src/server/shared/llm.test.ts
+++ b/src/server/shared/llm.test.ts
@@ -48,14 +48,36 @@ describe('llm compatibility normalization', () => {
 
     expect(run).toMatchObject({
       llmAdapter: 'codex',
+      llmSupportsResume: true,
       llmResumeCommand: 'codex resume thread_1',
       llmSessionId: 'thread_1',
       latestCodexResumeCommand: 'codex resume thread_1'
     });
     expect(run.operatorSession).toMatchObject({
       llmAdapter: 'codex',
+      llmSupportsResume: true,
       llmSessionId: 'thread_1',
       llmResumeCommand: 'codex resume thread_1'
     });
+  });
+
+  it('keeps non-resumable adapters truthful without fabricating resume commands', () => {
+    const run = normalizeRunLlmState({
+      runId: 'run_2',
+      taskId: 'task_2',
+      repoId: 'repo_2',
+      status: 'RUNNING_CODEX',
+      branchName: 'agent/task_2/run_2',
+      llmAdapter: 'cursor_cli',
+      errors: [],
+      startedAt: '2026-03-02T00:00:00.000Z',
+      timeline: [],
+      simulationProfile: 'happy_path',
+      pendingEvents: []
+    });
+
+    expect(run.llmSupportsResume).toBe(false);
+    expect(run.llmResumeCommand).toBeUndefined();
+    expect(run.latestCodexResumeCommand).toBeUndefined();
   });
 });

--- a/src/server/shared/real-run.ts
+++ b/src/server/shared/real-run.ts
@@ -1,5 +1,5 @@
 import type { ArtifactManifest, AgentRun, Repo, RunError, RunLogEntry, RunStatus, Task } from '../../ui/domain/types';
-import { normalizeRunLlmState, normalizeTaskUiMeta } from '../../shared/llm';
+import { DEFAULT_SUPPORTS_RESUME_BY_ADAPTER, normalizeRunLlmState, normalizeTaskUiMeta } from '../../shared/llm';
 import { normalizeRunReviewMetadata } from '../../shared/scm';
 
 export type RunJobMode = 'full_run' | 'evidence_only' | 'preview_only';
@@ -36,6 +36,7 @@ export type RunTransitionPatch = {
   codexProcessId?: string;
   currentCommandId?: string;
   llmAdapter?: AgentRun['llmAdapter'];
+  llmSupportsResume?: AgentRun['llmSupportsResume'];
   llmModel?: AgentRun['llmModel'];
   llmReasoningEffort?: AgentRun['llmReasoningEffort'];
   llmResumeCommand?: AgentRun['llmResumeCommand'];
@@ -69,6 +70,7 @@ type CreateRealRunOptions = {
 export function createRealRun(task: Task, runId: string, now = new Date(), options?: CreateRealRunOptions): AgentRun {
   const nowIso = now.toISOString();
   const taskUiMeta = normalizeTaskUiMeta(task.uiMeta);
+  const llmAdapter = taskUiMeta?.llmAdapter ?? 'codex';
   return normalizeRunLlmState(normalizeRunReviewMetadata({
     runId,
     taskId: task.taskId,
@@ -97,7 +99,8 @@ export function createRealRun(task: Task, runId: string, now = new Date(), optio
     evidenceStatus: 'NOT_STARTED',
     executorType: 'sandbox',
     orchestrationMode: 'workflow',
-    llmAdapter: taskUiMeta?.llmAdapter ?? 'codex',
+    llmAdapter,
+    llmSupportsResume: DEFAULT_SUPPORTS_RESUME_BY_ADAPTER[llmAdapter],
     llmModel: taskUiMeta?.llmModel,
     llmReasoningEffort: taskUiMeta?.llmReasoningEffort,
     executionSummary: {}

--- a/src/shared/llm.ts
+++ b/src/shared/llm.ts
@@ -3,6 +3,10 @@ import type { AgentRun, CodexModel, CodexReasoningEffort, LlmAdapter, LlmReasoni
 export const DEFAULT_LLM_ADAPTER: LlmAdapter = 'codex';
 export const DEFAULT_CODEX_MODEL: CodexModel = 'gpt-5.1-codex-mini';
 export const DEFAULT_REASONING_EFFORT: CodexReasoningEffort = 'medium';
+export const DEFAULT_SUPPORTS_RESUME_BY_ADAPTER: Record<LlmAdapter, boolean> = {
+  codex: true,
+  cursor_cli: false
+};
 
 export function normalizeTaskUiMeta(uiMeta?: TaskUiMeta): TaskUiMeta | undefined {
   if (!uiMeta) {
@@ -33,12 +37,14 @@ export function normalizeOperatorSession(session?: OperatorSession): OperatorSes
   }
 
   const llmAdapter = session.llmAdapter ?? DEFAULT_LLM_ADAPTER;
+  const llmSupportsResume = session.llmSupportsResume ?? DEFAULT_SUPPORTS_RESUME_BY_ADAPTER[llmAdapter];
   const llmSessionId = session.llmSessionId ?? session.codexThreadId;
   const llmResumeCommand = session.llmResumeCommand ?? session.codexResumeCommand;
 
   return {
     ...session,
     llmAdapter,
+    llmSupportsResume,
     llmSessionId,
     llmResumeCommand,
     codexThreadId: llmAdapter === 'codex' ? (session.codexThreadId ?? llmSessionId) : session.codexThreadId,
@@ -49,6 +55,9 @@ export function normalizeOperatorSession(session?: OperatorSession): OperatorSes
 export function normalizeRunLlmState(run: AgentRun): AgentRun {
   const operatorSession = normalizeOperatorSession(run.operatorSession);
   const llmAdapter = run.llmAdapter ?? operatorSession?.llmAdapter ?? DEFAULT_LLM_ADAPTER;
+  const llmSupportsResume = run.llmSupportsResume
+    ?? operatorSession?.llmSupportsResume
+    ?? DEFAULT_SUPPORTS_RESUME_BY_ADAPTER[llmAdapter];
   const llmResumeCommand = run.llmResumeCommand
     ?? run.latestCodexResumeCommand
     ?? operatorSession?.llmResumeCommand
@@ -59,6 +68,7 @@ export function normalizeRunLlmState(run: AgentRun): AgentRun {
     ...run,
     operatorSession,
     llmAdapter,
+    llmSupportsResume,
     llmResumeCommand,
     llmSessionId,
     latestCodexResumeCommand: llmAdapter === 'codex' ? (run.latestCodexResumeCommand ?? llmResumeCommand) : run.latestCodexResumeCommand,

--- a/src/ui/domain/types.ts
+++ b/src/ui/domain/types.ts
@@ -186,6 +186,7 @@ export type OperatorSession = {
   connectionState: 'connecting' | 'open' | 'closed' | 'failed';
   takeoverState: 'codex_control' | 'observing' | 'operator_control' | 'resumable';
   llmAdapter?: LlmAdapter;
+  llmSupportsResume?: boolean;
   llmSessionId?: string;
   llmResumeCommand?: string;
   codexThreadId?: string;
@@ -206,6 +207,7 @@ export type TerminalBootstrap = {
   cols: number;
   rows: number;
   session?: OperatorSession;
+  llmSupportsResume?: boolean;
   llmResumeCommand?: string;
   codexResumeCommand?: string;
 };
@@ -283,6 +285,7 @@ export type AgentRun = {
   codexProcessId?: string;
   currentCommandId?: string;
   llmAdapter?: LlmAdapter;
+  llmSupportsResume?: boolean;
   llmModel?: string;
   llmReasoningEffort?: LlmReasoningEffort;
   llmResumeCommand?: string;

--- a/src/ui/mock/local-agent-board-api.ts
+++ b/src/ui/mock/local-agent-board-api.ts
@@ -305,7 +305,7 @@ export class LocalAgentBoardApi implements AgentBoardApi {
           operatorSession: run.operatorSession
             ? normalizeOperatorSession({
                 ...run.operatorSession,
-                takeoverState: run.latestCodexResumeCommand ? 'resumable' : 'operator_control',
+                takeoverState: run.llmSupportsResume && run.llmResumeCommand ? 'resumable' : 'operator_control',
                 connectionState: 'open'
               })
             : normalizeOperatorSession({
@@ -317,8 +317,9 @@ export class LocalAgentBoardApi implements AgentBoardApi {
                 actorId: 'same-session',
                 actorLabel: 'Operator',
                 connectionState: 'open',
-                takeoverState: run.latestCodexResumeCommand ? 'resumable' : 'operator_control',
+                takeoverState: run.llmSupportsResume && run.llmResumeCommand ? 'resumable' : 'operator_control',
                 llmAdapter: run.llmAdapter ?? 'codex',
+                llmSupportsResume: run.llmSupportsResume,
                 llmSessionId: run.llmSessionId,
                 llmResumeCommand: run.llmResumeCommand ?? run.latestCodexResumeCommand,
                 codexResumeCommand: run.latestCodexResumeCommand
@@ -363,6 +364,7 @@ export class LocalAgentBoardApi implements AgentBoardApi {
         cols: 120,
         rows: 32,
         session: run.operatorSession,
+        llmSupportsResume: run.llmSupportsResume,
         llmResumeCommand: run.llmResumeCommand ?? run.latestCodexResumeCommand,
         codexResumeCommand: run.latestCodexResumeCommand
       };
@@ -380,6 +382,7 @@ export class LocalAgentBoardApi implements AgentBoardApi {
       cols: 120,
       rows: 32,
       session: run.operatorSession,
+      llmSupportsResume: run.llmSupportsResume,
       llmResumeCommand: run.llmResumeCommand ?? run.latestCodexResumeCommand,
       codexResumeCommand: run.latestCodexResumeCommand
     };

--- a/src/ui/mock/run-simulator.ts
+++ b/src/ui/mock/run-simulator.ts
@@ -3,7 +3,7 @@ import { buildLogsForStatus } from './log-builder';
 import { buildSimulationPlan } from './run-templates';
 import { getBaselineUrl } from '../domain/selectors';
 import { LocalBoardStore } from '../store/local-board-store';
-import { normalizeRunLlmState, normalizeTaskUiMeta } from '../../shared/llm';
+import { DEFAULT_SUPPORTS_RESUME_BY_ADAPTER, normalizeRunLlmState, normalizeTaskUiMeta } from '../../shared/llm';
 
 const terminalStatuses: RunStatus[] = ['DONE', 'FAILED'];
 
@@ -52,6 +52,7 @@ export class RunSimulator {
     const startedAt = new Date();
     const runId = `run_${task.taskId}_${startedAt.getTime()}`;
     const taskUiMeta = normalizeTaskUiMeta(task.uiMeta);
+    const llmAdapter = taskUiMeta?.llmAdapter ?? 'codex';
     const profile = taskUiMeta?.simulationProfile ?? 'happy_path';
     const run: AgentRun = normalizeRunLlmState({
       runId,
@@ -67,7 +68,8 @@ export class RunSimulator {
       errors: [],
       startedAt: startedAt.toISOString(),
       timeline: [],
-      llmAdapter: taskUiMeta?.llmAdapter ?? 'codex',
+      llmAdapter,
+      llmSupportsResume: DEFAULT_SUPPORTS_RESUME_BY_ADAPTER[llmAdapter],
       llmModel: taskUiMeta?.llmModel,
       llmReasoningEffort: taskUiMeta?.llmReasoningEffort,
       simulationProfile: profile,


### PR DESCRIPTION
Task: S35-L4 Provider-neutral run/session persistence for executor metadata

Refactor durable-object and run/session persistence so executor metadata is no longer Codex-specific, while keeping compatibility aliases intact.


Acceptance criteria:
- Run/session persistence can store generic executor metadata rather than only Codex fields.
- Compatibility aliases preserve current Codex UI and API behavior.
- The system can represent executors that do not support resume without faking a resume command.
- Durable-object state evolution remains backward compatible.

Run ID: run_repo_abuiles_minions_mm9brnxsdacw