### PR TITLE
S35-L5 UI and API surfaces for generic LLM executor metadata

### DIFF
--- a/src/server/durable/board-index.ts
+++ b/src/server/durable/board-index.ts
@@ -276,7 +276,10 @@ function buildRepoRecord(input: CreateRepoInput | Repo): Repo {
     previewProvider: 'previewProvider' in input ? input.previewProvider : 'cloudflare',
     previewCheckName: input.previewCheckName,
     previewUrlPattern: 'previewUrlPattern' in input ? input.previewUrlPattern : undefined,
-    codexAuthBundleR2Key: input.codexAuthBundleR2Key,
+    llmAdapter: input.llmAdapter,
+    llmProfileId: input.llmProfileId,
+    llmAuthBundleR2Key: input.llmAuthBundleR2Key ?? input.codexAuthBundleR2Key,
+    codexAuthBundleR2Key: input.codexAuthBundleR2Key ?? input.llmAuthBundleR2Key,
     createdAt: 'createdAt' in input ? input.createdAt : '',
     updatedAt: 'updatedAt' in input ? input.updatedAt : ''
   });

--- a/src/server/http/validation.test.ts
+++ b/src/server/http/validation.test.ts
@@ -221,6 +221,8 @@ describe('repo validation', () => {
       scmProvider: 'gitlab',
       scmBaseUrl: 'https://gitlab.example.com',
       projectPath: 'group/platform/repo',
+      llmAdapter: 'cursor_cli',
+      llmProfileId: 'cursor-default',
       baselineUrl: 'https://repo.example.com'
     });
 
@@ -228,7 +230,9 @@ describe('repo validation', () => {
       scmProvider: 'gitlab',
       scmBaseUrl: 'https://gitlab.example.com',
       projectPath: 'group/platform/repo',
-      slug: 'group/platform/repo'
+      slug: 'group/platform/repo',
+      llmAdapter: 'cursor_cli',
+      llmProfileId: 'cursor-default'
     });
   });
 
@@ -258,6 +262,17 @@ describe('repo validation', () => {
     })).toMatchObject({
       slug: 'acme/renamed',
       projectPath: 'acme/renamed'
+    });
+  });
+
+  it('accepts generic llm auth bundle key and mirrors codex compatibility alias', () => {
+    expect(parseCreateRepoInput({
+      slug: 'acme/renamed',
+      baselineUrl: 'https://example.com',
+      llmAuthBundleR2Key: 'auth/llm.tgz'
+    })).toMatchObject({
+      llmAuthBundleR2Key: 'auth/llm.tgz',
+      codexAuthBundleR2Key: 'auth/llm.tgz'
     });
   });
 });

--- a/src/server/http/validation.ts
+++ b/src/server/http/validation.ts
@@ -353,6 +353,10 @@ export function parseCreateRepoInput(body: unknown): CreateRepoInput {
     scmProvider: readEnumValue(body.scmProvider, 'scmProvider', SCM_PROVIDERS, false),
     scmBaseUrl: readTrimmedString(body.scmBaseUrl, 'scmBaseUrl', false),
     projectPath: projectPath ?? slug,
+    llmAdapter: readEnumValue(body.llmAdapter, 'llmAdapter', LLM_ADAPTERS, false),
+    llmProfileId: readTrimmedString(body.llmProfileId, 'llmProfileId', false),
+    llmAuthBundleR2Key: readTrimmedString(body.llmAuthBundleR2Key, 'llmAuthBundleR2Key', false)
+      ?? readTrimmedString(body.codexAuthBundleR2Key, 'codexAuthBundleR2Key', false),
     defaultBranch: readTrimmedString(body.defaultBranch, 'defaultBranch', false),
     baselineUrl: readTrimmedString(body.baselineUrl, 'baselineUrl')!,
     enabled: readBoolean(body.enabled, 'enabled', false),
@@ -362,7 +366,9 @@ export function parseCreateRepoInput(body: unknown): CreateRepoInput {
     previewConfig: readPreviewConfig(body.previewConfig, 'previewConfig', false),
     previewProvider: readEnumValue(body.previewProvider, 'previewProvider', new Set(['cloudflare'] as const), false),
     previewCheckName: readTrimmedString(body.previewCheckName, 'previewCheckName', false),
-    codexAuthBundleR2Key: readTrimmedString(body.codexAuthBundleR2Key, 'codexAuthBundleR2Key', false)
+    codexAuthBundleR2Key:
+      readTrimmedString(body.codexAuthBundleR2Key, 'codexAuthBundleR2Key', false)
+      ?? readTrimmedString(body.llmAuthBundleR2Key, 'llmAuthBundleR2Key', false)
   });
 }
 
@@ -376,6 +382,9 @@ export function parseUpdateRepoInput(body: unknown): UpdateRepoInput {
   if (hasOwn(body, 'scmProvider')) patch.scmProvider = readEnumValue(body.scmProvider, 'scmProvider', SCM_PROVIDERS, false);
   if (hasOwn(body, 'scmBaseUrl')) patch.scmBaseUrl = readTrimmedString(body.scmBaseUrl, 'scmBaseUrl', false);
   if (hasOwn(body, 'projectPath')) patch.projectPath = readTrimmedString(body.projectPath, 'projectPath', false);
+  if (hasOwn(body, 'llmAdapter')) patch.llmAdapter = readEnumValue(body.llmAdapter, 'llmAdapter', LLM_ADAPTERS, false);
+  if (hasOwn(body, 'llmProfileId')) patch.llmProfileId = readTrimmedString(body.llmProfileId, 'llmProfileId', false);
+  if (hasOwn(body, 'llmAuthBundleR2Key')) patch.llmAuthBundleR2Key = readTrimmedString(body.llmAuthBundleR2Key, 'llmAuthBundleR2Key', false);
   if (patch.slug && patch.projectPath && patch.slug !== patch.projectPath) {
     throw badRequest('Invalid repo patch payload: slug and projectPath must match when both are provided.');
   }
@@ -405,7 +414,8 @@ export function parseUpdateRepoInput(body: unknown): UpdateRepoInput {
     if (hasOwn(body, 'previewConfig') || hasOwn(body, 'previewCheckName')) patch.previewConfig = normalizedPreview.previewConfig;
     if (hasOwn(body, 'previewConfig') || hasOwn(body, 'previewCheckName')) patch.previewCheckName = normalizedPreview.previewCheckName;
   }
-
+  if (hasOwn(body, 'llmAuthBundleR2Key') && !hasOwn(body, 'codexAuthBundleR2Key')) patch.codexAuthBundleR2Key = patch.llmAuthBundleR2Key;
+  if (hasOwn(body, 'codexAuthBundleR2Key') && !hasOwn(body, 'llmAuthBundleR2Key')) patch.llmAuthBundleR2Key = patch.codexAuthBundleR2Key;
   return patch;
 }
 

--- a/src/server/llm/codex.ts
+++ b/src/server/llm/codex.ts
@@ -32,19 +32,20 @@ export const codexLlmAdapter: LlmAdapter = {
   async restoreAuth(context) {
     const env = context.env as Env & { RUN_ARTIFACTS?: R2Bucket };
     const { sandbox, repoBoard, runId, repo } = context;
+    const authBundleKey = repo.codexAuthBundleR2Key ?? repo.llmAuthBundleR2Key;
 
-    if (!repo.codexAuthBundleR2Key || !env.RUN_ARTIFACTS) {
-      const reason = !repo.codexAuthBundleR2Key
+    if (!authBundleKey || !env.RUN_ARTIFACTS) {
+      const reason = !authBundleKey
         ? 'No Codex auth bundle configured for this repo.'
         : 'RUN_ARTIFACTS binding is not configured.';
       await repoBoard.appendRunLogs(runId, [buildRunLog(runId, reason, 'bootstrap', 'error')]);
       throw await createNonRetryableError(reason);
     }
 
-    const object = await env.RUN_ARTIFACTS.get(repo.codexAuthBundleR2Key);
+    const object = await env.RUN_ARTIFACTS.get(authBundleKey);
     if (!object) {
-      await repoBoard.appendRunLogs(runId, [buildRunLog(runId, `Codex auth bundle ${repo.codexAuthBundleR2Key} was not found in R2.`, 'bootstrap', 'error')]);
-      throw await createNonRetryableError(`Codex auth bundle ${repo.codexAuthBundleR2Key} was not found in R2.`);
+      await repoBoard.appendRunLogs(runId, [buildRunLog(runId, `Codex auth bundle ${authBundleKey} was not found in R2.`, 'bootstrap', 'error')]);
+      throw await createNonRetryableError(`Codex auth bundle ${authBundleKey} was not found in R2.`);
     }
 
     const archiveBase64 = bytesToBase64(await object.arrayBuffer());

--- a/src/ui/App.test.tsx
+++ b/src/ui/App.test.tsx
@@ -187,7 +187,7 @@ describe('App', () => {
     await user.click(screen.getByRole('button', { name: 'Open terminal' }));
 
     expect(await screen.findByRole('heading', { name: /Live terminal/i })).toBeInTheDocument();
-    expect(screen.getByText('Live Codex stream')).toBeInTheDocument();
+    expect(screen.getByText('Live executor stream')).toBeInTheDocument();
     expect(screen.getAllByRole('button', { name: 'Take over' }).length).toBeGreaterThan(1);
     expect(screen.getByRole('button', { name: 'Disconnect' })).toBeInTheDocument();
   });

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -48,8 +48,8 @@ export default function App({ api: providedApi }: { api?: AgentBoardApi }) {
     : [];
   const terminalRun = terminalModalRunId ? snapshot.runs.find((run) => run.runId === terminalModalRunId) : undefined;
   const terminalLogs = terminalModalRunId ? snapshot.logs.filter((entry) => entry.runId === terminalModalRunId) : [];
-  const terminalCodexLogs = terminalLogs.filter((entry) => entry.phase === 'codex');
-  const terminalStreamLogs = terminalCodexLogs.length ? terminalCodexLogs : terminalLogs;
+  const terminalExecutorLogs = terminalLogs.filter((entry) => entry.phase === 'codex');
+  const terminalStreamLogs = terminalExecutorLogs.length ? terminalExecutorLogs : terminalLogs;
 
   useEffect(() => {
     const runId = detail?.latestRun?.runId;
@@ -182,7 +182,7 @@ export default function App({ api: providedApi }: { api?: AgentBoardApi }) {
   }
 
   async function copyTerminalResumeCommand() {
-    const command = terminalRun?.latestCodexResumeCommand;
+    const command = terminalRun?.llmResumeCommand ?? terminalRun?.latestCodexResumeCommand;
     if (!command) {
       return;
     }
@@ -190,10 +190,10 @@ export default function App({ api: providedApi }: { api?: AgentBoardApi }) {
     try {
       await navigator.clipboard.writeText(command);
       setTerminalResumeCopied(true);
-      setNotice('Copied the latest Codex resume command.');
+      setNotice('Copied the latest resume command.');
       window.setTimeout(() => setTerminalResumeCopied(false), 2_000);
     } catch (error) {
-      setNotice(error instanceof Error ? error.message : 'Failed to copy the Codex resume command.');
+      setNotice(error instanceof Error ? error.message : 'Failed to copy the resume command.');
     }
   }
 
@@ -286,6 +286,9 @@ export default function App({ api: providedApi }: { api?: AgentBoardApi }) {
               defaultBranch: repoToEdit.defaultBranch,
               baselineUrl: repoToEdit.baselineUrl,
               previewCheckName: repoToEdit.previewCheckName,
+              llmAdapter: repoToEdit.llmAdapter,
+              llmProfileId: repoToEdit.llmProfileId,
+              llmAuthBundleR2Key: repoToEdit.llmAuthBundleR2Key,
               codexAuthBundleR2Key: repoToEdit.codexAuthBundleR2Key
             }}
             submitLabel="Save repo"
@@ -333,6 +336,9 @@ export default function App({ api: providedApi }: { api?: AgentBoardApi }) {
               context: taskToEdit.context,
               status: taskToEdit.status,
               baselineUrlOverride: taskToEdit.baselineUrlOverride,
+              llmAdapter: taskToEdit.uiMeta?.llmAdapter,
+              llmModel: taskToEdit.uiMeta?.llmModel,
+              llmReasoningEffort: taskToEdit.uiMeta?.llmReasoningEffort,
               codexModel: taskToEdit.uiMeta?.codexModel,
               codexReasoningEffort: taskToEdit.uiMeta?.codexReasoningEffort
             }}
@@ -400,7 +406,7 @@ export default function App({ api: providedApi }: { api?: AgentBoardApi }) {
                     {terminalRun?.operatorSession?.takeoverState ?? 'observing'}
                   </div>
                   <div className="mt-1 text-xs text-slate-500">
-                    Separate operator shell. Codex keeps running until you explicitly take over.
+                    Separate operator shell. The executor keeps running until you explicitly take over.
                   </div>
                 </div>
                 <div className="flex flex-wrap items-center gap-2">
@@ -430,12 +436,12 @@ export default function App({ api: providedApi }: { api?: AgentBoardApi }) {
             <section className="space-y-3 rounded-xl border border-slate-800 bg-slate-950/70 p-4">
               <div className="flex items-center justify-between gap-3">
                 <div>
-                  <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500">Live Codex stream</div>
+                  <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500">Live executor stream</div>
                   <div className="mt-1 text-sm text-slate-300">
-                    {terminalCodexLogs.length ? 'Streaming Codex output.' : 'Showing live run logs while Codex output is unavailable.'}
+                    {terminalExecutorLogs.length ? 'Streaming executor output.' : 'Showing live run logs while dedicated executor output is unavailable.'}
                   </div>
                 </div>
-                {terminalRun?.latestCodexResumeCommand ? (
+                {(terminalRun?.llmResumeCommand ?? terminalRun?.latestCodexResumeCommand) ? (
                   <button
                     type="button"
                     onClick={() => void copyTerminalResumeCommand()}
@@ -445,10 +451,10 @@ export default function App({ api: providedApi }: { api?: AgentBoardApi }) {
                   </button>
                 ) : null}
               </div>
-              {terminalRun?.latestCodexResumeCommand ? (
+              {(terminalRun?.llmResumeCommand ?? terminalRun?.latestCodexResumeCommand) ? (
                 <div className="rounded-xl border border-slate-800 bg-slate-900/80 px-3 py-2">
                   <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-500">Resume command</div>
-                  <code className="mt-2 block break-all text-xs text-cyan-200">{terminalRun.latestCodexResumeCommand}</code>
+                  <code className="mt-2 block break-all text-xs text-cyan-200">{terminalRun?.llmResumeCommand ?? terminalRun?.latestCodexResumeCommand}</code>
                 </div>
               ) : null}
               <div className="max-h-[28rem] space-y-2 overflow-auto rounded-xl border border-slate-900 bg-[#040812] p-3 font-mono text-xs">

--- a/src/ui/components/ControlSurface.tsx
+++ b/src/ui/components/ControlSurface.tsx
@@ -151,7 +151,7 @@ export function SummaryRow({ repos, visibleTasks }: { repos: Repo[]; visibleTask
         <span className="inline-flex rounded-full border border-cyan-400/30 bg-cyan-400/10 px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-cyan-200">
           Run mode
         </span>
-        <span className="text-sm text-cyan-50/90">Drag a task into Active to start a real run with Codex, PR creation, preview discovery, and evidence.</span>
+        <span className="text-sm text-cyan-50/90">Drag a task into Active to start a real run with the selected executor, review creation, preview discovery, and evidence.</span>
       </div>
     </div>
   );

--- a/src/ui/components/DetailPanel.tsx
+++ b/src/ui/components/DetailPanel.tsx
@@ -51,6 +51,11 @@ function dependencyReasonTone(state: 'missing' | 'not_ready' | 'ready') {
   return 'border-amber-500/25 bg-amber-500/10 text-amber-100';
 }
 
+function llmAdapterLabel(adapter?: AgentRun['llmAdapter']) {
+  if (adapter === 'cursor_cli') return 'Cursor CLI';
+  return 'Codex';
+}
+
 function PanelSection({ title, children, aside }: { title: string; children: React.ReactNode; aside?: React.ReactNode }) {
   return (
     <section className="rounded-xl border border-slate-800 bg-slate-950/70 p-4">
@@ -137,8 +142,10 @@ export function DetailPanel({
   const { task, repo, latestRun } = detail;
   const baselineUrl = getBaselineUrl(task, repo as Repo);
   const canCopyLogs = logs.length > 0;
-  const codexModel = task.uiMeta?.codexModel ?? 'gpt-5.1-codex-mini';
-  const codexReasoningEffort = task.uiMeta?.codexReasoningEffort ?? 'medium';
+  const taskLlmAdapter = task.uiMeta?.llmAdapter ?? 'codex';
+  const taskLlmModel = task.uiMeta?.llmModel ?? task.uiMeta?.codexModel ?? 'gpt-5.1-codex-mini';
+  const taskLlmReasoningEffort = task.uiMeta?.llmReasoningEffort ?? task.uiMeta?.codexReasoningEffort ?? 'medium';
+  const latestRunResumeCommand = latestRun?.llmResumeCommand ?? latestRun?.latestCodexResumeCommand;
   const latestCommands = latestRun ? commands.filter((command) => command.runId === latestRun.runId) : [];
   const latestEvents = latestRun ? events.filter((event) => event.runId === latestRun.runId) : [];
   const currentCommand = latestRun?.currentCommandId ? latestCommands.find((command) => command.id === latestRun.currentCommandId) : undefined;
@@ -286,6 +293,18 @@ export function DetailPanel({
                   <div className="mt-1 text-xs text-slate-500">Waiting for preview</div>
                 )}
               </div>
+              <div className="rounded-lg border border-slate-800 bg-slate-900/70 px-3 py-2">
+                <div className="text-[11px] uppercase tracking-[0.16em] text-slate-500">Executor</div>
+                <div className="mt-1 text-xs text-slate-200">{llmAdapterLabel(latestRun.llmAdapter)}</div>
+              </div>
+              <div className="rounded-lg border border-slate-800 bg-slate-900/70 px-3 py-2">
+                <div className="text-[11px] uppercase tracking-[0.16em] text-slate-500">Model</div>
+                <code className="mt-1 block break-all text-xs text-slate-200">{latestRun.llmModel ?? taskLlmModel}</code>
+              </div>
+              <div className="rounded-lg border border-slate-800 bg-slate-900/70 px-3 py-2">
+                <div className="text-[11px] uppercase tracking-[0.16em] text-slate-500">Reasoning</div>
+                <code className="mt-1 block break-all text-xs text-slate-200">{latestRun.llmReasoningEffort ?? taskLlmReasoningEffort}</code>
+              </div>
             </div>
             <div className="rounded-lg border border-slate-800 bg-slate-900/70 p-3">
               <div className="mb-2 flex items-center justify-between gap-3">
@@ -330,7 +349,7 @@ export function DetailPanel({
                 </div>
               </div>
               <p className="text-sm text-slate-400">
-                Open the terminal in a dedicated modal window. It attaches to a separate operator session, so Codex can keep running unless you explicitly take over.
+                Open the terminal in a dedicated modal window. It attaches to a separate operator session, so the executor can keep running unless you explicitly take over.
               </p>
               {terminalBootstrap && !terminalBootstrap.attachable ? (
                 <div className="mt-3 rounded-lg border border-slate-800 bg-slate-950/70 px-3 py-2 text-sm text-slate-400">
@@ -357,10 +376,18 @@ export function DetailPanel({
                   </div>
                 </div>
               ) : null}
-              {latestRun.latestCodexResumeCommand ? (
+              {latestRun ? (
                 <div className="mt-3 rounded-lg border border-slate-800 bg-slate-950/70 px-3 py-2">
-                  <div className="text-[11px] uppercase tracking-[0.16em] text-slate-500">Codex resume</div>
-                  <code className="mt-1 block break-all text-xs text-cyan-200">{latestRun.latestCodexResumeCommand}</code>
+                  <div className="text-[11px] uppercase tracking-[0.16em] text-slate-500">Resume capability</div>
+                  {latestRun.llmSupportsResume ? (
+                    latestRunResumeCommand ? (
+                      <code className="mt-1 block break-all text-xs text-cyan-200">{latestRunResumeCommand}</code>
+                    ) : (
+                      <div className="mt-1 text-xs text-slate-400">{llmAdapterLabel(latestRun.llmAdapter)} supports resume, but no command is available yet.</div>
+                    )
+                  ) : (
+                    <div className="mt-1 text-xs text-slate-400">{llmAdapterLabel(latestRun.llmAdapter)} does not advertise resumable takeover for this run.</div>
+                  )}
                 </div>
               ) : null}
             </div>
@@ -425,14 +452,18 @@ export function DetailPanel({
         </summary>
         <div className="mt-4 grid gap-4 xl:grid-cols-1">
           <PanelSection title="Execution">
-            <div className="grid gap-2 sm:grid-cols-2">
+            <div className="grid gap-2 sm:grid-cols-3">
+              <div className="rounded-lg border border-slate-800 bg-slate-900/70 px-3 py-2">
+                <div className="text-[11px] uppercase tracking-[0.16em] text-slate-500">Adapter</div>
+                <code className="mt-1 block break-all text-xs text-slate-200">{llmAdapterLabel(taskLlmAdapter)}</code>
+              </div>
               <div className="rounded-lg border border-slate-800 bg-slate-900/70 px-3 py-2">
                 <div className="text-[11px] uppercase tracking-[0.16em] text-slate-500">Model</div>
-                <code className="mt-1 block break-all text-xs text-slate-200">{codexModel}</code>
+                <code className="mt-1 block break-all text-xs text-slate-200">{taskLlmModel}</code>
               </div>
               <div className="rounded-lg border border-slate-800 bg-slate-900/70 px-3 py-2">
                 <div className="text-[11px] uppercase tracking-[0.16em] text-slate-500">Reasoning</div>
-                <code className="mt-1 block break-all text-xs text-slate-200">{codexReasoningEffort}</code>
+                <code className="mt-1 block break-all text-xs text-slate-200">{taskLlmReasoningEffort}</code>
               </div>
             </div>
           </PanelSection>

--- a/src/ui/components/Forms.test.tsx
+++ b/src/ui/components/Forms.test.tsx
@@ -36,7 +36,8 @@ describe('RepoForm', () => {
       slug: 'group/platform/repo',
       scmProvider: 'gitlab',
       scmBaseUrl: 'https://gitlab.example.com',
-      projectPath: 'group/platform/repo'
+      projectPath: 'group/platform/repo',
+      llmAdapter: 'codex'
     }));
   });
 
@@ -82,11 +83,13 @@ describe('TaskForm', () => {
 
     const acceptanceCriteriaField = screen.getByText('Acceptance criteria').closest('label')?.querySelector('textarea');
     const dependenciesField = screen.getByText('Dependencies').closest('label')?.querySelector('textarea');
-    const codexModelField = screen.getByText('Codex model').closest('label')?.querySelector('select');
+    const llmAdapterField = screen.getByText('LLM adapter').closest('label')?.querySelector('select');
+    const llmModelField = screen.getByText('LLM model').closest('label')?.querySelector('select');
     const reasoningEffortField = screen.getByText('Reasoning effort').closest('label')?.querySelector('select');
     expect(acceptanceCriteriaField).not.toBeNull();
     expect(dependenciesField).not.toBeNull();
-    expect(codexModelField).not.toBeNull();
+    expect(llmAdapterField).not.toBeNull();
+    expect(llmModelField).not.toBeNull();
     expect(reasoningEffortField).not.toBeNull();
 
     const sourceRefField = screen.getByText('Source ref').closest('label')?.querySelector('input');
@@ -98,7 +101,8 @@ describe('TaskForm', () => {
     await user.type(acceptanceCriteriaField!, 'A playable snake game appears on index.');
     await user.type(dependenciesField!, 'task_repo_123abc\ntask_repo_456def|primary');
     await user.click(screen.getByRole('checkbox'));
-    await user.selectOptions(codexModelField! as unknown as Element, 'gpt-5.3-codex-spark');
+    await user.selectOptions(llmAdapterField! as unknown as Element, 'codex');
+    await user.selectOptions(llmModelField! as unknown as Element, 'gpt-5.3-codex-spark');
     await user.selectOptions(reasoningEffortField! as unknown as Element, 'high');
 
     await user.click(screen.getByRole('button', { name: 'Create task' }));
@@ -117,6 +121,9 @@ describe('TaskForm', () => {
       },
       taskPrompt: 'Create a simple snake game on the homepage.',
       acceptanceCriteria: ['A playable snake game appears on index.'],
+      llmAdapter: 'codex',
+      llmModel: 'gpt-5.3-codex-spark',
+      llmReasoningEffort: 'high',
       codexModel: 'gpt-5.3-codex-spark',
       codexReasoningEffort: 'high'
     });

--- a/src/ui/components/Forms.tsx
+++ b/src/ui/components/Forms.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import type { CreateRepoInput, CreateTaskInput } from '../domain/api';
-import type { CodexModel, CodexReasoningEffort, Repo, ScmProvider, TaskContextLink, TaskDependency, TaskStatus } from '../domain/types';
+import type { CodexModel, LlmAdapter, LlmReasoningEffort, Repo, ScmProvider, TaskContextLink, TaskDependency, TaskStatus } from '../domain/types';
 
 const DEFAULT_SCM_BASE_URLS: Record<ScmProvider, string> = {
   github: 'https://github.com',
@@ -12,6 +12,11 @@ const CODEX_MODELS: Array<{ value: CodexModel; label: string }> = [
   { value: 'gpt-5.3-codex', label: 'gpt-5.3-codex' },
   { value: 'gpt-5.3-codex-spark', label: 'gpt-5.3-codex-spark' }
 ];
+
+const DEFAULT_LLM_MODELS: Record<LlmAdapter, string> = {
+  codex: 'gpt-5.1-codex-mini',
+  cursor_cli: 'cursor-default'
+};
 
 function FieldShell({ label, children, hint }: { label: string; children: React.ReactNode; hint?: string }) {
   return (
@@ -58,7 +63,9 @@ export function RepoForm({
   const initialDefaultBranch = initialValues?.defaultBranch ?? 'main';
   const initialBaselineUrl = initialValues?.baselineUrl ?? '';
   const initialPreviewCheckName = initialValues?.previewCheckName ?? '';
-  const initialCodexAuthBundleR2Key = initialValues?.codexAuthBundleR2Key ?? '';
+  const initialLlmAdapter = initialValues?.llmAdapter ?? 'codex';
+  const initialLlmProfileId = initialValues?.llmProfileId ?? '';
+  const initialLlmAuthBundleR2Key = initialValues?.llmAuthBundleR2Key ?? initialValues?.codexAuthBundleR2Key ?? '';
 
   const [scmProvider, setScmProvider] = useState<ScmProvider>(initialScmProvider);
   const [scmBaseUrl, setScmBaseUrl] = useState(initialScmBaseUrl);
@@ -66,7 +73,9 @@ export function RepoForm({
   const [defaultBranch, setDefaultBranch] = useState(initialDefaultBranch);
   const [baselineUrl, setBaselineUrl] = useState(initialBaselineUrl);
   const [previewCheckName, setPreviewCheckName] = useState(initialPreviewCheckName);
-  const [codexAuthBundleR2Key, setCodexAuthBundleR2Key] = useState(initialCodexAuthBundleR2Key);
+  const [llmAdapter, setLlmAdapter] = useState<LlmAdapter>(initialLlmAdapter);
+  const [llmProfileId, setLlmProfileId] = useState(initialLlmProfileId);
+  const [llmAuthBundleR2Key, setLlmAuthBundleR2Key] = useState(initialLlmAuthBundleR2Key);
 
   useEffect(() => {
     setScmProvider(initialScmProvider);
@@ -75,8 +84,10 @@ export function RepoForm({
     setDefaultBranch(initialDefaultBranch);
     setBaselineUrl(initialBaselineUrl);
     setPreviewCheckName(initialPreviewCheckName);
-    setCodexAuthBundleR2Key(initialCodexAuthBundleR2Key);
-  }, [initialScmProvider, initialScmBaseUrl, initialProjectPath, initialDefaultBranch, initialBaselineUrl, initialPreviewCheckName, initialCodexAuthBundleR2Key]);
+    setLlmAdapter(initialLlmAdapter);
+    setLlmProfileId(initialLlmProfileId);
+    setLlmAuthBundleR2Key(initialLlmAuthBundleR2Key);
+  }, [initialScmProvider, initialScmBaseUrl, initialProjectPath, initialDefaultBranch, initialBaselineUrl, initialPreviewCheckName, initialLlmAdapter, initialLlmProfileId, initialLlmAuthBundleR2Key]);
 
   const projectPathHint = scmProvider === 'gitlab'
     ? 'Use the GitLab project path like group/subgroup/repo.'
@@ -100,11 +111,14 @@ export function RepoForm({
           scmProvider,
           scmBaseUrl,
           projectPath,
+          llmAdapter,
+          llmProfileId: llmProfileId || undefined,
+          llmAuthBundleR2Key: llmAuthBundleR2Key || undefined,
           defaultBranch,
           baselineUrl,
           enabled: true,
           previewCheckName: previewCheckName || undefined,
-          codexAuthBundleR2Key: codexAuthBundleR2Key || undefined
+          codexAuthBundleR2Key: llmAdapter === 'codex' ? (llmAuthBundleR2Key || undefined) : undefined
         });
         setScmProvider('github');
         setScmBaseUrl(DEFAULT_SCM_BASE_URLS.github);
@@ -112,7 +126,9 @@ export function RepoForm({
         setDefaultBranch('main');
         setBaselineUrl('');
         setPreviewCheckName('');
-        setCodexAuthBundleR2Key('');
+        setLlmAdapter('codex');
+        setLlmProfileId('');
+        setLlmAuthBundleR2Key('');
       }}
     >
       <div className="grid gap-4 md:grid-cols-3">
@@ -165,8 +181,19 @@ export function RepoForm({
         <FieldShell label="Preview check name" hint={previewCheckHint}>
           <input className={inputClass()} value={previewCheckName} onChange={(event) => setPreviewCheckName(event.target.value)} placeholder="Cloudflare Pages" />
         </FieldShell>
-        <FieldShell label="Codex auth bundle key" hint="Optional R2 key for a `.codex` auth bundle tarball.">
-          <input className={inputClass()} value={codexAuthBundleR2Key} onChange={(event) => setCodexAuthBundleR2Key(event.target.value)} placeholder="auth/codex.tgz" />
+        <FieldShell label="LLM adapter">
+          <select className={inputClass()} value={llmAdapter} onChange={(event) => setLlmAdapter(event.target.value as LlmAdapter)}>
+            <option value="codex">Codex</option>
+            <option value="cursor_cli">Cursor CLI</option>
+          </select>
+        </FieldShell>
+      </div>
+      <div className="grid gap-4 md:grid-cols-2">
+        <FieldShell label="LLM profile id" hint="Optional profile identifier used by adapter integrations.">
+          <input className={inputClass()} value={llmProfileId} onChange={(event) => setLlmProfileId(event.target.value)} placeholder="codex-default" />
+        </FieldShell>
+        <FieldShell label="LLM auth bundle key" hint="Optional R2 key for executor credentials (for example `.codex` auth tarball).">
+          <input className={inputClass()} value={llmAuthBundleR2Key} onChange={(event) => setLlmAuthBundleR2Key(event.target.value)} placeholder={llmAdapter === 'codex' ? 'auth/codex.tgz' : 'auth/cursor.tgz'} />
         </FieldShell>
       </div>
       <PrimaryButton>{submitLabel}</PrimaryButton>
@@ -247,8 +274,9 @@ export function TaskForm({
   const initialTaskStatus = initialValues?.status ?? initialStatus;
   const initialBaselineUrlOverride = initialValues?.baselineUrlOverride ?? '';
   const initialAutoStartEligible = initialValues?.automationState?.autoStartEligible ?? false;
-  const initialCodexModel = initialValues?.codexModel ?? 'gpt-5.1-codex-mini';
-  const initialCodexReasoningEffort = initialValues?.codexReasoningEffort ?? 'medium';
+  const initialLlmAdapter = initialValues?.llmAdapter ?? 'codex';
+  const initialLlmModel = initialValues?.llmModel ?? initialValues?.codexModel ?? DEFAULT_LLM_MODELS[initialLlmAdapter];
+  const initialLlmReasoningEffort = initialValues?.llmReasoningEffort ?? initialValues?.codexReasoningEffort ?? 'medium';
 
   const [repoId, setRepoId] = useState(initialRepoId);
   const [title, setTitle] = useState(initialTitle);
@@ -262,8 +290,9 @@ export function TaskForm({
   const [status, setStatus] = useState<TaskStatus>(initialTaskStatus);
   const [baselineUrlOverride, setBaselineUrlOverride] = useState(initialBaselineUrlOverride);
   const [autoStartEligible, setAutoStartEligible] = useState(initialAutoStartEligible);
-  const [codexModel, setCodexModel] = useState<CodexModel>(initialCodexModel);
-  const [codexReasoningEffort, setCodexReasoningEffort] = useState<CodexReasoningEffort>(initialCodexReasoningEffort);
+  const [llmAdapter, setLlmAdapter] = useState<LlmAdapter>(initialLlmAdapter);
+  const [llmModel, setLlmModel] = useState(initialLlmModel);
+  const [llmReasoningEffort, setLlmReasoningEffort] = useState<LlmReasoningEffort>(initialLlmReasoningEffort);
 
   useEffect(() => {
     if (!repos.length) {
@@ -289,13 +318,15 @@ export function TaskForm({
     setStatus(initialTaskStatus);
     setBaselineUrlOverride(initialBaselineUrlOverride);
     setAutoStartEligible(initialAutoStartEligible);
-    setCodexModel(initialCodexModel);
-    setCodexReasoningEffort(initialCodexReasoningEffort);
+    setLlmAdapter(initialLlmAdapter);
+    setLlmModel(initialLlmModel);
+    setLlmReasoningEffort(initialLlmReasoningEffort);
   }, [
     initialAutoStartEligible,
     initialBaselineUrlOverride,
-    initialCodexModel,
-    initialCodexReasoningEffort,
+    initialLlmAdapter,
+    initialLlmModel,
+    initialLlmReasoningEffort,
     initialCriteria,
     initialDependencies,
     initialDescription,
@@ -332,8 +363,11 @@ export function TaskForm({
           status,
           baselineUrlOverride: baselineUrlOverride || undefined,
           simulationProfile: 'happy_path',
-          codexModel,
-          codexReasoningEffort
+          llmAdapter,
+          llmModel: llmModel || undefined,
+          llmReasoningEffort,
+          codexModel: llmAdapter === 'codex' ? (llmModel as CodexModel) : undefined,
+          codexReasoningEffort: llmAdapter === 'codex' ? llmReasoningEffort : undefined
         });
         setTitle('');
         setDescription('');
@@ -346,8 +380,9 @@ export function TaskForm({
         setStatus(initialStatus);
         setBaselineUrlOverride('');
         setAutoStartEligible(false);
-        setCodexModel('gpt-5.1-codex-mini');
-        setCodexReasoningEffort('medium');
+        setLlmAdapter('codex');
+        setLlmModel('gpt-5.1-codex-mini');
+        setLlmReasoningEffort('medium');
       }}
     >
       <div className="grid gap-4 md:grid-cols-2">
@@ -434,20 +469,42 @@ export function TaskForm({
         </FieldShell>
       </div>
       <div className="grid gap-4 md:grid-cols-2">
-        <FieldShell label="Codex model" hint="Per-task execution model.">
-          <select className={inputClass()} value={codexModel} onChange={(event) => setCodexModel(event.target.value as CodexModel)}>
-            {CODEX_MODELS.map((model) => (
-              <option key={model.value} value={model.value}>
-                {model.label}
-              </option>
-            ))}
-          </select>
-        </FieldShell>
-        <FieldShell label="Reasoning effort" hint="Passed to Codex as model reasoning effort.">
+        <FieldShell label="LLM adapter" hint="Selects the executor for this task.">
           <select
             className={inputClass()}
-            value={codexReasoningEffort}
-            onChange={(event) => setCodexReasoningEffort(event.target.value as CodexReasoningEffort)}
+            value={llmAdapter}
+            onChange={(event) => {
+              const nextAdapter = event.target.value as LlmAdapter;
+              setLlmAdapter(nextAdapter);
+              if (!llmModel || llmModel === DEFAULT_LLM_MODELS.codex || llmModel === DEFAULT_LLM_MODELS.cursor_cli) {
+                setLlmModel(DEFAULT_LLM_MODELS[nextAdapter]);
+              }
+            }}
+          >
+            <option value="codex">Codex</option>
+            <option value="cursor_cli">Cursor CLI</option>
+          </select>
+        </FieldShell>
+        <FieldShell label="LLM model" hint="Per-task execution model for the selected adapter.">
+          {llmAdapter === 'codex' ? (
+            <select className={inputClass()} value={llmModel} onChange={(event) => setLlmModel(event.target.value)}>
+              {CODEX_MODELS.map((model) => (
+                <option key={model.value} value={model.value}>
+                  {model.label}
+                </option>
+              ))}
+            </select>
+          ) : (
+            <input className={inputClass()} value={llmModel} onChange={(event) => setLlmModel(event.target.value)} placeholder="cursor-default" />
+          )}
+        </FieldShell>
+      </div>
+      <div className="grid gap-4 md:grid-cols-2">
+        <FieldShell label="Reasoning effort" hint="Executor reasoning effort hint.">
+          <select
+            className={inputClass()}
+            value={llmReasoningEffort}
+            onChange={(event) => setLlmReasoningEffort(event.target.value as LlmReasoningEffort)}
           >
             <option value="low">low</option>
             <option value="medium">medium (default)</option>

--- a/src/ui/domain/api.ts
+++ b/src/ui/domain/api.ts
@@ -22,6 +22,9 @@ export type CreateRepoInput = {
   scmProvider?: Repo['scmProvider'];
   scmBaseUrl?: string;
   projectPath?: string;
+  llmAdapter?: Repo['llmAdapter'];
+  llmProfileId?: string;
+  llmAuthBundleR2Key?: string;
   defaultBranch?: string;
   baselineUrl: string;
   enabled?: boolean;
@@ -31,6 +34,7 @@ export type CreateRepoInput = {
   previewConfig?: Repo['previewConfig'];
   previewProvider?: Repo['previewProvider'];
   previewCheckName?: string;
+  // Compatibility alias during migration to generic LLM executor fields.
   codexAuthBundleR2Key?: string;
 };
 

--- a/src/ui/domain/types.ts
+++ b/src/ui/domain/types.ts
@@ -45,6 +45,9 @@ export type Repo = {
   scmProvider?: ScmProvider;
   scmBaseUrl?: string;
   projectPath?: string;
+  llmAdapter?: LlmAdapter;
+  llmProfileId?: string;
+  llmAuthBundleR2Key?: string;
   defaultBranch: string;
   baselineUrl: string;
   enabled: boolean;
@@ -56,6 +59,7 @@ export type Repo = {
   previewProvider?: 'cloudflare';
   previewCheckName?: string;
   previewUrlPattern?: string;
+  // Compatibility alias during migration to generic LLM executor fields.
   codexAuthBundleR2Key?: string;
   createdAt: string;
   updatedAt: string;

--- a/src/ui/mock/local-agent-board-api.ts
+++ b/src/ui/mock/local-agent-board-api.ts
@@ -40,6 +40,9 @@ export class LocalAgentBoardApi implements AgentBoardApi {
       scmProvider: input.scmProvider,
       scmBaseUrl: input.scmBaseUrl,
       projectPath: input.projectPath,
+      llmAdapter: input.llmAdapter,
+      llmProfileId: input.llmProfileId,
+      llmAuthBundleR2Key: input.llmAuthBundleR2Key ?? input.codexAuthBundleR2Key,
       defaultBranch: input.defaultBranch ?? 'main',
       baselineUrl: input.baselineUrl,
       enabled: input.enabled ?? true,
@@ -49,7 +52,7 @@ export class LocalAgentBoardApi implements AgentBoardApi {
       previewConfig: input.previewConfig,
       previewProvider: input.previewProvider ?? 'cloudflare',
       previewCheckName: input.previewCheckName,
-      codexAuthBundleR2Key: input.codexAuthBundleR2Key,
+      codexAuthBundleR2Key: input.codexAuthBundleR2Key ?? input.llmAuthBundleR2Key,
       createdAt: timestamp,
       updatedAt: timestamp
     });


### PR DESCRIPTION
Task: S35-L5 UI and API surfaces for generic LLM executor metadata

Expose the generic LLM adapter/model/resume capability fields through APIs and user-facing UI without assuming Codex is universal.


Acceptance criteria:
- Task and repo APIs support generic LLM executor configuration fields.
- UI surfaces can display executor-neutral metadata and resume capability.
- Current Codex users do not lose functionality during the transition.
- The UI does not falsely imply that every executor supports resume/takeover parity.

Run ID: run_repo_abuiles_minions_mm9d8u7l1w23