### PR TITLE
S35-L5 UI and API surfaces for generic LLM executor metadata

### DIFF
--- a/src/server/durable/board-index.ts
+++ b/src/server/durable/board-index.ts
@@ -268,6 +268,8 @@ function buildRepoRecord(input: CreateRepoInput | Repo): Repo {
     defaultBranch: input.defaultBranch ?? 'main',
     baselineUrl: input.baselineUrl,
     enabled: input.enabled ?? true,
+    llmAdapter: input.llmAdapter,
+    llmProfileId: input.llmProfileId,
     githubAuthMode: 'githubAuthMode' in input ? input.githubAuthMode : undefined,
     previewMode: 'previewMode' in input ? input.previewMode : 'auto',
     evidenceMode: 'evidenceMode' in input ? input.evidenceMode : 'auto',

--- a/src/server/durable/repo-board.ts
+++ b/src/server/durable/repo-board.ts
@@ -353,7 +353,7 @@ export class RepoBoardDO extends DurableObject<Env> {
         status: run.previewUrl ? 'EVIDENCE_RUNNING' : 'WAITING_PREVIEW',
         previewStatus: run.previewUrl ? 'READY' : 'DISCOVERING',
         evidenceStatus: 'RUNNING',
-        appendTimelineNote: 'Retrying evidence for the existing PR.'
+        appendTimelineNote: 'Retrying evidence for the existing review.'
       },
       nowIso
     );
@@ -383,7 +383,7 @@ export class RepoBoardDO extends DurableObject<Env> {
         previewUrl: undefined,
         previewStatus: 'DISCOVERING',
         evidenceStatus: 'NOT_STARTED',
-        appendTimelineNote: 'Retrying preview discovery for the existing PR.'
+        appendTimelineNote: 'Retrying preview discovery for the existing review.'
       },
       nowIso
     );
@@ -709,7 +709,7 @@ export class RepoBoardDO extends DurableObject<Env> {
       updatedAt: now
     };
     const events: RunEvent[] = [
-      buildRunEvent(updated, 'operator', 'operator.takeover_started', 'Operator took control of the live sandbox session and stopped Codex execution.', { sessionName: nextSession.sessionName })
+      buildRunEvent(updated, 'operator', 'operator.takeover_started', 'Operator took control of the live sandbox session and stopped executor execution.', { sessionName: nextSession.sessionName })
     ];
     if (updated.latestCodexResumeCommand) {
       events.push(

--- a/src/server/run-orchestrator.ts
+++ b/src/server/run-orchestrator.ts
@@ -615,7 +615,7 @@ function buildLlmPrompt(task: Task, repo: Repo, run: Awaited<ReturnType<RepoBoar
     '- Make the requested code changes in this repository.',
     '- Decide which install/build/test commands are appropriate and run them as needed.',
     run.changeRequest?.prompt
-      ? `- The outer system already prepared the existing PR branch ${run.branchName} for this change request. Update that branch in place and keep the existing PR alive.`
+      ? `- The outer system already prepared the existing review branch ${run.branchName} for this change request. Update that branch in place and keep the existing review request alive.`
       : task.sourceRef
         ? `- The outer system already prepared the run branch from this task source ref: ${task.sourceRef}. Do not fetch or checkout another starting branch yourself.`
         : undefined,
@@ -637,14 +637,14 @@ async function prepareRunBranchFromTaskSource(
 ) {
   if (run.changeRequest?.prompt && getRunReviewUrl(run)) {
     await repoBoard.appendRunLogs(runId, [
-      buildRunLog(runId, `Preparing existing PR branch ${run.branchName} for a review change request.`, 'bootstrap')
+      buildRunLog(runId, `Preparing existing review branch ${run.branchName} for a review change request.`, 'bootstrap')
     ]);
     const checkout = await sandbox.exec(
       `cd /workspace/repo && git fetch origin ${shellEscape(run.branchName)} && git checkout -B ${shellEscape(run.branchName)} FETCH_HEAD`
     );
     await appendCommandLogs(repoBoard, runId, 'bootstrap', checkout.stdout, checkout.stderr);
     if (!checkout.success) {
-      throw new Error(checkout.stderr || `Failed to prepare existing PR branch ${run.branchName}.`);
+      throw new Error(checkout.stderr || `Failed to prepare existing review branch ${run.branchName}.`);
     }
     return;
   }

--- a/src/ui/App.test.tsx
+++ b/src/ui/App.test.tsx
@@ -148,7 +148,7 @@ describe('App', () => {
     expect(await screen.findByText('Updated Refresh homepage hero copy.')).toBeInTheDocument();
   });
 
-  it('requests changes from a review task and starts a rerun on the same PR branch', async () => {
+  it('requests changes from a review task and starts a rerun on the same review branch', async () => {
     const user = userEvent.setup();
     const api = getLocalAgentBoardApi();
     const previousRun = api.getSnapshot().runs.find((run) => run.runId === 'run_nav_1');
@@ -158,7 +158,7 @@ describe('App', () => {
     await screen.findByRole('heading', { name: 'Fix settings navigation overflow' });
     await user.click(await screen.findByRole('button', { name: 'Request changes' }));
     await user.type(
-      await screen.findByPlaceholderText('Describe the changes you want on the current PR.'),
+      await screen.findByPlaceholderText('Describe the changes you want on the current review.'),
       'Tighten the spacing and update the review copy.'
     );
     await user.click(screen.getByRole('button', { name: 'Start review rerun' }));
@@ -175,7 +175,7 @@ describe('App', () => {
       expect(latestRun.prUrl).toBe(previousRun?.prUrl);
     });
 
-    expect(await screen.findByText('Started a review rerun on the existing PR branch.')).toBeInTheDocument();
+    expect(await screen.findByText('Started a review rerun on the existing review branch.')).toBeInTheDocument();
   });
 
   it('opens the terminal in a modal with the live stream panel', async () => {

--- a/src/ui/components/Board.tsx
+++ b/src/ui/components/Board.tsx
@@ -22,7 +22,7 @@ const laneStyles: Record<TaskStatus, { tint: string; badge: string; empty: strin
   REVIEW: {
     tint: 'from-violet-500/22 to-violet-500/0 border-violet-500/20',
     badge: 'bg-violet-500/20 text-violet-50',
-    empty: 'PRs and evidence collect here'
+    empty: 'Reviews and evidence collect here'
   },
   DONE: {
     tint: 'from-emerald-500/22 to-emerald-500/0 border-emerald-500/20',
@@ -67,7 +67,7 @@ function deriveRunSignal(run?: AgentRun) {
         : { label: 'Running', tone: 'text-cyan-300' };
     case 'PR_OPEN':
     case 'WAITING_PREVIEW':
-      return { label: 'PR open', tone: 'text-violet-300' };
+      return { label: 'Review open', tone: 'text-violet-300' };
     case 'EVIDENCE_RUNNING':
       return { label: 'Evidence', tone: 'text-amber-300' };
     case 'DONE':
@@ -127,7 +127,7 @@ function TaskCard({
       {task.description ? <p className="mt-1.5 line-clamp-2 text-xs leading-5 text-slate-400">{task.description}</p> : null}
 
       <div className="mt-2 flex items-center justify-between text-[11px] text-slate-500">
-        <span>{latestRun?.prNumber ? `PR #${latestRun.prNumber}` : 'No PR yet'}</span>
+        <span>{(latestRun?.reviewNumber ?? latestRun?.prNumber) ? `Review #${latestRun.reviewNumber ?? latestRun.prNumber}` : 'No review yet'}</span>
         <span>{formatRelativeTime(task.updatedAt)}</span>
       </div>
     </button>
@@ -224,7 +224,7 @@ export function Board({
       <div className="flex items-center justify-between border-b border-slate-800 px-4 py-2.5">
         <div>
           <h2 className="text-sm font-semibold uppercase tracking-[0.18em] text-slate-300">Board operations</h2>
-          <p className="mt-1 text-sm text-slate-500">Active starts a run. Review collects PRs and evidence.</p>
+          <p className="mt-1 text-sm text-slate-500">Active starts a run. Review collects review requests and evidence.</p>
         </div>
       </div>
       <DndContext


### PR DESCRIPTION
Task: S35-L5 UI and API surfaces for generic LLM executor metadata

Expose the generic LLM adapter/model/resume capability fields through APIs and user-facing UI without assuming Codex is universal.


Acceptance criteria:
- Task and repo APIs support generic LLM executor configuration fields.
- UI surfaces can display executor-neutral metadata and resume capability.
- Current Codex users do not lose functionality during the transition.
- The UI does not falsely imply that every executor supports resume/takeover parity.

Run ID: run_repo_abuiles_minions_mm9d8xfzjv9z