### PR TITLE
S35-P1 Preview adapter types, registry, and legacy config mapping

### DIFF
--- a/src/server/durable/board-index.ts
+++ b/src/server/durable/board-index.ts
@@ -271,6 +271,8 @@ function buildRepoRecord(input: CreateRepoInput | Repo): Repo {
     githubAuthMode: 'githubAuthMode' in input ? input.githubAuthMode : undefined,
     previewMode: 'previewMode' in input ? input.previewMode : 'auto',
     evidenceMode: 'evidenceMode' in input ? input.evidenceMode : 'auto',
+    previewAdapter: 'previewAdapter' in input ? input.previewAdapter : undefined,
+    previewConfig: 'previewConfig' in input ? input.previewConfig : undefined,
     previewProvider: 'previewProvider' in input ? input.previewProvider : 'cloudflare',
     previewCheckName: input.previewCheckName,
     previewUrlPattern: 'previewUrlPattern' in input ? input.previewUrlPattern : undefined,

--- a/src/server/http/validation.test.ts
+++ b/src/server/http/validation.test.ts
@@ -169,12 +169,51 @@ describe('repo validation', () => {
     expect(parsed.previewProvider).toBe('cloudflare');
   });
 
+  it('parses generic preview adapter fields and mirrors legacy check name', () => {
+    const parsed = parseCreateRepoInput({
+      slug: 'abuiles/minions',
+      baselineUrl: 'https://example.com',
+      previewAdapter: 'cloudflare_checks',
+      previewConfig: {
+        checkName: 'Workers Builds: minions'
+      }
+    });
+
+    expect(parsed.previewAdapter).toBe('cloudflare_checks');
+    expect(parsed.previewProvider).toBe('cloudflare');
+    expect(parsed.previewCheckName).toBe('Workers Builds: minions');
+    expect(parsed.previewConfig?.checkName).toBe('Workers Builds: minions');
+  });
+
+  it('maps legacy preview fields to the new preview config shape', () => {
+    const parsed = parseCreateRepoInput({
+      slug: 'abuiles/minions',
+      baselineUrl: 'https://example.com',
+      previewProvider: 'cloudflare',
+      previewCheckName: 'Workers Builds: minions'
+    });
+
+    expect(parsed.previewAdapter).toBe('cloudflare_checks');
+    expect(parsed.previewConfig).toEqual({ checkName: 'Workers Builds: minions' });
+  });
+
   it('rejects invalid repo execution policy values', () => {
     expect(() =>
       parseUpdateRepoInput({
         previewMode: 'sometimes'
       })
     ).toThrow('Invalid previewMode.');
+  });
+
+  it('rejects incompatible legacy and new preview adapter payloads', () => {
+    expect(() =>
+      parseCreateRepoInput({
+        slug: 'abuiles/minions',
+        baselineUrl: 'https://example.com',
+        previewProvider: 'cloudflare',
+        previewAdapter: 'prompt_recipe'
+      })
+    ).toThrow('Invalid preview payload: previewProvider "cloudflare" requires previewAdapter "cloudflare_checks".');
   });
 
   it('parses provider-neutral repo payloads and keeps slug compatibility', () => {

--- a/src/server/http/validation.ts
+++ b/src/server/http/validation.ts
@@ -5,6 +5,7 @@ import { SCM_PROVIDERS } from '../../shared/scm';
 const CODEX_MODELS = new Set(['gpt-5.1-codex-mini', 'gpt-5.3-codex', 'gpt-5.3-codex-spark'] as const);
 const CODEX_REASONING_EFFORTS = new Set(['low', 'medium', 'high'] as const);
 const LLM_ADAPTERS = new Set(['codex', 'cursor_cli'] as const);
+const PREVIEW_ADAPTERS = new Set(['cloudflare_checks', 'prompt_recipe'] as const);
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
@@ -271,6 +272,60 @@ function readTaskLlmFields(body: Record<string, unknown>, mode: 'create' | 'upda
   };
 }
 
+function readPreviewConfig(value: unknown, field: string, required = true): CreateRepoInput['previewConfig'] | undefined {
+  if (!required && typeof value === 'undefined') {
+    return undefined;
+  }
+
+  if (!isRecord(value)) {
+    throw badRequest(`Invalid ${field}.`);
+  }
+
+  const checkName = readTrimmedString(value.checkName, `${field}.checkName`, false);
+  const promptRecipe = readTrimmedString(value.promptRecipe, `${field}.promptRecipe`, false);
+  if (!checkName && !promptRecipe) {
+    return undefined;
+  }
+
+  return {
+    ...(checkName ? { checkName } : {}),
+    ...(promptRecipe ? { promptRecipe } : {})
+  };
+}
+
+function normalizeRepoPreviewFields<T extends {
+  previewAdapter?: CreateRepoInput['previewAdapter'];
+  previewConfig?: CreateRepoInput['previewConfig'];
+  previewProvider?: CreateRepoInput['previewProvider'];
+  previewCheckName?: string;
+}>(input: T): T {
+  const checkName = input.previewConfig?.checkName ?? input.previewCheckName;
+  if (input.previewConfig?.checkName && input.previewCheckName && input.previewConfig.checkName !== input.previewCheckName) {
+    throw badRequest('Invalid preview payload: previewConfig.checkName and previewCheckName must match when both are provided.');
+  }
+
+  if (input.previewProvider === 'cloudflare' && input.previewAdapter && input.previewAdapter !== 'cloudflare_checks') {
+    throw badRequest('Invalid preview payload: previewProvider "cloudflare" requires previewAdapter "cloudflare_checks".');
+  }
+
+  const previewAdapter = input.previewAdapter ?? (input.previewProvider === 'cloudflare' ? 'cloudflare_checks' : undefined);
+  const previewProvider = input.previewProvider ?? (previewAdapter === 'cloudflare_checks' ? 'cloudflare' : undefined);
+  const previewConfig = input.previewConfig?.promptRecipe || checkName
+    ? {
+        ...(checkName ? { checkName } : {}),
+        ...(input.previewConfig?.promptRecipe ? { promptRecipe: input.previewConfig.promptRecipe } : {})
+      }
+    : input.previewConfig;
+
+  return {
+    ...input,
+    previewAdapter,
+    previewConfig,
+    previewProvider,
+    previewCheckName: checkName
+  };
+}
+
 export async function readJson(request: Request) {
   try {
     return (await request.json()) as unknown;
@@ -293,7 +348,7 @@ export function parseCreateRepoInput(body: unknown): CreateRepoInput {
     throw badRequest('Invalid repo payload: slug and projectPath must match when both are provided.');
   }
 
-  return {
+  return normalizeRepoPreviewFields({
     slug: slug ?? projectPath,
     scmProvider: readEnumValue(body.scmProvider, 'scmProvider', SCM_PROVIDERS, false),
     scmBaseUrl: readTrimmedString(body.scmBaseUrl, 'scmBaseUrl', false),
@@ -303,10 +358,12 @@ export function parseCreateRepoInput(body: unknown): CreateRepoInput {
     enabled: readBoolean(body.enabled, 'enabled', false),
     previewMode: readEnumValue(body.previewMode, 'previewMode', new Set(['auto', 'skip'] as const), false),
     evidenceMode: readEnumValue(body.evidenceMode, 'evidenceMode', new Set(['auto', 'skip'] as const), false),
+    previewAdapter: readEnumValue(body.previewAdapter, 'previewAdapter', PREVIEW_ADAPTERS, false),
+    previewConfig: readPreviewConfig(body.previewConfig, 'previewConfig', false),
     previewProvider: readEnumValue(body.previewProvider, 'previewProvider', new Set(['cloudflare'] as const), false),
     previewCheckName: readTrimmedString(body.previewCheckName, 'previewCheckName', false),
     codexAuthBundleR2Key: readTrimmedString(body.codexAuthBundleR2Key, 'codexAuthBundleR2Key', false)
-  };
+  });
 }
 
 export function parseUpdateRepoInput(body: unknown): UpdateRepoInput {
@@ -329,9 +386,26 @@ export function parseUpdateRepoInput(body: unknown): UpdateRepoInput {
   if (hasOwn(body, 'enabled')) patch.enabled = readBoolean(body.enabled, 'enabled', false);
   if (hasOwn(body, 'previewMode')) patch.previewMode = readEnumValue(body.previewMode, 'previewMode', new Set(['auto', 'skip'] as const), false);
   if (hasOwn(body, 'evidenceMode')) patch.evidenceMode = readEnumValue(body.evidenceMode, 'evidenceMode', new Set(['auto', 'skip'] as const), false);
+  if (hasOwn(body, 'previewAdapter')) patch.previewAdapter = readEnumValue(body.previewAdapter, 'previewAdapter', PREVIEW_ADAPTERS, false);
+  if (hasOwn(body, 'previewConfig')) patch.previewConfig = readPreviewConfig(body.previewConfig, 'previewConfig', false);
   if (hasOwn(body, 'previewProvider')) patch.previewProvider = readEnumValue(body.previewProvider, 'previewProvider', new Set(['cloudflare'] as const), false);
   if (hasOwn(body, 'previewCheckName')) patch.previewCheckName = readTrimmedString(body.previewCheckName, 'previewCheckName', false);
   if (hasOwn(body, 'codexAuthBundleR2Key')) patch.codexAuthBundleR2Key = readTrimmedString(body.codexAuthBundleR2Key, 'codexAuthBundleR2Key', false);
+
+  if (hasOwn(body, 'previewAdapter') || hasOwn(body, 'previewConfig') || hasOwn(body, 'previewProvider') || hasOwn(body, 'previewCheckName')) {
+    const normalizedPreview = normalizeRepoPreviewFields({
+      previewAdapter: patch.previewAdapter,
+      previewConfig: patch.previewConfig,
+      previewProvider: patch.previewProvider,
+      previewCheckName: patch.previewCheckName
+    });
+
+    if (hasOwn(body, 'previewAdapter') || hasOwn(body, 'previewProvider')) patch.previewAdapter = normalizedPreview.previewAdapter;
+    if (hasOwn(body, 'previewAdapter') || hasOwn(body, 'previewProvider')) patch.previewProvider = normalizedPreview.previewProvider;
+    if (hasOwn(body, 'previewConfig') || hasOwn(body, 'previewCheckName')) patch.previewConfig = normalizedPreview.previewConfig;
+    if (hasOwn(body, 'previewConfig') || hasOwn(body, 'previewCheckName')) patch.previewCheckName = normalizedPreview.previewCheckName;
+  }
+
   return patch;
 }
 

--- a/src/server/preview-discovery.test.ts
+++ b/src/server/preview-discovery.test.ts
@@ -55,6 +55,24 @@ Preview Alias URL: https://abuiles-patch-1-minions-demo.abuiles.workers.dev
     expect(previewUrl).toBe('https://commit-minions-demo.abuiles.workers.dev');
   });
 
+  it('uses previewConfig.checkName via compatibility mapping', () => {
+    const previewUrl = discoverPreviewUrl(buildRepo({
+      previewAdapter: 'cloudflare_checks',
+      previewConfig: { checkName: 'Workers Builds: minions-demo' },
+      previewCheckName: undefined
+    }), [
+      {
+        name: 'Workers Builds: minions-demo',
+        app: { slug: 'cloudflare-workers-and-pages' },
+        output: {
+          summary: 'Preview URL: https://commit-minions-demo.abuiles.workers.dev'
+        }
+      }
+    ]);
+
+    expect(previewUrl).toBe('https://commit-minions-demo.abuiles.workers.dev');
+  });
+
   it('falls back to Cloudflare heuristics when the configured check name does not match', () => {
     const previewUrl = discoverPreviewUrl(buildRepo({ previewCheckName: 'Cloudflare Pages' }), [
       {

--- a/src/server/preview-discovery.ts
+++ b/src/server/preview-discovery.ts
@@ -1,6 +1,7 @@
 import type { Repo } from '../ui/domain/types';
+import { normalizeRepoPreviewConfig, resolvePreviewCheckName } from '../shared/preview';
 
-type GithubCheckRun = {
+export type PreviewDiscoveryCheckRun = {
   name?: string;
   details_url?: string;
   html_url?: string;
@@ -14,8 +15,8 @@ type GithubCheckRun = {
 
 type PreviewDiscoveryAdapter = {
   name: string;
-  supports: (repo: Repo, checkRun: GithubCheckRun) => boolean;
-  extractPreviewUrl: (repo: Repo, checkRun: GithubCheckRun) => { url?: string; source?: 'summary' | 'details_url' | 'html_url' };
+  supports: (repo: Repo, checkRun: PreviewDiscoveryCheckRun) => boolean;
+  extractPreviewUrl: (repo: Repo, checkRun: PreviewDiscoveryCheckRun) => { url?: string; source?: 'summary' | 'details_url' | 'html_url' };
 };
 
 export type PreviewDiscoveryResult = {
@@ -43,7 +44,9 @@ const adapters: PreviewDiscoveryAdapter[] = [
   {
     name: 'cloudflare',
     supports: (repo, checkRun) => {
-      return (repo.previewProvider === 'cloudflare' && checkRun.name === repo.previewCheckName)
+      const normalizedRepo = normalizeRepoPreviewConfig(repo);
+      const previewCheckName = resolvePreviewCheckName(normalizedRepo);
+      return (normalizedRepo.previewProvider === 'cloudflare' && checkRun.name === previewCheckName)
         || checkRun.app?.slug === 'cloudflare-workers-and-pages'
         || checkRun.name?.startsWith('Workers Builds:')
         || checkRun.details_url?.includes('dash.cloudflare.com')
@@ -68,23 +71,25 @@ const adapters: PreviewDiscoveryAdapter[] = [
   {
     name: 'generic-direct-url',
     supports: (repo, checkRun) => {
-      return checkRun.name === repo.previewCheckName || Boolean(firstDirectPreviewUrl(checkRun));
+      const previewCheckName = resolvePreviewCheckName(repo);
+      return checkRun.name === previewCheckName || Boolean(firstDirectPreviewUrl(checkRun));
     },
     extractPreviewUrl: (_repo, checkRun) => firstDirectPreviewUrl(checkRun)
   }
 ];
 
-export function discoverPreviewUrl(repo: Repo, checkRuns: GithubCheckRun[]) {
+export function discoverPreviewUrl(repo: Repo, checkRuns: PreviewDiscoveryCheckRun[]) {
   return inspectPreviewDiscovery(repo, checkRuns).previewUrl;
 }
 
-export function inspectPreviewDiscovery(repo: Repo, checkRuns: GithubCheckRun[]): PreviewDiscoveryResult {
-  const orderedCheckRuns = [...checkRuns].sort((left, right) => scoreCheckRun(repo, right) - scoreCheckRun(repo, left));
+export function inspectPreviewDiscovery(repo: Repo, checkRuns: PreviewDiscoveryCheckRun[]): PreviewDiscoveryResult {
+  const normalizedRepo = normalizeRepoPreviewConfig(repo);
+  const orderedCheckRuns = [...checkRuns].sort((left, right) => scoreCheckRun(normalizedRepo, right) - scoreCheckRun(normalizedRepo, left));
   const checks: PreviewDiscoveryResult['checks'] = [];
 
   for (const checkRun of orderedCheckRuns) {
-    const adapter = adapters.find((candidate) => candidate.supports(repo, checkRun));
-    const score = scoreCheckRun(repo, checkRun);
+    const adapter = adapters.find((candidate) => candidate.supports(normalizedRepo, checkRun));
+    const score = scoreCheckRun(normalizedRepo, checkRun);
     if (!adapter) {
       checks.push({
         name: checkRun.name,
@@ -117,10 +122,11 @@ export function inspectPreviewDiscovery(repo: Repo, checkRuns: GithubCheckRun[])
   return { checks };
 }
 
-function scoreCheckRun(repo: Repo, checkRun: GithubCheckRun) {
+function scoreCheckRun(repo: Repo, checkRun: PreviewDiscoveryCheckRun) {
   let score = 0;
+  const previewCheckName = resolvePreviewCheckName(repo);
 
-  if (repo.previewCheckName && checkRun.name === repo.previewCheckName) {
+  if (previewCheckName && checkRun.name === previewCheckName) {
     score += 100;
   }
 
@@ -139,7 +145,7 @@ function scoreCheckRun(repo: Repo, checkRun: GithubCheckRun) {
   return score;
 }
 
-function firstDirectPreviewUrl(checkRun: GithubCheckRun) {
+function firstDirectPreviewUrl(checkRun: PreviewDiscoveryCheckRun) {
   if (isPreviewUrl(checkRun.details_url)) {
     return { url: checkRun.details_url, source: 'details_url' as const };
   }

--- a/src/server/preview/adapter.ts
+++ b/src/server/preview/adapter.ts
@@ -1,0 +1,34 @@
+import type { Repo, Task, AgentRun, PreviewAdapterKind } from '../../ui/domain/types';
+import type { PreviewDiscoveryResult } from '../preview-discovery';
+
+export type PreviewCheck = {
+  name?: string;
+  detailsUrl?: string;
+  htmlUrl?: string;
+  summary?: string;
+  appSlug?: string;
+};
+
+export type PreviewResolution = {
+  previewUrl?: string;
+  adapter: PreviewAdapterKind;
+  explanation: string;
+  diagnostics: Array<Record<string, string | number | boolean>>;
+};
+
+export type PreviewAdapterContext = {
+  repo: Repo;
+  task?: Task;
+  run?: AgentRun;
+  checks: PreviewCheck[];
+};
+
+export type PreviewAdapterResult = {
+  resolution: PreviewResolution;
+  compatibility: PreviewDiscoveryResult;
+};
+
+export type PreviewAdapter = {
+  kind: PreviewAdapterKind;
+  resolve(context: PreviewAdapterContext): PreviewAdapterResult;
+};

--- a/src/server/preview/cloudflare-checks.ts
+++ b/src/server/preview/cloudflare-checks.ts
@@ -1,0 +1,40 @@
+import { inspectPreviewDiscovery } from '../preview-discovery';
+import { resolvePreviewCheckName } from '../../shared/preview';
+import type { PreviewAdapter } from './adapter';
+
+export const cloudflareChecksPreviewAdapter: PreviewAdapter = {
+  kind: 'cloudflare_checks',
+  resolve: ({ repo, checks }) => {
+    const compatibility = inspectPreviewDiscovery(
+      { ...repo, previewCheckName: resolvePreviewCheckName(repo) },
+      checks.map((check) => ({
+        name: check.name,
+        details_url: check.detailsUrl,
+        html_url: check.htmlUrl,
+        output: { summary: check.summary ?? null },
+        app: { slug: check.appSlug }
+      }))
+    );
+
+    const diagnostics = compatibility.checks.map((check) => ({
+      name: check.name ?? '(unnamed check)',
+      appSlug: check.appSlug ?? 'none',
+      score: check.score,
+      extracted: check.extracted,
+      matchedAdapter: check.matchedAdapter ?? 'none'
+    }));
+    const explanation = compatibility.previewUrl
+      ? `Preview discovery matched ${compatibility.matchedCheck ?? 'unknown check'} via ${compatibility.adapter ?? 'unknown adapter'} from ${compatibility.source ?? 'unknown source'}.`
+      : 'Preview discovery found no usable preview URL.';
+
+    return {
+      compatibility,
+      resolution: {
+        previewUrl: compatibility.previewUrl,
+        adapter: 'cloudflare_checks',
+        explanation,
+        diagnostics
+      }
+    };
+  }
+};

--- a/src/server/preview/registry.test.ts
+++ b/src/server/preview/registry.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { getPreviewAdapter, resolvePreviewAdapterKind } from './registry';
+import type { Repo } from '../../ui/domain/types';
+
+function buildRepo(overrides: Partial<Repo> = {}): Repo {
+  return {
+    repoId: 'repo_1',
+    slug: 'abuiles/minions-demo',
+    defaultBranch: 'main',
+    baselineUrl: 'https://example.com',
+    enabled: true,
+    createdAt: '2026-03-02T00:00:00.000Z',
+    updatedAt: '2026-03-02T00:00:00.000Z',
+    ...overrides
+  };
+}
+
+describe('preview registry compatibility', () => {
+  it('defaults to cloudflare checks in compatibility mode', () => {
+    expect(resolvePreviewAdapterKind(buildRepo())).toBe('cloudflare_checks');
+    expect(getPreviewAdapter(buildRepo()).kind).toBe('cloudflare_checks');
+  });
+
+  it('keeps cloudflare checks behavior while prompt recipe is not extracted yet', () => {
+    const repo = buildRepo({
+      previewAdapter: 'prompt_recipe',
+      previewConfig: { promptRecipe: 'derive preview URL from CI logs' }
+    });
+
+    expect(resolvePreviewAdapterKind(repo)).toBe('cloudflare_checks');
+    expect(getPreviewAdapter(repo).kind).toBe('cloudflare_checks');
+  });
+});

--- a/src/server/preview/registry.ts
+++ b/src/server/preview/registry.ts
@@ -1,0 +1,21 @@
+import type { Repo } from '../../ui/domain/types';
+import { resolvePreviewAdapterKind as resolvePreviewAdapterKindFromRepo } from '../../shared/preview';
+import type { PreviewAdapter } from './adapter';
+import { cloudflareChecksPreviewAdapter } from './cloudflare-checks';
+
+const PREVIEW_ADAPTERS: Record<'cloudflare_checks', PreviewAdapter> = {
+  cloudflare_checks: cloudflareChecksPreviewAdapter
+};
+
+export function resolvePreviewAdapterKind(repo: Repo): 'cloudflare_checks' {
+  const configured = resolvePreviewAdapterKindFromRepo(repo);
+  if (configured === 'prompt_recipe') {
+    return 'cloudflare_checks';
+  }
+
+  return 'cloudflare_checks';
+}
+
+export function getPreviewAdapter(repo: Repo): PreviewAdapter {
+  return PREVIEW_ADAPTERS[resolvePreviewAdapterKind(repo)];
+}

--- a/src/server/run-orchestrator.ts
+++ b/src/server/run-orchestrator.ts
@@ -4,7 +4,6 @@ import type { BoardIndexDO } from './durable/board-index';
 import type { Repo, RunCommand, RunCommandPhase, RunEvent, Task } from '../ui/domain/types';
 import { buildRunLog, type RunJobParams } from './shared/real-run';
 import { NonRetryableError } from 'cloudflare:workflows';
-import { inspectPreviewDiscovery } from './preview-discovery';
 import { buildWorkflowInvocationId } from './workflow-id';
 import { shouldRunEvidence, shouldRunPreview } from './shared/repo-execution-policy';
 import { getRepoHost } from '../shared/scm';
@@ -13,6 +12,7 @@ import type { ScmAdapter, ScmAdapterCredential } from './scm/adapter';
 import { getScmAdapter } from './scm/registry';
 import { getScmSourceRefFetchSpec } from './scm/source-ref';
 import { getLlmAdapter, resolveLlmAdapterKind } from './llm/registry';
+import { getPreviewAdapter } from './preview/registry';
 
 type WorkflowBinding<T> = {
   create(options?: { id?: string; params?: T; retention?: { successRetention?: string | number; errorRetention?: string | number } }): Promise<{ id: string }>;
@@ -369,7 +369,7 @@ async function waitForPreview(
   }
 
   for (let attempt = 1; attempt <= attempts; attempt += 1) {
-    const discovery = await lookupPreviewUrl(repo, headSha, scmAdapter, scmCredential, repo.previewCheckName);
+    const discovery = await lookupPreviewUrl(repo, headSha, scmAdapter, scmCredential);
     await repoBoard.appendRunLogs(runId, [
       buildRunLog(runId, `Preview discovery attempt ${attempt}/${attempts}.`, 'preview', 'info', { headSha }),
       buildRunLog(
@@ -453,20 +453,20 @@ async function lookupPreviewUrl(
   repo: Repo,
   headSha: string,
   scmAdapter: ScmAdapter,
-  scmCredential: ScmAdapterCredential,
-  previewCheckName?: string
+  scmCredential: ScmAdapterCredential
 ) {
   const checks = await scmAdapter.listCommitChecks(repo, headSha, scmCredential);
-  return inspectPreviewDiscovery(
-    { ...repo, previewCheckName },
-    checks.map((check) => ({
+  const previewAdapter = getPreviewAdapter(repo);
+  return previewAdapter.resolve({
+    repo,
+    checks: checks.map((check) => ({
       name: check.name,
-      details_url: check.detailsUrl,
-      html_url: check.htmlUrl,
-      output: { summary: check.summary ?? null },
-      app: { slug: check.appSlug }
+      detailsUrl: check.detailsUrl,
+      htmlUrl: check.htmlUrl,
+      summary: check.summary,
+      appSlug: check.appSlug
     }))
-  );
+  }).compatibility;
 }
 
 function formatPreviewDiscoveryLog(discovery: Awaited<ReturnType<typeof lookupPreviewUrl>>) {

--- a/src/shared/preview.test.ts
+++ b/src/shared/preview.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeRepoPreviewConfig, resolvePreviewAdapterKind, resolvePreviewCheckName } from './preview';
+import type { Repo } from '../ui/domain/types';
+
+describe('preview compatibility normalization', () => {
+  it('maps legacy preview provider/check name to preview adapter/config', () => {
+    const normalized = normalizeRepoPreviewConfig<Pick<Repo, 'previewAdapter' | 'previewConfig' | 'previewProvider' | 'previewCheckName'>>({
+      previewProvider: 'cloudflare',
+      previewCheckName: 'Workers Builds: minions'
+    });
+
+    expect(normalized.previewAdapter).toBe('cloudflare_checks');
+    expect(normalized.previewConfig).toEqual({ checkName: 'Workers Builds: minions' });
+    expect(resolvePreviewCheckName(normalized)).toBe('Workers Builds: minions');
+  });
+
+  it('preserves explicit preview adapter/config fields', () => {
+    const normalized = normalizeRepoPreviewConfig<Pick<Repo, 'previewAdapter' | 'previewConfig' | 'previewProvider' | 'previewCheckName'>>({
+      previewAdapter: 'prompt_recipe',
+      previewConfig: { promptRecipe: 'Find preview URL from deployment logs.' }
+    });
+
+    expect(normalized.previewAdapter).toBe('prompt_recipe');
+    expect(normalized.previewConfig).toEqual({ promptRecipe: 'Find preview URL from deployment logs.' });
+    expect(resolvePreviewAdapterKind(normalized)).toBe('prompt_recipe');
+  });
+});

--- a/src/shared/preview.ts
+++ b/src/shared/preview.ts
@@ -1,0 +1,33 @@
+import type { Repo } from '../ui/domain/types';
+
+export const DEFAULT_PREVIEW_ADAPTER: NonNullable<Repo['previewAdapter']> = 'cloudflare_checks';
+
+type RepoPreviewLike = Pick<Repo, 'previewAdapter' | 'previewConfig' | 'previewProvider' | 'previewCheckName'>;
+
+export function normalizeRepoPreviewConfig<T extends RepoPreviewLike>(repo: T): T {
+  const previewAdapter = repo.previewAdapter
+    ?? (repo.previewProvider === 'cloudflare' ? 'cloudflare_checks' : undefined)
+    ?? DEFAULT_PREVIEW_ADAPTER;
+  const checkName = repo.previewConfig?.checkName ?? repo.previewCheckName;
+  const promptRecipe = repo.previewConfig?.promptRecipe;
+  const previewConfig = checkName || promptRecipe
+    ? { ...(checkName ? { checkName } : {}), ...(promptRecipe ? { promptRecipe } : {}) }
+    : undefined;
+
+  return {
+    ...repo,
+    previewAdapter,
+    previewConfig,
+    previewProvider: repo.previewProvider ?? (previewAdapter === 'cloudflare_checks' ? 'cloudflare' : undefined),
+    previewCheckName: repo.previewCheckName ?? checkName
+  };
+}
+
+export function resolvePreviewAdapterKind(repo: RepoPreviewLike): NonNullable<Repo['previewAdapter']> {
+  return normalizeRepoPreviewConfig(repo).previewAdapter ?? DEFAULT_PREVIEW_ADAPTER;
+}
+
+export function resolvePreviewCheckName(repo: RepoPreviewLike): string | undefined {
+  const normalized = normalizeRepoPreviewConfig(repo);
+  return normalized.previewConfig?.checkName ?? normalized.previewCheckName;
+}

--- a/src/shared/scm.ts
+++ b/src/shared/scm.ts
@@ -1,4 +1,5 @@
 import type { AgentRun, Repo, ScmProvider, TaskBranchSource } from '../ui/domain/types';
+import { normalizeRepoPreviewConfig } from './preview';
 
 export const SCM_PROVIDERS = new Set(['github', 'gitlab'] as const);
 
@@ -53,13 +54,13 @@ export function normalizeRepo(repo: RepoScmLike & Omit<Repo, 'slug' | 'scmProvid
     throw new Error('Repo project path is required.');
   }
 
-  return {
+  return normalizeRepoPreviewConfig({
     ...repo,
     slug: projectPath,
     scmProvider,
     scmBaseUrl: normalizeScmBaseUrl(scmProvider, repo.scmBaseUrl),
     projectPath
-  };
+  });
 }
 
 export function getRepoScmProvider(repo: RepoScmLike): ScmProvider {

--- a/src/ui/domain/api.ts
+++ b/src/ui/domain/api.ts
@@ -27,6 +27,8 @@ export type CreateRepoInput = {
   enabled?: boolean;
   previewMode?: Repo['previewMode'];
   evidenceMode?: Repo['evidenceMode'];
+  previewAdapter?: Repo['previewAdapter'];
+  previewConfig?: Repo['previewConfig'];
   previewProvider?: Repo['previewProvider'];
   previewCheckName?: string;
   codexAuthBundleR2Key?: string;

--- a/src/ui/domain/types.ts
+++ b/src/ui/domain/types.ts
@@ -20,6 +20,11 @@ export type LlmAdapter = 'codex' | 'cursor_cli';
 export type LlmReasoningEffort = 'low' | 'medium' | 'high';
 export type ScmProvider = 'github' | 'gitlab';
 export type ReviewProvider = ScmProvider;
+export type PreviewAdapterKind = 'cloudflare_checks' | 'prompt_recipe';
+export type RepoPreviewConfig = {
+  checkName?: string;
+  promptRecipe?: string;
+};
 
 export type RunEventType =
   | 'run.status_changed'
@@ -46,6 +51,8 @@ export type Repo = {
   githubAuthMode?: 'kv_pat';
   previewMode?: 'auto' | 'skip';
   evidenceMode?: 'auto' | 'skip';
+  previewAdapter?: PreviewAdapterKind;
+  previewConfig?: RepoPreviewConfig;
   previewProvider?: 'cloudflare';
   previewCheckName?: string;
   previewUrlPattern?: string;

--- a/src/ui/mock/local-agent-board-api.ts
+++ b/src/ui/mock/local-agent-board-api.ts
@@ -45,6 +45,8 @@ export class LocalAgentBoardApi implements AgentBoardApi {
       enabled: input.enabled ?? true,
       previewMode: input.previewMode ?? 'auto',
       evidenceMode: input.evidenceMode ?? 'auto',
+      previewAdapter: input.previewAdapter,
+      previewConfig: input.previewConfig,
       previewProvider: input.previewProvider ?? 'cloudflare',
       previewCheckName: input.previewCheckName,
       codexAuthBundleR2Key: input.codexAuthBundleR2Key,


### PR DESCRIPTION
Task: S35-P1 Preview adapter types, registry, and legacy config mapping

Introduce the preview adapter seam and normalize preview repo config without changing preview behavior yet.


Acceptance criteria:
- Generic preview adapter types and registry exist.
- Repo validation/storage can represent previewAdapter and previewConfig.
- Legacy preview fields map cleanly to the new config shape.
- No current preview behavior regresses during the seam introduction.

Run ID: run_repo_abuiles_minions_mm9dfi1ei6ae