### PR TITLE
S35-P2 Extract current Cloudflare preview logic into a preview adapter

### DIFF
--- a/src/server/preview-discovery.ts
+++ b/src/server/preview-discovery.ts
@@ -1,5 +1,6 @@
 import type { Repo } from '../ui/domain/types';
-import { normalizeRepoPreviewConfig, resolvePreviewCheckName } from '../shared/preview';
+import type { PreviewDiscoveryResult } from './preview/adapter';
+import { discoverCloudflarePreviewUrl, inspectCloudflarePreviewDiscovery } from './preview/cloudflare-checks';
 
 export type PreviewDiscoveryCheckRun = {
   name?: string;
@@ -13,150 +14,20 @@ export type PreviewDiscoveryCheckRun = {
   };
 };
 
-type PreviewDiscoveryAdapter = {
-  name: string;
-  supports: (repo: Repo, checkRun: PreviewDiscoveryCheckRun) => boolean;
-  extractPreviewUrl: (repo: Repo, checkRun: PreviewDiscoveryCheckRun) => { url?: string; source?: 'summary' | 'details_url' | 'html_url' };
-};
-
-export type PreviewDiscoveryResult = {
-  previewUrl?: string;
-  adapter?: string;
-  source?: 'summary' | 'details_url' | 'html_url';
-  matchedCheck?: string;
-  checks: Array<{
-    name?: string;
-    appSlug?: string;
-    score: number;
-    matchedAdapter?: string;
-    extracted: boolean;
-  }>;
-};
-
-const URL_LABEL_PATTERNS = [
-  /Preview Alias URL:\s*(https:\/\/[^\s]+)/i,
-  /Branch Preview URL:\s*(https:\/\/[^\s]+)/i,
-  /Preview URL:\s*(https:\/\/[^\s]+)/i,
-  /Commit Preview URL:\s*(https:\/\/[^\s]+)/i
-];
-
-const adapters: PreviewDiscoveryAdapter[] = [
-  {
-    name: 'cloudflare',
-    supports: (repo, checkRun) => {
-      const normalizedRepo = normalizeRepoPreviewConfig(repo);
-      const previewCheckName = resolvePreviewCheckName(normalizedRepo);
-      return (normalizedRepo.previewProvider === 'cloudflare' && checkRun.name === previewCheckName)
-        || checkRun.app?.slug === 'cloudflare-workers-and-pages'
-        || checkRun.name?.startsWith('Workers Builds:')
-        || checkRun.details_url?.includes('dash.cloudflare.com')
-        || checkRun.output?.summary?.includes('Preview URL:')
-        || checkRun.output?.summary?.includes('Preview Alias URL:')
-        || false;
-    },
-    extractPreviewUrl: (_repo, checkRun) => {
-      const summary = checkRun.output?.summary;
-      if (summary) {
-        for (const pattern of URL_LABEL_PATTERNS) {
-          const match = summary.match(pattern);
-          if (match?.[1]) {
-            return { url: match[1], source: 'summary' };
-          }
-        }
-      }
-
-      return firstDirectPreviewUrl(checkRun);
-    }
-  },
-  {
-    name: 'generic-direct-url',
-    supports: (repo, checkRun) => {
-      const previewCheckName = resolvePreviewCheckName(repo);
-      return checkRun.name === previewCheckName || Boolean(firstDirectPreviewUrl(checkRun));
-    },
-    extractPreviewUrl: (_repo, checkRun) => firstDirectPreviewUrl(checkRun)
-  }
-];
-
 export function discoverPreviewUrl(repo: Repo, checkRuns: PreviewDiscoveryCheckRun[]) {
-  return inspectPreviewDiscovery(repo, checkRuns).previewUrl;
+  return discoverCloudflarePreviewUrl(repo, mapCheckRuns(checkRuns));
 }
 
 export function inspectPreviewDiscovery(repo: Repo, checkRuns: PreviewDiscoveryCheckRun[]): PreviewDiscoveryResult {
-  const normalizedRepo = normalizeRepoPreviewConfig(repo);
-  const orderedCheckRuns = [...checkRuns].sort((left, right) => scoreCheckRun(normalizedRepo, right) - scoreCheckRun(normalizedRepo, left));
-  const checks: PreviewDiscoveryResult['checks'] = [];
-
-  for (const checkRun of orderedCheckRuns) {
-    const adapter = adapters.find((candidate) => candidate.supports(normalizedRepo, checkRun));
-    const score = scoreCheckRun(normalizedRepo, checkRun);
-    if (!adapter) {
-      checks.push({
-        name: checkRun.name,
-        appSlug: checkRun.app?.slug,
-        score,
-        extracted: false
-      });
-      continue;
-    }
-
-    const extraction = adapter.extractPreviewUrl(repo, checkRun);
-    checks.push({
-      name: checkRun.name,
-      appSlug: checkRun.app?.slug,
-      score,
-      matchedAdapter: adapter.name,
-      extracted: Boolean(extraction.url)
-    });
-    if (extraction.url) {
-      return {
-        previewUrl: extraction.url,
-        adapter: adapter.name,
-        source: extraction.source,
-        matchedCheck: checkRun.name,
-        checks
-      };
-    }
-  }
-
-  return { checks };
+  return inspectCloudflarePreviewDiscovery(repo, mapCheckRuns(checkRuns));
 }
 
-function scoreCheckRun(repo: Repo, checkRun: PreviewDiscoveryCheckRun) {
-  let score = 0;
-  const previewCheckName = resolvePreviewCheckName(repo);
-
-  if (previewCheckName && checkRun.name === previewCheckName) {
-    score += 100;
-  }
-
-  if (checkRun.app?.slug === 'cloudflare-workers-and-pages') {
-    score += 20;
-  }
-
-  if (checkRun.name?.startsWith('Workers Builds:')) {
-    score += 10;
-  }
-
-  if (checkRun.output?.summary?.includes('Preview URL:') || checkRun.output?.summary?.includes('Preview Alias URL:')) {
-    score += 5;
-  }
-
-  return score;
-}
-
-function firstDirectPreviewUrl(checkRun: PreviewDiscoveryCheckRun) {
-  if (isPreviewUrl(checkRun.details_url)) {
-    return { url: checkRun.details_url, source: 'details_url' as const };
-  }
-
-  if (isPreviewUrl(checkRun.html_url)) {
-    return { url: checkRun.html_url, source: 'html_url' as const };
-  }
-
-  return {};
-}
-
-function isPreviewUrl(value?: string) {
-  return Boolean(value && (value.includes('.pages.dev') || value.includes('.workers.dev')));
+function mapCheckRuns(checkRuns: PreviewDiscoveryCheckRun[]) {
+  return checkRuns.map((check) => ({
+    name: check.name,
+    detailsUrl: check.details_url,
+    htmlUrl: check.html_url,
+    summary: check.output?.summary ?? undefined,
+    appSlug: check.app?.slug
+  }));
 }

--- a/src/server/preview/adapter.ts
+++ b/src/server/preview/adapter.ts
@@ -1,5 +1,4 @@
 import type { Repo, Task, AgentRun, PreviewAdapterKind } from '../../ui/domain/types';
-import type { PreviewDiscoveryResult } from '../preview-discovery';
 
 export type PreviewCheck = {
   name?: string;
@@ -7,6 +6,22 @@ export type PreviewCheck = {
   htmlUrl?: string;
   summary?: string;
   appSlug?: string;
+};
+
+export type PreviewDiscoverySource = 'summary' | 'details_url' | 'html_url';
+
+export type PreviewDiscoveryResult = {
+  previewUrl?: string;
+  adapter?: string;
+  source?: PreviewDiscoverySource;
+  matchedCheck?: string;
+  checks: Array<{
+    name?: string;
+    appSlug?: string;
+    score: number;
+    matchedAdapter?: string;
+    extracted: boolean;
+  }>;
 };
 
 export type PreviewResolution = {

--- a/src/server/preview/cloudflare-checks.ts
+++ b/src/server/preview/cloudflare-checks.ts
@@ -1,20 +1,58 @@
-import { inspectPreviewDiscovery } from '../preview-discovery';
-import { resolvePreviewCheckName } from '../../shared/preview';
-import type { PreviewAdapter } from './adapter';
+import { normalizeRepoPreviewConfig, resolvePreviewCheckName } from '../../shared/preview';
+import type { PreviewAdapter, PreviewCheck, PreviewDiscoveryResult } from './adapter';
+
+const URL_LABEL_PATTERNS = [
+  /Preview Alias URL:\s*(https:\/\/[^\s]+)/i,
+  /Branch Preview URL:\s*(https:\/\/[^\s]+)/i,
+  /Preview URL:\s*(https:\/\/[^\s]+)/i,
+  /Commit Preview URL:\s*(https:\/\/[^\s]+)/i
+];
+
+type PreviewDiscoveryAdapter = {
+  name: string;
+  supports: (repo: Parameters<typeof normalizeRepoPreviewConfig>[0], check: PreviewCheck) => boolean;
+  extractPreviewUrl: (repo: Parameters<typeof normalizeRepoPreviewConfig>[0], check: PreviewCheck) => { url?: string; source?: PreviewDiscoveryResult['source'] };
+};
+
+const adapters: PreviewDiscoveryAdapter[] = [
+  {
+    name: 'cloudflare',
+    supports: (repo, check) => {
+      const previewCheckName = resolvePreviewCheckName(repo);
+      return (repo.previewProvider === 'cloudflare' && check.name === previewCheckName)
+        || check.appSlug === 'cloudflare-workers-and-pages'
+        || check.name?.startsWith('Workers Builds:')
+        || check.detailsUrl?.includes('dash.cloudflare.com')
+        || check.summary?.includes('Preview URL:')
+        || check.summary?.includes('Preview Alias URL:')
+        || false;
+    },
+    extractPreviewUrl: (_repo, check) => {
+      if (check.summary) {
+        for (const pattern of URL_LABEL_PATTERNS) {
+          const match = check.summary.match(pattern);
+          if (match?.[1]) {
+            return { url: match[1], source: 'summary' };
+          }
+        }
+      }
+      return firstDirectPreviewUrl(check);
+    }
+  },
+  {
+    name: 'generic-direct-url',
+    supports: (repo, check) => {
+      const previewCheckName = resolvePreviewCheckName(repo);
+      return check.name === previewCheckName || Boolean(firstDirectPreviewUrl(check));
+    },
+    extractPreviewUrl: (_repo, check) => firstDirectPreviewUrl(check)
+  }
+];
 
 export const cloudflareChecksPreviewAdapter: PreviewAdapter = {
   kind: 'cloudflare_checks',
   resolve: ({ repo, checks }) => {
-    const compatibility = inspectPreviewDiscovery(
-      { ...repo, previewCheckName: resolvePreviewCheckName(repo) },
-      checks.map((check) => ({
-        name: check.name,
-        details_url: check.detailsUrl,
-        html_url: check.htmlUrl,
-        output: { summary: check.summary ?? null },
-        app: { slug: check.appSlug }
-      }))
-    );
+    const compatibility = inspectCloudflarePreviewDiscovery(repo, checks);
 
     const diagnostics = compatibility.checks.map((check) => ({
       name: check.name ?? '(unnamed check)',
@@ -38,3 +76,92 @@ export const cloudflareChecksPreviewAdapter: PreviewAdapter = {
     };
   }
 };
+
+export function inspectCloudflarePreviewDiscovery(
+  repo: Parameters<typeof normalizeRepoPreviewConfig>[0],
+  checks: PreviewCheck[]
+): PreviewDiscoveryResult {
+  const normalizedRepo = normalizeRepoPreviewConfig(repo);
+  const orderedChecks = [...checks].sort((left, right) => scoreCheckRun(normalizedRepo, right) - scoreCheckRun(normalizedRepo, left));
+  const compatibilityChecks: PreviewDiscoveryResult['checks'] = [];
+
+  for (const check of orderedChecks) {
+    const adapter = adapters.find((candidate) => candidate.supports(normalizedRepo, check));
+    const score = scoreCheckRun(normalizedRepo, check);
+    if (!adapter) {
+      compatibilityChecks.push({
+        name: check.name,
+        appSlug: check.appSlug,
+        score,
+        extracted: false
+      });
+      continue;
+    }
+
+    const extraction = adapter.extractPreviewUrl(normalizedRepo, check);
+    compatibilityChecks.push({
+      name: check.name,
+      appSlug: check.appSlug,
+      score,
+      matchedAdapter: adapter.name,
+      extracted: Boolean(extraction.url)
+    });
+    if (extraction.url) {
+      return {
+        previewUrl: extraction.url,
+        adapter: adapter.name,
+        source: extraction.source,
+        matchedCheck: check.name,
+        checks: compatibilityChecks
+      };
+    }
+  }
+
+  return { checks: compatibilityChecks };
+}
+
+export function discoverCloudflarePreviewUrl(
+  repo: Parameters<typeof normalizeRepoPreviewConfig>[0],
+  checks: PreviewCheck[]
+) {
+  return inspectCloudflarePreviewDiscovery(repo, checks).previewUrl;
+}
+
+function scoreCheckRun(repo: Parameters<typeof normalizeRepoPreviewConfig>[0], check: PreviewCheck) {
+  let score = 0;
+  const previewCheckName = resolvePreviewCheckName(repo);
+
+  if (previewCheckName && check.name === previewCheckName) {
+    score += 100;
+  }
+
+  if (check.appSlug === 'cloudflare-workers-and-pages') {
+    score += 20;
+  }
+
+  if (check.name?.startsWith('Workers Builds:')) {
+    score += 10;
+  }
+
+  if (check.summary?.includes('Preview URL:') || check.summary?.includes('Preview Alias URL:')) {
+    score += 5;
+  }
+
+  return score;
+}
+
+function firstDirectPreviewUrl(check: PreviewCheck) {
+  if (isPreviewUrl(check.detailsUrl)) {
+    return { url: check.detailsUrl, source: 'details_url' as const };
+  }
+
+  if (isPreviewUrl(check.htmlUrl)) {
+    return { url: check.htmlUrl, source: 'html_url' as const };
+  }
+
+  return {};
+}
+
+function isPreviewUrl(value?: string) {
+  return Boolean(value && (value.includes('.pages.dev') || value.includes('.workers.dev')));
+}


### PR DESCRIPTION
Task: S35-P2 Extract current Cloudflare preview logic into a preview adapter

Move the existing Cloudflare preview-discovery heuristics behind the generic preview adapter seam without changing behavior.


Acceptance criteria:
- Current Cloudflare preview discovery logic lives behind a preview adapter rather than directly in the orchestrator.
- Existing GitHub + Cloudflare behavior remains unchanged.
- The orchestrator resolves preview work through the preview registry.
- No prompt-recipe behavior is added yet.

Run ID: run_repo_abuiles_minions_mm9dptkf569s