### PR TITLE
S35-P3/4 Normalize preview discovery and define prompt-recipe contract

### DIFF
--- a/src/server/durable/board-index.ts
+++ b/src/server/durable/board-index.ts
@@ -278,8 +278,6 @@ function buildRepoRecord(input: CreateRepoInput | Repo): Repo {
     previewProvider: 'previewProvider' in input ? input.previewProvider : undefined,
     previewCheckName: input.previewCheckName,
     previewUrlPattern: 'previewUrlPattern' in input ? input.previewUrlPattern : undefined,
-    llmAdapter: input.llmAdapter,
-    llmProfileId: input.llmProfileId,
     llmAuthBundleR2Key: input.llmAuthBundleR2Key ?? input.codexAuthBundleR2Key,
     codexAuthBundleR2Key: input.codexAuthBundleR2Key ?? input.llmAuthBundleR2Key,
     createdAt: 'createdAt' in input ? input.createdAt : '',

--- a/src/server/preview-discovery.test.ts
+++ b/src/server/preview-discovery.test.ts
@@ -21,16 +21,15 @@ describe('discoverPreviewUrl', () => {
     const previewUrl = discoverPreviewUrl(buildRepo(), [
       {
         name: 'Workers Builds: minions-demo',
-        app: { slug: 'cloudflare-workers-and-pages' },
-        details_url: 'https://dash.cloudflare.com/account/workers/services/view/minions-demo/builds/abc123',
-        html_url: 'https://github.com/abuiles/minions-demo/runs/123',
-        output: {
-          summary: `
+        appSlug: 'cloudflare-workers-and-pages',
+        detailsUrl: 'https://dash.cloudflare.com/account/workers/services/view/minions-demo/builds/abc123',
+        htmlUrl: 'https://github.com/abuiles/minions-demo/runs/123',
+        summary: `
 Build ID: [abc123](https://dash.cloudflare.com/account/workers/services/view/minions-demo/builds/abc123)
 Preview URL: https://b537c13e-minions-demo.abuiles.workers.dev
 Preview Alias URL: https://abuiles-patch-1-minions-demo.abuiles.workers.dev
-`
-        }
+`,
+        rawSource: 'github_check_run'
       }
     ]);
 
@@ -41,14 +40,14 @@ Preview Alias URL: https://abuiles-patch-1-minions-demo.abuiles.workers.dev
     const previewUrl = discoverPreviewUrl(buildRepo({ previewCheckName: 'Workers Builds: minions-demo' }), [
       {
         name: 'Unrelated check',
-        details_url: 'https://unrelated.example.com'
+        detailsUrl: 'https://unrelated.example.com',
+        rawSource: 'github_check_run'
       },
       {
         name: 'Workers Builds: minions-demo',
-        app: { slug: 'cloudflare-workers-and-pages' },
-        output: {
-          summary: 'Preview URL: https://commit-minions-demo.abuiles.workers.dev'
-        }
+        appSlug: 'cloudflare-workers-and-pages',
+        summary: 'Preview URL: https://commit-minions-demo.abuiles.workers.dev',
+        rawSource: 'github_check_run'
       }
     ]);
 
@@ -63,10 +62,9 @@ Preview Alias URL: https://abuiles-patch-1-minions-demo.abuiles.workers.dev
     }), [
       {
         name: 'Workers Builds: minions-demo',
-        app: { slug: 'cloudflare-workers-and-pages' },
-        output: {
-          summary: 'Preview URL: https://commit-minions-demo.abuiles.workers.dev'
-        }
+        appSlug: 'cloudflare-workers-and-pages',
+        summary: 'Preview URL: https://commit-minions-demo.abuiles.workers.dev',
+        rawSource: 'github_check_run'
       }
     ]);
 
@@ -77,11 +75,10 @@ Preview Alias URL: https://abuiles-patch-1-minions-demo.abuiles.workers.dev
     const previewUrl = discoverPreviewUrl(buildRepo({ previewCheckName: 'Cloudflare Pages' }), [
       {
         name: 'Workers Builds: minions-demo',
-        app: { slug: 'cloudflare-workers-and-pages' },
-        details_url: 'https://dash.cloudflare.com/account/workers/services/view/minions-demo/builds/abc123',
-        output: {
-          summary: 'Preview Alias URL: https://abuiles-patch-1-minions-demo.abuiles.workers.dev'
-        }
+        appSlug: 'cloudflare-workers-and-pages',
+        detailsUrl: 'https://dash.cloudflare.com/account/workers/services/view/minions-demo/builds/abc123',
+        summary: 'Preview Alias URL: https://abuiles-patch-1-minions-demo.abuiles.workers.dev',
+        rawSource: 'github_check_run'
       }
     ]);
 
@@ -92,11 +89,10 @@ Preview Alias URL: https://abuiles-patch-1-minions-demo.abuiles.workers.dev
     const previewUrl = discoverPreviewUrl(buildRepo({ previewProvider: undefined, previewCheckName: undefined }), [
       {
         name: 'Workers Builds: minions-demo',
-        app: { slug: 'cloudflare-workers-and-pages' },
-        details_url: 'https://dash.cloudflare.com/account/workers/services/view/minions-demo/builds/abc123',
-        output: {
-          summary: 'Preview Alias URL: https://abuiles-patch-1-minions-demo.abuiles.workers.dev'
-        }
+        appSlug: 'cloudflare-workers-and-pages',
+        detailsUrl: 'https://dash.cloudflare.com/account/workers/services/view/minions-demo/builds/abc123',
+        summary: 'Preview Alias URL: https://abuiles-patch-1-minions-demo.abuiles.workers.dev',
+        rawSource: 'github_check_run'
       }
     ]);
 
@@ -107,21 +103,50 @@ Preview Alias URL: https://abuiles-patch-1-minions-demo.abuiles.workers.dev
     const previewUrl = discoverPreviewUrl(buildRepo({ previewProvider: undefined, previewCheckName: undefined }), [
       {
         name: 'Deploy Preview',
-        details_url: 'https://deploy-preview-42.pages.dev'
+        detailsUrl: 'https://deploy-preview-42.pages.dev',
+        rawSource: 'github_check_run'
       }
     ]);
 
     expect(previewUrl).toBe('https://deploy-preview-42.pages.dev');
   });
 
+  it('extracts previews from normalized GitLab status checks', () => {
+    const previewUrl = discoverPreviewUrl(buildRepo({
+      scmProvider: 'gitlab',
+      scmBaseUrl: 'https://gitlab.example.com',
+      projectPath: 'group/minions-demo',
+      previewCheckName: 'workers-preview'
+    }), [
+      {
+        name: 'pipeline',
+        detailsUrl: 'https://gitlab.example.com/group/minions-demo/-/pipelines/9',
+        htmlUrl: 'https://gitlab.example.com/group/minions-demo/-/pipelines/9',
+        summary: 'ref feature/minions',
+        status: 'completed',
+        conclusion: 'success',
+        rawSource: 'gitlab_pipeline'
+      },
+      {
+        name: 'workers-preview',
+        detailsUrl: 'https://preview-minions-demo.abuiles.workers.dev',
+        htmlUrl: 'https://preview-minions-demo.abuiles.workers.dev',
+        summary: 'Preview URL: https://preview-minions-demo.abuiles.workers.dev',
+        status: 'in_progress',
+        rawSource: 'gitlab_status'
+      }
+    ]);
+
+    expect(previewUrl).toBe('https://preview-minions-demo.abuiles.workers.dev');
+  });
+
   it('returns debug metadata for inspected checks', () => {
     const result = inspectPreviewDiscovery(buildRepo({ previewCheckName: 'Cloudflare Pages' }), [
       {
         name: 'Workers Builds: minions-demo',
-        app: { slug: 'cloudflare-workers-and-pages' },
-        output: {
-          summary: 'Preview Alias URL: https://abuiles-patch-1-minions-demo.abuiles.workers.dev'
-        }
+        appSlug: 'cloudflare-workers-and-pages',
+        summary: 'Preview Alias URL: https://abuiles-patch-1-minions-demo.abuiles.workers.dev',
+        rawSource: 'github_check_run'
       }
     ]);
 
@@ -132,6 +157,7 @@ Preview Alias URL: https://abuiles-patch-1-minions-demo.abuiles.workers.dev
       {
         name: 'Workers Builds: minions-demo',
         appSlug: 'cloudflare-workers-and-pages',
+        rawSource: 'github_check_run',
         score: 35,
         matchedAdapter: 'cloudflare',
         extracted: true

--- a/src/server/preview-discovery.ts
+++ b/src/server/preview-discovery.ts
@@ -1,33 +1,12 @@
 import type { Repo } from '../ui/domain/types';
+import type { ScmCommitCheck } from './scm/adapter';
 import type { PreviewDiscoveryResult } from './preview/adapter';
 import { discoverCloudflarePreviewUrl, inspectCloudflarePreviewDiscovery } from './preview/cloudflare-checks';
 
-export type PreviewDiscoveryCheckRun = {
-  name?: string;
-  details_url?: string;
-  html_url?: string;
-  output?: {
-    summary?: string | null;
-  };
-  app?: {
-    slug?: string;
-  };
-};
-
-export function discoverPreviewUrl(repo: Repo, checkRuns: PreviewDiscoveryCheckRun[]) {
-  return discoverCloudflarePreviewUrl(repo, mapCheckRuns(checkRuns));
+export function discoverPreviewUrl(repo: Repo, checks: ScmCommitCheck[]) {
+  return discoverCloudflarePreviewUrl(repo, checks);
 }
 
-export function inspectPreviewDiscovery(repo: Repo, checkRuns: PreviewDiscoveryCheckRun[]): PreviewDiscoveryResult {
-  return inspectCloudflarePreviewDiscovery(repo, mapCheckRuns(checkRuns));
-}
-
-function mapCheckRuns(checkRuns: PreviewDiscoveryCheckRun[]) {
-  return checkRuns.map((check) => ({
-    name: check.name,
-    detailsUrl: check.details_url,
-    htmlUrl: check.html_url,
-    summary: check.output?.summary ?? undefined,
-    appSlug: check.app?.slug
-  }));
+export function inspectPreviewDiscovery(repo: Repo, checks: ScmCommitCheck[]): PreviewDiscoveryResult {
+  return inspectCloudflarePreviewDiscovery(repo, checks);
 }

--- a/src/server/preview/adapter.ts
+++ b/src/server/preview/adapter.ts
@@ -1,14 +1,14 @@
 import type { Repo, Task, AgentRun, PreviewAdapterKind } from '../../ui/domain/types';
-
-export type PreviewCheck = {
-  name?: string;
-  detailsUrl?: string;
-  htmlUrl?: string;
-  summary?: string;
-  appSlug?: string;
-};
+import type { ScmCommitCheck } from '../scm/adapter';
 
 export type PreviewDiscoverySource = 'summary' | 'details_url' | 'html_url';
+
+export type PreviewDiagnostic = {
+  code: string;
+  level: 'info' | 'error';
+  message: string;
+  metadata?: Record<string, string | number | boolean>;
+};
 
 export type PreviewDiscoveryResult = {
   previewUrl?: string;
@@ -18,6 +18,9 @@ export type PreviewDiscoveryResult = {
   checks: Array<{
     name?: string;
     appSlug?: string;
+    rawSource?: ScmCommitCheck['rawSource'];
+    status?: ScmCommitCheck['status'];
+    conclusion?: ScmCommitCheck['conclusion'];
     score: number;
     matchedAdapter?: string;
     extracted: boolean;
@@ -25,17 +28,18 @@ export type PreviewDiscoveryResult = {
 };
 
 export type PreviewResolution = {
+  status: 'ready' | 'pending' | 'failed' | 'timed_out';
   previewUrl?: string;
   adapter: PreviewAdapterKind;
   explanation: string;
-  diagnostics: Array<Record<string, string | number | boolean>>;
+  diagnostics: PreviewDiagnostic[];
 };
 
 export type PreviewAdapterContext = {
   repo: Repo;
   task?: Task;
   run?: AgentRun;
-  checks: PreviewCheck[];
+  checks: ScmCommitCheck[];
 };
 
 export type PreviewAdapterResult = {

--- a/src/server/preview/cloudflare-checks.ts
+++ b/src/server/preview/cloudflare-checks.ts
@@ -1,5 +1,6 @@
 import { normalizeRepoPreviewConfig, resolvePreviewCheckName } from '../../shared/preview';
-import type { PreviewAdapter, PreviewCheck, PreviewDiscoveryResult } from './adapter';
+import type { ScmCommitCheck } from '../scm/adapter';
+import type { PreviewAdapter, PreviewDiscoveryResult } from './adapter';
 
 const URL_LABEL_PATTERNS = [
   /Preview Alias URL:\s*(https:\/\/[^\s]+)/i,
@@ -10,8 +11,8 @@ const URL_LABEL_PATTERNS = [
 
 type PreviewDiscoveryAdapter = {
   name: string;
-  supports: (repo: Parameters<typeof normalizeRepoPreviewConfig>[0], check: PreviewCheck) => boolean;
-  extractPreviewUrl: (repo: Parameters<typeof normalizeRepoPreviewConfig>[0], check: PreviewCheck) => { url?: string; source?: PreviewDiscoveryResult['source'] };
+  supports: (repo: Parameters<typeof normalizeRepoPreviewConfig>[0], check: ScmCommitCheck) => boolean;
+  extractPreviewUrl: (repo: Parameters<typeof normalizeRepoPreviewConfig>[0], check: ScmCommitCheck) => { url?: string; source?: PreviewDiscoveryResult['source'] };
 };
 
 const adapters: PreviewDiscoveryAdapter[] = [
@@ -68,10 +69,18 @@ export const cloudflareChecksPreviewAdapter: PreviewAdapter = {
     return {
       compatibility,
       resolution: {
+        status: compatibility.previewUrl ? 'ready' : 'pending',
         previewUrl: compatibility.previewUrl,
         adapter: 'cloudflare_checks',
         explanation,
-        diagnostics
+        diagnostics: diagnostics.map((diagnostic) => ({
+          code: diagnostic.extracted ? 'CLOUDFLARE_CHECK_MATCHED' : 'CLOUDFLARE_CHECK_SCANNED',
+          level: diagnostic.extracted ? 'info' : 'error',
+          message: diagnostic.extracted
+            ? `Discovered preview URL from ${diagnostic.name}.`
+            : `Scanned ${diagnostic.name} but found no preview URL.`,
+          metadata: diagnostic
+        }))
       }
     };
   }
@@ -79,7 +88,7 @@ export const cloudflareChecksPreviewAdapter: PreviewAdapter = {
 
 export function inspectCloudflarePreviewDiscovery(
   repo: Parameters<typeof normalizeRepoPreviewConfig>[0],
-  checks: PreviewCheck[]
+  checks: ScmCommitCheck[]
 ): PreviewDiscoveryResult {
   const normalizedRepo = normalizeRepoPreviewConfig(repo);
   const orderedChecks = [...checks].sort((left, right) => scoreCheckRun(normalizedRepo, right) - scoreCheckRun(normalizedRepo, left));
@@ -92,6 +101,9 @@ export function inspectCloudflarePreviewDiscovery(
       compatibilityChecks.push({
         name: check.name,
         appSlug: check.appSlug,
+        rawSource: check.rawSource,
+        status: check.status,
+        conclusion: check.conclusion,
         score,
         extracted: false
       });
@@ -102,6 +114,9 @@ export function inspectCloudflarePreviewDiscovery(
     compatibilityChecks.push({
       name: check.name,
       appSlug: check.appSlug,
+      rawSource: check.rawSource,
+      status: check.status,
+      conclusion: check.conclusion,
       score,
       matchedAdapter: adapter.name,
       extracted: Boolean(extraction.url)
@@ -122,12 +137,12 @@ export function inspectCloudflarePreviewDiscovery(
 
 export function discoverCloudflarePreviewUrl(
   repo: Parameters<typeof normalizeRepoPreviewConfig>[0],
-  checks: PreviewCheck[]
+  checks: ScmCommitCheck[]
 ) {
   return inspectCloudflarePreviewDiscovery(repo, checks).previewUrl;
 }
 
-function scoreCheckRun(repo: Parameters<typeof normalizeRepoPreviewConfig>[0], check: PreviewCheck) {
+function scoreCheckRun(repo: Parameters<typeof normalizeRepoPreviewConfig>[0], check: ScmCommitCheck) {
   let score = 0;
   const previewCheckName = resolvePreviewCheckName(repo);
 
@@ -150,7 +165,7 @@ function scoreCheckRun(repo: Parameters<typeof normalizeRepoPreviewConfig>[0], c
   return score;
 }
 
-function firstDirectPreviewUrl(check: PreviewCheck) {
+function firstDirectPreviewUrl(check: ScmCommitCheck) {
   if (isPreviewUrl(check.detailsUrl)) {
     return { url: check.detailsUrl, source: 'details_url' as const };
   }

--- a/src/server/preview/prompt-recipe.test.ts
+++ b/src/server/preview/prompt-recipe.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, it } from 'vitest';
+import {
+  PROMPT_RECIPE_PREVIEW_TIMEOUT_MS,
+  inspectPromptRecipeConfiguration,
+  resolvePromptRecipeExecution,
+  validatePromptRecipePreviewOutput
+} from './prompt-recipe';
+import type { Repo } from '../../ui/domain/types';
+
+function buildRepo(overrides: Partial<Repo> = {}): Repo {
+  return {
+    repoId: 'repo_1',
+    slug: 'abuiles/minions-demo',
+    defaultBranch: 'main',
+    baselineUrl: 'https://example.com',
+    enabled: true,
+    createdAt: '2026-03-02T00:00:00.000Z',
+    updatedAt: '2026-03-02T00:00:00.000Z',
+    ...overrides
+  };
+}
+
+describe('validatePromptRecipePreviewOutput', () => {
+  it('accepts strict JSON with only previewUrl', () => {
+    expect(validatePromptRecipePreviewOutput('{\"previewUrl\":\"https://preview.example.com\"}')).toEqual({
+      ok: true,
+      payload: { previewUrl: 'https://preview.example.com' },
+      diagnostics: [
+        {
+          code: 'PROMPT_RECIPE_OUTPUT_VALID',
+          level: 'info',
+          message: 'Prompt recipe output passed strict preview validation.',
+          metadata: { outputPresent: true }
+        }
+      ]
+    });
+  });
+
+  it('rejects non-json output', () => {
+    expect(validatePromptRecipePreviewOutput('https://preview.example.com')).toEqual({
+      ok: false,
+      diagnostics: [
+        {
+          code: 'PROMPT_RECIPE_INVALID_JSON',
+          level: 'error',
+          message: 'Prompt recipe output is not valid JSON.',
+          metadata: { outputPresent: true }
+        }
+      ]
+    });
+  });
+
+  it('rejects extra keys and invalid URLs deterministically', () => {
+    expect(validatePromptRecipePreviewOutput('{\"previewUrl\":\"http://preview.example.com\",\"note\":\"extra\"}')).toEqual({
+      ok: false,
+      diagnostics: [
+        {
+          code: 'PROMPT_RECIPE_INVALID_KEYS',
+          level: 'error',
+          message: 'Prompt recipe output must contain exactly one key: \"previewUrl\".',
+          metadata: { keyCount: 2, outputPresent: true }
+        }
+      ]
+    });
+  });
+});
+
+describe('resolvePromptRecipeExecution', () => {
+  it('returns a ready resolution for validated output', () => {
+    expect(resolvePromptRecipeExecution({
+      status: 'success',
+      elapsedMs: 350,
+      rawOutput: '{\"previewUrl\":\"https://preview.example.com\"}'
+    })).toEqual({
+      status: 'ready',
+      adapter: 'prompt_recipe',
+      previewUrl: 'https://preview.example.com',
+      explanation: 'Prompt-recipe preview resolution returned a validated preview URL.',
+      diagnostics: [
+        {
+          code: 'PROMPT_RECIPE_EXECUTION_SUCCEEDED',
+          level: 'info',
+          message: 'Prompt-recipe preview resolution produced a validated preview URL.',
+          metadata: { elapsedMs: 350 }
+        },
+        {
+          code: 'PROMPT_RECIPE_OUTPUT_VALID',
+          level: 'info',
+          message: 'Prompt recipe output passed strict preview validation.',
+          metadata: { outputPresent: true }
+        }
+      ]
+    });
+  });
+
+  it('surfaces timeout as an explicit terminal outcome', () => {
+    expect(resolvePromptRecipeExecution({
+      status: 'timed_out',
+      elapsedMs: PROMPT_RECIPE_PREVIEW_TIMEOUT_MS,
+      timeoutMs: PROMPT_RECIPE_PREVIEW_TIMEOUT_MS
+    })).toEqual({
+      status: 'timed_out',
+      adapter: 'prompt_recipe',
+      explanation: 'Prompt-recipe preview resolution timed out before a validated preview URL was returned.',
+      diagnostics: [
+        {
+          code: 'PROMPT_RECIPE_TIMEOUT',
+          level: 'error',
+          message: 'Prompt-recipe preview resolution exceeded its timeout.',
+          metadata: {
+            elapsedMs: PROMPT_RECIPE_PREVIEW_TIMEOUT_MS,
+            timeoutMs: PROMPT_RECIPE_PREVIEW_TIMEOUT_MS,
+            rawOutputPresent: false
+          }
+        }
+      ]
+    });
+  });
+
+  it('surfaces malformed output with validation diagnostics', () => {
+    expect(resolvePromptRecipeExecution({
+      status: 'success',
+      elapsedMs: 1200,
+      rawOutput: '{\"previewUrl\":\"http://preview.example.com\",\"extra\":true}'
+    })).toEqual({
+      status: 'failed',
+      adapter: 'prompt_recipe',
+      explanation: 'Prompt-recipe preview resolution returned output that failed strict validation.',
+      diagnostics: [
+        {
+          code: 'PROMPT_RECIPE_VALIDATION_FAILED',
+          level: 'error',
+          message: 'Prompt recipe output failed strict preview validation.',
+          metadata: {
+            elapsedMs: 1200,
+            rawOutputPresent: true
+          }
+        },
+        {
+          code: 'PROMPT_RECIPE_INVALID_KEYS',
+          level: 'error',
+          message: 'Prompt recipe output must contain exactly one key: \"previewUrl\".',
+          metadata: { keyCount: 2, outputPresent: true }
+        }
+      ]
+    });
+  });
+});
+
+describe('inspectPromptRecipeConfiguration', () => {
+  it('fails clearly when no prompt recipe is configured', () => {
+    expect(inspectPromptRecipeConfiguration(buildRepo({
+      previewAdapter: 'prompt_recipe',
+      previewConfig: {}
+    }))).toEqual({
+      compatibility: { checks: [] },
+      resolution: {
+        status: 'failed',
+        adapter: 'prompt_recipe',
+        explanation: 'Prompt-recipe preview resolution requires previewConfig.promptRecipe.',
+        diagnostics: [
+          {
+            code: 'PROMPT_RECIPE_CONFIG_MISSING',
+            level: 'error',
+            message: 'Prompt-recipe preview resolution requires a configured prompt recipe.',
+            metadata: { hasPromptRecipe: false }
+          }
+        ]
+      }
+    });
+  });
+
+  it('defines the contract seam without wiring the runtime yet', () => {
+    expect(inspectPromptRecipeConfiguration(buildRepo({
+      previewAdapter: 'prompt_recipe',
+      previewConfig: { promptRecipe: 'read checks and emit strict JSON' }
+    }))).toEqual({
+      compatibility: { checks: [] },
+      resolution: {
+        status: 'failed',
+        adapter: 'prompt_recipe',
+        explanation: 'Prompt-recipe preview contract is defined, but the runtime adapter is not wired yet.',
+        diagnostics: [
+          {
+            code: 'PROMPT_RECIPE_RUNTIME_UNAVAILABLE',
+            level: 'error',
+            message: 'Prompt-recipe preview runtime will be implemented in a later stage.',
+            metadata: {
+              hasPromptRecipe: true,
+              timeoutMs: PROMPT_RECIPE_PREVIEW_TIMEOUT_MS
+            }
+          }
+        ]
+      }
+    });
+  });
+});

--- a/src/server/preview/prompt-recipe.ts
+++ b/src/server/preview/prompt-recipe.ts
@@ -1,0 +1,245 @@
+import { normalizeRepoPreviewConfig } from '../../shared/preview';
+import type { PreviewAdapter, PreviewAdapterResult, PreviewDiagnostic, PreviewResolution } from './adapter';
+
+export const PROMPT_RECIPE_PREVIEW_TIMEOUT_MS = 45_000;
+
+type PromptRecipePreviewPayload = {
+  previewUrl: string;
+};
+
+export type PromptRecipeExecutionResult =
+  | {
+      status: 'success';
+      elapsedMs: number;
+      rawOutput: string;
+    }
+  | {
+      status: 'failed';
+      elapsedMs: number;
+      message: string;
+      rawOutput?: string;
+    }
+  | {
+      status: 'timed_out';
+      elapsedMs: number;
+      timeoutMs: number;
+      rawOutput?: string;
+    };
+
+export type PromptRecipeValidationResult =
+  | {
+      ok: true;
+      payload: PromptRecipePreviewPayload;
+      diagnostics: PreviewDiagnostic[];
+    }
+  | {
+      ok: false;
+      diagnostics: PreviewDiagnostic[];
+    };
+
+export function validatePromptRecipePreviewOutput(rawOutput: string): PromptRecipeValidationResult {
+  const trimmed = rawOutput.trim();
+  if (!trimmed) {
+    return invalid('PROMPT_RECIPE_EMPTY_OUTPUT', 'error', 'Prompt recipe returned empty output.', { outputPresent: false });
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    return invalid('PROMPT_RECIPE_INVALID_JSON', 'error', 'Prompt recipe output is not valid JSON.', { outputPresent: true });
+  }
+
+  if (!isPlainObject(parsed)) {
+    return invalid('PROMPT_RECIPE_INVALID_SHAPE', 'error', 'Prompt recipe output must be a JSON object.', { outputPresent: true });
+  }
+
+  const keys = Object.keys(parsed);
+  if (keys.length !== 1 || keys[0] !== 'previewUrl') {
+    return invalid(
+      'PROMPT_RECIPE_INVALID_KEYS',
+      'error',
+      'Prompt recipe output must contain exactly one key: "previewUrl".',
+      { keyCount: keys.length, outputPresent: true }
+    );
+  }
+
+  const previewUrl = parsed.previewUrl;
+  if (typeof previewUrl !== 'string' || !previewUrl.trim()) {
+    return invalid('PROMPT_RECIPE_INVALID_PREVIEW_URL', 'error', 'Prompt recipe previewUrl must be a non-empty string.', { outputPresent: true });
+  }
+
+  try {
+    const url = new URL(previewUrl);
+    if (url.protocol !== 'https:') {
+      return invalid('PROMPT_RECIPE_INVALID_PREVIEW_URL', 'error', 'Prompt recipe previewUrl must use HTTPS.', { protocol: url.protocol });
+    }
+  } catch {
+    return invalid('PROMPT_RECIPE_INVALID_PREVIEW_URL', 'error', 'Prompt recipe previewUrl must be an absolute HTTPS URL.', { outputPresent: true });
+  }
+
+  return {
+    ok: true,
+    payload: { previewUrl },
+    diagnostics: [
+      {
+        code: 'PROMPT_RECIPE_OUTPUT_VALID',
+        level: 'info',
+        message: 'Prompt recipe output passed strict preview validation.',
+        metadata: { outputPresent: true }
+      }
+    ]
+  };
+}
+
+export function resolvePromptRecipeExecution(result: PromptRecipeExecutionResult): PreviewResolution {
+  if (result.status === 'timed_out') {
+    return {
+      status: 'timed_out',
+      adapter: 'prompt_recipe',
+      explanation: 'Prompt-recipe preview resolution timed out before a validated preview URL was returned.',
+      diagnostics: [
+        {
+          code: 'PROMPT_RECIPE_TIMEOUT',
+          level: 'error',
+          message: 'Prompt-recipe preview resolution exceeded its timeout.',
+          metadata: {
+            elapsedMs: result.elapsedMs,
+            timeoutMs: result.timeoutMs,
+            rawOutputPresent: Boolean(result.rawOutput?.trim())
+          }
+        }
+      ]
+    };
+  }
+
+  if (result.status === 'failed') {
+    const diagnostics: PreviewDiagnostic[] = [
+      {
+        code: 'PROMPT_RECIPE_EXECUTION_FAILED',
+        level: 'error',
+        message: result.message,
+        metadata: {
+          elapsedMs: result.elapsedMs,
+          rawOutputPresent: Boolean(result.rawOutput?.trim())
+        }
+      }
+    ];
+    if (result.rawOutput?.trim()) {
+      const validation = validatePromptRecipePreviewOutput(result.rawOutput);
+      diagnostics.push(...validation.diagnostics);
+    }
+
+    return {
+      status: 'failed',
+      adapter: 'prompt_recipe',
+      explanation: 'Prompt-recipe preview resolution failed before producing a validated preview URL.',
+      diagnostics
+    };
+  }
+
+  const validation = validatePromptRecipePreviewOutput(result.rawOutput);
+  if (!validation.ok) {
+    return {
+      status: 'failed',
+      adapter: 'prompt_recipe',
+      explanation: 'Prompt-recipe preview resolution returned output that failed strict validation.',
+      diagnostics: [
+        {
+          code: 'PROMPT_RECIPE_VALIDATION_FAILED',
+          level: 'error',
+          message: 'Prompt recipe output failed strict preview validation.',
+          metadata: {
+            elapsedMs: result.elapsedMs,
+            rawOutputPresent: Boolean(result.rawOutput.trim())
+          }
+        },
+        ...validation.diagnostics
+      ]
+    };
+  }
+
+  return {
+    status: 'ready',
+    adapter: 'prompt_recipe',
+    previewUrl: validation.payload.previewUrl,
+    explanation: 'Prompt-recipe preview resolution returned a validated preview URL.',
+    diagnostics: [
+      {
+        code: 'PROMPT_RECIPE_EXECUTION_SUCCEEDED',
+        level: 'info',
+        message: 'Prompt-recipe preview resolution produced a validated preview URL.',
+        metadata: {
+          elapsedMs: result.elapsedMs
+        }
+      },
+      ...validation.diagnostics
+    ]
+  };
+}
+
+export function inspectPromptRecipeConfiguration(
+  repo: Parameters<typeof normalizeRepoPreviewConfig>[0]
+): PreviewAdapterResult {
+  const normalizedRepo = normalizeRepoPreviewConfig(repo);
+  const recipe = normalizedRepo.previewConfig?.promptRecipe?.trim();
+  if (!recipe) {
+    return {
+      compatibility: { checks: [] },
+      resolution: {
+        status: 'failed',
+        adapter: 'prompt_recipe',
+        explanation: 'Prompt-recipe preview resolution requires previewConfig.promptRecipe.',
+        diagnostics: [
+          {
+            code: 'PROMPT_RECIPE_CONFIG_MISSING',
+            level: 'error',
+            message: 'Prompt-recipe preview resolution requires a configured prompt recipe.',
+            metadata: { hasPromptRecipe: false }
+          }
+        ]
+      }
+    };
+  }
+
+  return {
+    compatibility: { checks: [] },
+    resolution: {
+      status: 'failed',
+      adapter: 'prompt_recipe',
+      explanation: 'Prompt-recipe preview contract is defined, but the runtime adapter is not wired yet.',
+      diagnostics: [
+        {
+          code: 'PROMPT_RECIPE_RUNTIME_UNAVAILABLE',
+          level: 'error',
+          message: 'Prompt-recipe preview runtime will be implemented in a later stage.',
+          metadata: {
+            hasPromptRecipe: true,
+            timeoutMs: PROMPT_RECIPE_PREVIEW_TIMEOUT_MS
+          }
+        }
+      ]
+    }
+  };
+}
+
+export const promptRecipePreviewAdapter: PreviewAdapter = {
+  kind: 'prompt_recipe',
+  resolve: ({ repo }) => inspectPromptRecipeConfiguration(repo)
+};
+
+function invalid(
+  code: string,
+  level: PreviewDiagnostic['level'],
+  message: string,
+  metadata?: Record<string, string | number | boolean>
+): PromptRecipeValidationResult {
+  return {
+    ok: false,
+    diagnostics: [{ code, level, message, metadata }]
+  };
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/src/server/preview/registry.test.ts
+++ b/src/server/preview/registry.test.ts
@@ -21,13 +21,13 @@ describe('preview registry compatibility', () => {
     expect(getPreviewAdapter(buildRepo()).kind).toBe('cloudflare_checks');
   });
 
-  it('keeps cloudflare checks behavior while prompt recipe is not extracted yet', () => {
+  it('resolves prompt recipe repos to the prompt recipe adapter contract', () => {
     const repo = buildRepo({
       previewAdapter: 'prompt_recipe',
       previewConfig: { promptRecipe: 'derive preview URL from CI logs' }
     });
 
-    expect(resolvePreviewAdapterKind(repo)).toBe('cloudflare_checks');
-    expect(getPreviewAdapter(repo).kind).toBe('cloudflare_checks');
+    expect(resolvePreviewAdapterKind(repo)).toBe('prompt_recipe');
+    expect(getPreviewAdapter(repo).kind).toBe('prompt_recipe');
   });
 });

--- a/src/server/preview/registry.ts
+++ b/src/server/preview/registry.ts
@@ -2,18 +2,15 @@ import type { Repo } from '../../ui/domain/types';
 import { resolvePreviewAdapterKind as resolvePreviewAdapterKindFromRepo } from '../../shared/preview';
 import type { PreviewAdapter } from './adapter';
 import { cloudflareChecksPreviewAdapter } from './cloudflare-checks';
+import { promptRecipePreviewAdapter } from './prompt-recipe';
 
-const PREVIEW_ADAPTERS: Record<'cloudflare_checks', PreviewAdapter> = {
-  cloudflare_checks: cloudflareChecksPreviewAdapter
+const PREVIEW_ADAPTERS: Record<'cloudflare_checks' | 'prompt_recipe', PreviewAdapter> = {
+  cloudflare_checks: cloudflareChecksPreviewAdapter,
+  prompt_recipe: promptRecipePreviewAdapter
 };
 
-export function resolvePreviewAdapterKind(repo: Repo): 'cloudflare_checks' {
-  const configured = resolvePreviewAdapterKindFromRepo(repo);
-  if (configured === 'prompt_recipe') {
-    return 'cloudflare_checks';
-  }
-
-  return 'cloudflare_checks';
+export function resolvePreviewAdapterKind(repo: Repo): 'cloudflare_checks' | 'prompt_recipe' {
+  return resolvePreviewAdapterKindFromRepo(repo);
 }
 
 export function getPreviewAdapter(repo: Repo): PreviewAdapter {

--- a/src/server/run-orchestrator.ts
+++ b/src/server/run-orchestrator.ts
@@ -13,6 +13,7 @@ import { getScmAdapter } from './scm/registry';
 import { getScmSourceRefFetchSpec } from './scm/source-ref';
 import { getLlmAdapter, resolveLlmAdapterKind } from './llm/registry';
 import { getPreviewAdapter } from './preview/registry';
+import type { PreviewAdapterResult } from './preview/adapter';
 
 type WorkflowBinding<T> = {
   create(options?: { id?: string; params?: T; retention?: { successRetention?: string | number; errorRetention?: string | number } }): Promise<{ id: string }>;
@@ -365,7 +366,7 @@ async function waitForPreview(
   const attempts = 12;
   const headSha = (await repoBoard.getRun(runId)).headSha;
   if (!headSha) {
-    return undefined;
+    return { status: 'failed' as const, reason: 'missing_head_sha' as const };
   }
 
   for (let attempt = 1; attempt <= attempts; attempt += 1) {
@@ -376,23 +377,27 @@ async function waitForPreview(
         runId,
         formatPreviewDiscoveryLog(discovery),
         'preview',
-        discovery.previewUrl ? 'info' : 'error',
+        discovery.resolution.status === 'ready' ? 'info' : discovery.resolution.status === 'pending' ? 'info' : 'error',
         {
           headSha,
-          matchedCheck: discovery.matchedCheck ?? 'none',
-          adapter: discovery.adapter ?? 'none',
-          source: discovery.source ?? 'none',
-          checkCount: discovery.checks.length
+          adapter: discovery.resolution.adapter,
+          resolutionStatus: discovery.resolution.status,
+          matchedCheck: discovery.compatibility.matchedCheck ?? 'none',
+          source: discovery.compatibility.source ?? 'none',
+          checkCount: discovery.compatibility.checks.length
         }
       )
     ]);
-    if (discovery.previewUrl) {
-      return discovery.previewUrl;
+    if (discovery.resolution.status === 'ready' && discovery.resolution.previewUrl) {
+      return { status: 'ready' as const, previewUrl: discovery.resolution.previewUrl };
+    }
+    if (discovery.resolution.status === 'failed' || discovery.resolution.status === 'timed_out') {
+      return { status: discovery.resolution.status, resolution: discovery.resolution } as const;
     }
     await sleepFn(`preview-${attempt}`, 10_000);
   }
 
-  return undefined;
+  return { status: 'timed_out' as const };
 }
 
 async function discoverPreviewAndRunEvidence(
@@ -410,23 +415,30 @@ async function discoverPreviewAndRunEvidence(
     previewStatus: 'DISCOVERING',
     appendTimelineNote: 'Polling SCM checks for preview URL.'
   });
-  const previewUrl = await waitForPreview(env, repoBoard, repo, runId, sleepFn, scmAdapter, scmCredential);
-  if (!previewUrl) {
+  const preview = await waitForPreview(env, repoBoard, repo, runId, sleepFn, scmAdapter, scmCredential);
+  if (preview.status !== 'ready') {
+    const timeoutMessage = preview.status === 'timed_out'
+      ? 'Preview URL did not appear before timeout. Completing run without preview evidence.'
+      : preview.status === 'failed' && preview.reason === 'missing_head_sha'
+        ? 'Preview discovery could not start because the run head SHA is missing.'
+        : preview.resolution?.explanation ?? 'Preview discovery failed before a usable preview URL was produced.';
     await repoBoard.appendRunLogs(runId, [
-      buildRunLog(runId, 'Preview URL did not appear before timeout. Completing run without preview evidence.', 'preview', 'error')
+      buildRunLog(runId, timeoutMessage, 'preview', 'error')
     ]);
     await repoBoard.transitionRun(runId, {
       status: 'DONE',
       previewStatus: 'FAILED',
       evidenceStatus: 'NOT_STARTED',
       endedAt: new Date().toISOString(),
-      appendTimelineNote: 'Preview URL was not discovered before timeout. Run completed without preview evidence.'
+      appendTimelineNote: preview.status === 'timed_out'
+        ? 'Preview URL was not discovered before timeout. Run completed without preview evidence.'
+        : 'Preview resolution failed. Run completed without preview evidence.'
     });
     return;
   }
 
   await repoBoard.transitionRun(runId, {
-    previewUrl,
+    previewUrl: preview.previewUrl,
     previewStatus: 'READY',
     status: shouldRunEvidence(repo) ? 'EVIDENCE_RUNNING' : 'DONE',
     evidenceStatus: shouldRunEvidence(repo) ? 'RUNNING' : 'NOT_STARTED',
@@ -468,23 +480,20 @@ async function lookupPreviewUrl(
   const previewAdapter = getPreviewAdapter(repo);
   return previewAdapter.resolve({
     repo,
-    checks: checks.map((check) => ({
-      name: check.name,
-      detailsUrl: check.detailsUrl,
-      htmlUrl: check.htmlUrl,
-      summary: check.summary,
-      appSlug: check.appSlug
-    }))
-  }).compatibility;
+    checks
+  });
 }
 
-function formatPreviewDiscoveryLog(discovery: Awaited<ReturnType<typeof lookupPreviewUrl>>) {
-  const checks = discovery.checks.length
-    ? discovery.checks
+function formatPreviewDiscoveryLog(discovery: PreviewAdapterResult) {
+  const checks = discovery.compatibility.checks.length
+    ? discovery.compatibility.checks
         .map((check) => {
           const parts = [
             check.name ?? '(unnamed check)',
             check.appSlug ? `app=${check.appSlug}` : undefined,
+            check.rawSource ? `source=${check.rawSource}` : undefined,
+            check.status ? `status=${check.status}` : undefined,
+            check.conclusion ? `conclusion=${check.conclusion}` : undefined,
             `score=${check.score}`,
             check.matchedAdapter ? `adapter=${check.matchedAdapter}` : undefined,
             check.extracted ? 'preview=found' : 'preview=missing'
@@ -494,11 +503,15 @@ function formatPreviewDiscoveryLog(discovery: Awaited<ReturnType<typeof lookupPr
         .join(' | ')
     : 'no check runs returned';
 
-  if (discovery.previewUrl) {
-    return `Preview discovery matched ${discovery.matchedCheck ?? 'unknown check'} via ${discovery.adapter ?? 'unknown adapter'} from ${discovery.source ?? 'unknown source'}: ${discovery.previewUrl} | checks: ${checks}`;
+  const diagnostics = discovery.resolution.diagnostics.length
+    ? ` | diagnostics: ${discovery.resolution.diagnostics.map((diagnostic) => diagnostic.code).join(', ')}`
+    : '';
+
+  if (discovery.resolution.previewUrl) {
+    return `Preview discovery matched ${discovery.compatibility.matchedCheck ?? 'unknown check'} via ${discovery.compatibility.adapter ?? discovery.resolution.adapter} from ${discovery.compatibility.source ?? 'unknown source'}: ${discovery.resolution.previewUrl} | checks: ${checks}${diagnostics}`;
   }
 
-  return `Preview discovery found no usable preview URL. checks: ${checks}`;
+  return `${discovery.resolution.explanation} | checks: ${checks}${diagnostics}`;
 }
 
 async function getScmCredential(


### PR DESCRIPTION
Task: S35-P3/4 Normalize preview discovery and define prompt-recipe contract

Combine normalized Cloudflare preview discovery on SCM checks with the strict prompt-recipe preview adapter contract and validation layer, without implementing the full prompt runtime yet.


Acceptance criteria:
- Cloudflare preview discovery consumes normalized SCM check data rather than raw provider payloads.
- GitHub Cloudflare preview behavior remains intact and the seam can support GitLab normalized checks.
- The prompt-recipe preview adapter contract is defined with strict output validation and structured diagnostics.
- Failure and timeout cases are explicit, and the orchestrator no longer owns provider-specific preview parsing logic.

Run ID: run_repo_abuiles_minions_mm9g0gly8o57