### PR TITLE
S35-P5 Implement prompt-recipe preview adapter on the LLM seam

### DIFF
--- a/src/server/durable/repo-board.ts
+++ b/src/server/durable/repo-board.ts
@@ -1039,7 +1039,20 @@ function cloneRepoBoardState(state: RepoBoardState): RepoBoardState {
       errors: run.errors.map((error) => ({ ...error })),
       timeline: run.timeline.map((entry) => ({ ...entry })),
       pendingEvents: run.pendingEvents.map((event) => ({ ...event })),
-      executionSummary: run.executionSummary ? { ...run.executionSummary } : undefined,
+      executionSummary: run.executionSummary
+        ? {
+            ...run.executionSummary,
+            previewResolution: run.executionSummary.previewResolution
+              ? {
+                  ...run.executionSummary.previewResolution,
+                  diagnostics: run.executionSummary.previewResolution.diagnostics.map((diagnostic) => ({
+                    ...diagnostic,
+                    metadata: diagnostic.metadata ? { ...diagnostic.metadata } : undefined
+                  }))
+                }
+              : undefined
+          }
+        : undefined,
       artifacts: run.artifacts ? [...run.artifacts] : undefined,
       latestCodexResumeCommand: (run.llmAdapter ?? run.operatorSession?.llmAdapter ?? 'codex') === 'codex'
         ? (run.latestCodexResumeCommand ?? run.llmResumeCommand)
@@ -1072,7 +1085,21 @@ function normalizeRepoBoardState(state?: Partial<RepoBoardState> | null): RepoBo
     })),
     runs: (state?.runs ?? []).map((run) => ({
       ...normalizeRunLlmState(normalizeRunReviewMetadata(run)),
-      dependencyContext: run.dependencyContext ? normalizeDependencyReviewMetadata({ ...run.dependencyContext }) : undefined
+      dependencyContext: run.dependencyContext ? normalizeDependencyReviewMetadata({ ...run.dependencyContext }) : undefined,
+      executionSummary: run.executionSummary
+        ? {
+            ...run.executionSummary,
+            previewResolution: run.executionSummary.previewResolution
+              ? {
+                  ...run.executionSummary.previewResolution,
+                  diagnostics: (run.executionSummary.previewResolution.diagnostics ?? []).map((diagnostic) => ({
+                    ...diagnostic,
+                    metadata: diagnostic.metadata ? { ...diagnostic.metadata } : undefined
+                  }))
+                }
+              : undefined
+          }
+        : undefined
     })),
     logs: (state?.logs ?? [])
       .slice(-MAX_LOG_ENTRIES)

--- a/src/server/llm/adapter.ts
+++ b/src/server/llm/adapter.ts
@@ -1,6 +1,6 @@
 import type { getSandbox } from '@cloudflare/sandbox';
 import type { RepoBoardDO } from '../durable/repo-board';
-import type { AgentRun, LlmAdapter as LlmAdapterKind, LlmReasoningEffort, Repo, Task } from '../../ui/domain/types';
+import type { AgentRun, LlmAdapter as LlmAdapterKind, LlmReasoningEffort, Repo, RunCommandPhase, Task } from '../../ui/domain/types';
 
 export type SandboxHandle = ReturnType<typeof getSandbox>;
 export type RepoBoardHandle = DurableObjectStub<RepoBoardDO>;
@@ -17,6 +17,19 @@ export type LlmExecutionRequest = {
   reasoningEffort?: LlmReasoningEffort;
 };
 
+export type LlmPromptExecutionRequest = {
+  repo: Repo;
+  task: Task;
+  run: AgentRun;
+  cwd: string;
+  prompt: string;
+  model: string;
+  reasoningEffort?: LlmReasoningEffort;
+  timeoutMs?: number;
+  outputSchema?: Record<string, unknown>;
+  phase?: Exclude<RunCommandPhase, 'operator'>;
+};
+
 export type LlmExecutionResult = {
   success: boolean;
   stoppedForTakeover?: boolean;
@@ -24,6 +37,28 @@ export type LlmExecutionResult = {
   resumeCommand?: string;
   sessionId?: string;
 };
+
+export type LlmPromptExecutionResult =
+  | {
+      status: 'success';
+      elapsedMs: number;
+      rawOutput: string;
+      stderr?: string;
+    }
+  | {
+      status: 'failed';
+      elapsedMs: number;
+      message: string;
+      rawOutput?: string;
+      stderr?: string;
+    }
+  | {
+      status: 'timed_out';
+      elapsedMs: number;
+      timeoutMs: number;
+      rawOutput?: string;
+      stderr?: string;
+    };
 
 export type LlmSessionState = {
   sessionId?: string;
@@ -52,6 +87,7 @@ export type LlmAdapter = {
   logDiagnostics(context: LlmRuntimeContext, request: LlmExecutionRequest): Promise<void>;
   waitForCapacityIfNeeded?(context: LlmRuntimeContext, request: LlmExecutionRequest, sleepFn: SleepFn): Promise<void>;
   run(context: LlmRuntimeContext, request: LlmExecutionRequest): Promise<LlmExecutionResult>;
+  runPrompt(context: LlmRuntimeContext, request: LlmPromptExecutionRequest): Promise<LlmPromptExecutionResult>;
 
   extractSessionState?(chunk: string, fallbackSessionId?: string): LlmSessionState;
 };

--- a/src/server/llm/codex.ts
+++ b/src/server/llm/codex.ts
@@ -156,6 +156,77 @@ cat /workspace/task.txt | codex exec -m ${request.model} -c model_reasoning_effo
     return runCodexProcessWithLogs(context, command);
   },
 
+  async runPrompt(context, request) {
+    const startedAt = Date.now();
+    const timeoutMs = request.timeoutMs ?? 45_000;
+    const timeoutSeconds = Math.max(1, Math.ceil(timeoutMs / 1000));
+    const phase = request.phase ?? 'preview';
+    await context.sandbox.writeFile('/workspace/prompt.txt', request.prompt);
+    if (request.outputSchema) {
+      await context.sandbox.writeFile('/workspace/prompt-output-schema.json', JSON.stringify(request.outputSchema, null, 2));
+    }
+
+    const schemaArg = request.outputSchema ? '--output-schema /workspace/prompt-output-schema.json' : '';
+    const command = `bash -lc ${shellQuote(`set -euo pipefail
+export HOME="\${HOME:-/root}"
+mkdir -p ${request.cwd}
+cd ${request.cwd}
+rm -f /workspace/prompt-last-message.txt
+run_with_timeout() {
+  if command -v timeout >/dev/null 2>&1; then
+    timeout ${timeoutSeconds}s "$@"
+  else
+    "$@"
+  fi
+}
+cat /workspace/prompt.txt | run_with_timeout codex exec -m ${request.model} -c model_reasoning_effort="${request.reasoningEffort ?? 'medium'}" --dangerously-bypass-approvals-and-sandbox --skip-git-repo-check --ephemeral -C ${request.cwd} ${schemaArg} --output-last-message /workspace/prompt-last-message.txt -
+if [ -f /workspace/prompt-last-message.txt ]; then
+  printf '\\n===CODEX_LAST_MESSAGE===\\n'
+  cat /workspace/prompt-last-message.txt
+fi
+`)}`;
+    const result = await emitCommandLifecycle(
+      context.repoBoard,
+      context.runId,
+      phase,
+      command,
+      () => context.sandbox.exec(command)
+    );
+
+    const elapsedMs = Date.now() - startedAt;
+    const marker = '===CODEX_LAST_MESSAGE===';
+    const rawOutput = result.stdout?.includes(marker)
+      ? result.stdout.split(marker).slice(1).join(marker).trim()
+      : undefined;
+
+    if (result.exitCode === 124) {
+      return {
+        status: 'timed_out',
+        elapsedMs,
+        timeoutMs,
+        rawOutput,
+        stderr: result.stderr
+      };
+    }
+
+    if (!result.success) {
+      return {
+        status: 'failed',
+        elapsedMs,
+        message: result.stderr?.trim() || 'Codex prompt execution failed.',
+        rawOutput,
+        stderr: result.stderr
+      };
+    }
+
+    return {
+      status: 'success',
+      elapsedMs,
+      rawOutput: rawOutput ?? '',
+      stderr: result.stderr
+    };
+  },
+
   extractSessionState(chunk: string, fallbackSessionId?: string) {
     const sessionMatch = chunk.match(/"thread_id":"([^"]+)"/);
     const sessionId = sessionMatch?.[1] ?? fallbackSessionId;

--- a/src/server/llm/cursor-cli.ts
+++ b/src/server/llm/cursor-cli.ts
@@ -148,6 +148,71 @@ PROMPT="$(cat /workspace/task.txt)"
 "$CURSOR_BIN" -p --force --output-format text --model ${shellQuote(request.model)} "$PROMPT"
 `)}`;
     return runCursorProcessWithLogs(context, command);
+  },
+
+  async runPrompt(context, request) {
+    const startedAt = Date.now();
+    const timeoutSeconds = Math.max(1, Math.ceil((request.timeoutMs ?? 45_000) / 1000));
+    await context.sandbox.writeFile('/workspace/prompt.txt', request.prompt);
+    const command = `bash -lc ${shellQuote(`set -euo pipefail
+export HOME="\${HOME:-/root}"
+mkdir -p ${request.cwd}
+cd ${request.cwd}
+if command -v cursor-agent >/dev/null 2>&1; then
+  CURSOR_BIN="cursor-agent"
+elif command -v cursor >/dev/null 2>&1; then
+  CURSOR_BIN="cursor"
+else
+  echo "Cursor CLI is not installed." >&2
+  exit 127
+fi
+run_with_timeout() {
+  if command -v timeout >/dev/null 2>&1; then
+    timeout ${timeoutSeconds}s "$@"
+  else
+    "$@"
+  fi
+}
+PROMPT="$(cat /workspace/prompt.txt)"
+run_with_timeout "$CURSOR_BIN" -p --force --output-format text --model ${shellQuote(request.model)} "$PROMPT"
+`)}`;
+    const phase = request.phase ?? 'preview';
+    const result = await emitCommandLifecycle(
+      context.repoBoard,
+      context.runId,
+      phase,
+      command,
+      () => context.sandbox.exec(command)
+    );
+    const elapsedMs = Date.now() - startedAt;
+    const rawOutput = result.stdout?.trim();
+
+    if (result.exitCode === 124) {
+      return {
+        status: 'timed_out',
+        elapsedMs,
+        timeoutMs: request.timeoutMs ?? 45_000,
+        rawOutput,
+        stderr: result.stderr
+      };
+    }
+
+    if (!result.success) {
+      return {
+        status: 'failed',
+        elapsedMs,
+        message: result.stderr?.trim() || 'Cursor CLI prompt execution failed.',
+        rawOutput,
+        stderr: result.stderr
+      };
+    }
+
+    return {
+      status: 'success',
+      elapsedMs,
+      rawOutput: rawOutput ?? '',
+      stderr: result.stderr
+    };
   }
 };
 

--- a/src/server/llm/runtime.ts
+++ b/src/server/llm/runtime.ts
@@ -1,0 +1,14 @@
+import type { LlmAdapter, LlmPromptExecutionRequest, LlmPromptExecutionResult, LlmRuntimeContext, SleepFn } from './adapter';
+
+export async function executePromptWithLlmAdapter(
+  adapter: LlmAdapter,
+  context: LlmRuntimeContext,
+  request: LlmPromptExecutionRequest,
+  sleepFn: SleepFn
+): Promise<LlmPromptExecutionResult> {
+  await adapter.ensureInstalled(context);
+  await adapter.restoreAuth({ ...context, repo: request.repo });
+  await adapter.logDiagnostics(context, request);
+  await adapter.waitForCapacityIfNeeded?.(context, request, sleepFn);
+  return adapter.runPrompt(context, request);
+}

--- a/src/server/preview/adapter.ts
+++ b/src/server/preview/adapter.ts
@@ -1,14 +1,16 @@
-import type { Repo, Task, AgentRun, PreviewAdapterKind } from '../../ui/domain/types';
+import type {
+  Repo,
+  Task,
+  AgentRun,
+  LlmReasoningEffort,
+  PreviewAdapterKind,
+  PreviewDiagnostic,
+  PreviewResolutionStatus
+} from '../../ui/domain/types';
 import type { ScmCommitCheck } from '../scm/adapter';
+import type { LlmAdapter, LlmPromptExecutionResult, LlmRuntimeContext, SleepFn } from '../llm/adapter';
 
 export type PreviewDiscoverySource = 'summary' | 'details_url' | 'html_url';
-
-export type PreviewDiagnostic = {
-  code: string;
-  level: 'info' | 'error';
-  message: string;
-  metadata?: Record<string, string | number | boolean>;
-};
 
 export type PreviewDiscoveryResult = {
   previewUrl?: string;
@@ -28,11 +30,21 @@ export type PreviewDiscoveryResult = {
 };
 
 export type PreviewResolution = {
-  status: 'ready' | 'pending' | 'failed' | 'timed_out';
+  status: PreviewResolutionStatus;
   previewUrl?: string;
   adapter: PreviewAdapterKind;
   explanation: string;
   diagnostics: PreviewDiagnostic[];
+};
+
+export type PreviewLlmContext = {
+  adapter: LlmAdapter;
+  runtimeContext: LlmRuntimeContext;
+  model: string;
+  reasoningEffort?: LlmReasoningEffort;
+  cwd: string;
+  sleepFn: SleepFn;
+  runPrompt: (prompt: string, options?: { timeoutMs?: number; outputSchema?: Record<string, unknown> }) => Promise<LlmPromptExecutionResult>;
 };
 
 export type PreviewAdapterContext = {
@@ -40,6 +52,7 @@ export type PreviewAdapterContext = {
   task?: Task;
   run?: AgentRun;
   checks: ScmCommitCheck[];
+  llm?: PreviewLlmContext;
 };
 
 export type PreviewAdapterResult = {
@@ -49,5 +62,5 @@ export type PreviewAdapterResult = {
 
 export type PreviewAdapter = {
   kind: PreviewAdapterKind;
-  resolve(context: PreviewAdapterContext): PreviewAdapterResult;
+  resolve(context: PreviewAdapterContext): PreviewAdapterResult | Promise<PreviewAdapterResult>;
 };

--- a/src/server/preview/prompt-recipe.test.ts
+++ b/src/server/preview/prompt-recipe.test.ts
@@ -1,11 +1,14 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
   PROMPT_RECIPE_PREVIEW_TIMEOUT_MS,
   inspectPromptRecipeConfiguration,
+  promptRecipePreviewAdapter,
   resolvePromptRecipeExecution,
   validatePromptRecipePreviewOutput
 } from './prompt-recipe';
-import type { Repo } from '../../ui/domain/types';
+import type { Repo, Task, AgentRun } from '../../ui/domain/types';
+import type { PreviewAdapterContext } from './adapter';
+import type { LlmAdapter, LlmPromptExecutionResult } from '../llm/adapter';
 
 function buildRepo(overrides: Partial<Repo> = {}): Repo {
   return {
@@ -20,9 +23,87 @@ function buildRepo(overrides: Partial<Repo> = {}): Repo {
   };
 }
 
+function buildTask(overrides: Partial<Task> = {}): Task {
+  return {
+    taskId: 'task_1',
+    repoId: 'repo_1',
+    title: 'Resolve preview',
+    taskPrompt: 'Resolve preview',
+    acceptanceCriteria: [],
+    context: { links: [] },
+    status: 'REVIEW',
+    createdAt: '2026-03-02T00:00:00.000Z',
+    updatedAt: '2026-03-02T00:00:00.000Z',
+    ...overrides
+  };
+}
+
+function buildRun(overrides: Partial<AgentRun> = {}): AgentRun {
+  return {
+    runId: 'run_1',
+    taskId: 'task_1',
+    repoId: 'repo_1',
+    status: 'WAITING_PREVIEW',
+    branchName: 'agent/task_1/run_1',
+    previewStatus: 'DISCOVERING',
+    evidenceStatus: 'NOT_STARTED',
+    errors: [],
+    startedAt: '2026-03-02T00:00:00.000Z',
+    timeline: [],
+    simulationProfile: 'happy_path',
+    pendingEvents: [],
+    executionSummary: {},
+    ...overrides
+  };
+}
+
+function buildContext(
+  result: LlmPromptExecutionResult,
+  overrides: Partial<PreviewAdapterContext> = {}
+): PreviewAdapterContext {
+  const adapter: LlmAdapter = {
+    kind: 'codex',
+    capabilities: {
+      supportsResume: true,
+      supportsTakeover: true
+    },
+    ensureInstalled: vi.fn(),
+    restoreAuth: vi.fn(),
+    logDiagnostics: vi.fn(),
+    run: vi.fn(),
+    runPrompt: vi.fn()
+  };
+
+  return {
+    repo: buildRepo({
+      previewAdapter: 'prompt_recipe',
+      previewConfig: { promptRecipe: 'Read the checks and return the preview URL.' }
+    }),
+    task: buildTask(),
+    run: buildRun(),
+    checks: [{
+      name: 'Workers Builds: minions-demo',
+      status: 'completed',
+      conclusion: 'success',
+      summary: 'Preview URL: https://preview.example.com',
+      rawSource: 'github_check_run'
+    }],
+    llm: {
+      adapter,
+      runtimeContext: {} as never,
+      model: 'gpt-5.3-codex',
+      reasoningEffort: 'medium',
+      cwd: '/workspace/repo',
+      sleepFn: vi.fn(),
+      runPrompt: vi.fn().mockResolvedValue(result)
+    },
+    ...overrides
+  };
+}
+
 describe('validatePromptRecipePreviewOutput', () => {
   it('accepts strict JSON with only previewUrl', () => {
-    expect(validatePromptRecipePreviewOutput('{\"previewUrl\":\"https://preview.example.com\"}')).toEqual({
+    expect(validatePromptRecipePreviewOutput('{"previewUrl":"https://preview.example.com"}')).toEqual({
       ok: true,
       payload: { previewUrl: 'https://preview.example.com' },
       diagnostics: [
@@ -50,14 +131,14 @@ describe('validatePromptRecipePreviewOutput', () => {
     });
   });
 
-  it('rejects extra keys and invalid URLs deterministically', () => {
-    expect(validatePromptRecipePreviewOutput('{\"previewUrl\":\"http://preview.example.com\",\"note\":\"extra\"}')).toEqual({
+  it('rejects extra keys deterministically', () => {
+    expect(validatePromptRecipePreviewOutput('{"previewUrl":"http://preview.example.com","note":"extra"}')).toEqual({
       ok: false,
       diagnostics: [
         {
           code: 'PROMPT_RECIPE_INVALID_KEYS',
           level: 'error',
-          message: 'Prompt recipe output must contain exactly one key: \"previewUrl\".',
+          message: 'Prompt recipe output must contain exactly one key: "previewUrl".',
           metadata: { keyCount: 2, outputPresent: true }
         }
       ]
@@ -70,7 +151,7 @@ describe('resolvePromptRecipeExecution', () => {
     expect(resolvePromptRecipeExecution({
       status: 'success',
       elapsedMs: 350,
-      rawOutput: '{\"previewUrl\":\"https://preview.example.com\"}'
+      rawOutput: '{"previewUrl":"https://preview.example.com"}'
     })).toEqual({
       status: 'ready',
       adapter: 'prompt_recipe',
@@ -116,35 +197,6 @@ describe('resolvePromptRecipeExecution', () => {
       ]
     });
   });
-
-  it('surfaces malformed output with validation diagnostics', () => {
-    expect(resolvePromptRecipeExecution({
-      status: 'success',
-      elapsedMs: 1200,
-      rawOutput: '{\"previewUrl\":\"http://preview.example.com\",\"extra\":true}'
-    })).toEqual({
-      status: 'failed',
-      adapter: 'prompt_recipe',
-      explanation: 'Prompt-recipe preview resolution returned output that failed strict validation.',
-      diagnostics: [
-        {
-          code: 'PROMPT_RECIPE_VALIDATION_FAILED',
-          level: 'error',
-          message: 'Prompt recipe output failed strict preview validation.',
-          metadata: {
-            elapsedMs: 1200,
-            rawOutputPresent: true
-          }
-        },
-        {
-          code: 'PROMPT_RECIPE_INVALID_KEYS',
-          level: 'error',
-          message: 'Prompt recipe output must contain exactly one key: \"previewUrl\".',
-          metadata: { keyCount: 2, outputPresent: true }
-        }
-      ]
-    });
-  });
 });
 
 describe('inspectPromptRecipeConfiguration', () => {
@@ -170,21 +222,21 @@ describe('inspectPromptRecipeConfiguration', () => {
     });
   });
 
-  it('defines the contract seam without wiring the runtime yet', () => {
+  it('reports a configured recipe as pending executor work', () => {
     expect(inspectPromptRecipeConfiguration(buildRepo({
       previewAdapter: 'prompt_recipe',
       previewConfig: { promptRecipe: 'read checks and emit strict JSON' }
     }))).toEqual({
       compatibility: { checks: [] },
       resolution: {
-        status: 'failed',
+        status: 'pending',
         adapter: 'prompt_recipe',
-        explanation: 'Prompt-recipe preview contract is defined, but the runtime adapter is not wired yet.',
+        explanation: 'Prompt-recipe preview resolution is configured and waiting for executor context.',
         diagnostics: [
           {
-            code: 'PROMPT_RECIPE_RUNTIME_UNAVAILABLE',
-            level: 'error',
-            message: 'Prompt-recipe preview runtime will be implemented in a later stage.',
+            code: 'PROMPT_RECIPE_CONFIG_READY',
+            level: 'info',
+            message: 'Prompt-recipe preview resolution has a configured prompt recipe.',
             metadata: {
               hasPromptRecipe: true,
               timeoutMs: PROMPT_RECIPE_PREVIEW_TIMEOUT_MS
@@ -193,5 +245,70 @@ describe('inspectPromptRecipeConfiguration', () => {
         ]
       }
     });
+  });
+});
+
+describe('promptRecipePreviewAdapter', () => {
+  it('resolves a validated preview URL through the executor seam', async () => {
+    const context = buildContext({
+      status: 'success',
+      elapsedMs: 420,
+      rawOutput: '{"previewUrl":"https://preview.example.com"}'
+    });
+
+    const result = await promptRecipePreviewAdapter.resolve(context);
+
+    expect(result.resolution.status).toBe('ready');
+    expect(result.resolution.previewUrl).toBe('https://preview.example.com');
+    expect(result.resolution.diagnostics.map((diagnostic) => diagnostic.code)).toEqual([
+      'PROMPT_RECIPE_EXECUTOR_SELECTED',
+      'PROMPT_RECIPE_EXECUTION_SUCCEEDED',
+      'PROMPT_RECIPE_OUTPUT_VALID'
+    ]);
+    expect(context.llm?.runPrompt).toHaveBeenCalledOnce();
+  });
+
+  it('fails clearly when runtime context is unavailable', async () => {
+    const result = await promptRecipePreviewAdapter.resolve(buildContext(
+      {
+        status: 'success',
+        elapsedMs: 420,
+        rawOutput: '{"previewUrl":"https://preview.example.com"}'
+      },
+      { llm: undefined }
+    ));
+
+    expect(result.resolution).toEqual({
+      status: 'failed',
+      adapter: 'prompt_recipe',
+      explanation: 'Prompt-recipe preview resolution requires task, run, and executor context.',
+      diagnostics: [
+        {
+          code: 'PROMPT_RECIPE_RUNTIME_CONTEXT_MISSING',
+          level: 'error',
+          message: 'Prompt-recipe preview resolution could not access the selected executor context.',
+          metadata: {
+            hasTask: true,
+            hasRun: true,
+            hasLlmContext: false
+          }
+        }
+      ]
+    });
+  });
+
+  it('surfaces malformed output with validation diagnostics', async () => {
+    const result = await promptRecipePreviewAdapter.resolve(buildContext({
+      status: 'success',
+      elapsedMs: 1200,
+      rawOutput: '{"previewUrl":"http://preview.example.com","extra":true}'
+    }));
+
+    expect(result.resolution.status).toBe('failed');
+    expect(result.resolution.diagnostics.map((diagnostic) => diagnostic.code)).toEqual([
+      'PROMPT_RECIPE_EXECUTOR_SELECTED',
+      'PROMPT_RECIPE_VALIDATION_FAILED',
+      'PROMPT_RECIPE_INVALID_KEYS'
+    ]);
   });
 });

--- a/src/server/preview/prompt-recipe.ts
+++ b/src/server/preview/prompt-recipe.ts
@@ -1,7 +1,22 @@
 import { normalizeRepoPreviewConfig } from '../../shared/preview';
-import type { PreviewAdapter, PreviewAdapterResult, PreviewDiagnostic, PreviewResolution } from './adapter';
+import type { PreviewDiagnostic } from '../../ui/domain/types';
+import type { PreviewAdapter, PreviewAdapterContext, PreviewAdapterResult, PreviewResolution } from './adapter';
 
 export const PROMPT_RECIPE_PREVIEW_TIMEOUT_MS = 45_000;
+export const PROMPT_RECIPE_DEFAULT_MODEL = 'gpt-5.3-codex';
+export const PROMPT_RECIPE_DEFAULT_REASONING_EFFORT = 'medium';
+
+const PROMPT_RECIPE_OUTPUT_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['previewUrl'],
+  properties: {
+    previewUrl: {
+      type: 'string',
+      pattern: '^https://.+'
+    }
+  }
+} as const;
 
 type PromptRecipePreviewPayload = {
   previewUrl: string;
@@ -205,14 +220,14 @@ export function inspectPromptRecipeConfiguration(
   return {
     compatibility: { checks: [] },
     resolution: {
-      status: 'failed',
+      status: 'pending',
       adapter: 'prompt_recipe',
-      explanation: 'Prompt-recipe preview contract is defined, but the runtime adapter is not wired yet.',
+      explanation: 'Prompt-recipe preview resolution is configured and waiting for executor context.',
       diagnostics: [
         {
-          code: 'PROMPT_RECIPE_RUNTIME_UNAVAILABLE',
-          level: 'error',
-          message: 'Prompt-recipe preview runtime will be implemented in a later stage.',
+          code: 'PROMPT_RECIPE_CONFIG_READY',
+          level: 'info',
+          message: 'Prompt-recipe preview resolution has a configured prompt recipe.',
           metadata: {
             hasPromptRecipe: true,
             timeoutMs: PROMPT_RECIPE_PREVIEW_TIMEOUT_MS
@@ -225,8 +240,136 @@ export function inspectPromptRecipeConfiguration(
 
 export const promptRecipePreviewAdapter: PreviewAdapter = {
   kind: 'prompt_recipe',
-  resolve: ({ repo }) => inspectPromptRecipeConfiguration(repo)
+  async resolve(context) {
+    const configuration = inspectPromptRecipeConfiguration(context.repo);
+    if (configuration.resolution.status === 'failed') {
+      return configuration;
+    }
+
+    if (!context.task || !context.run || !context.llm) {
+      return {
+        compatibility: buildCompatibility(context),
+        resolution: {
+          status: 'failed',
+          adapter: 'prompt_recipe',
+          explanation: 'Prompt-recipe preview resolution requires task, run, and executor context.',
+          diagnostics: [
+            {
+              code: 'PROMPT_RECIPE_RUNTIME_CONTEXT_MISSING',
+              level: 'error',
+              message: 'Prompt-recipe preview resolution could not access the selected executor context.',
+              metadata: {
+                hasTask: Boolean(context.task),
+                hasRun: Boolean(context.run),
+                hasLlmContext: Boolean(context.llm)
+              }
+            }
+          ]
+        }
+      };
+    }
+
+    const recipe = normalizeRepoPreviewConfig(context.repo).previewConfig?.promptRecipe?.trim();
+    const execution = await context.llm.runPrompt(buildPromptRecipePrompt(context, recipe ?? ''), {
+      timeoutMs: PROMPT_RECIPE_PREVIEW_TIMEOUT_MS,
+      outputSchema: PROMPT_RECIPE_OUTPUT_SCHEMA
+    });
+    const baseResolution = resolvePromptRecipeExecution(execution);
+    const resolution = {
+      ...baseResolution,
+      diagnostics: [
+        {
+          code: 'PROMPT_RECIPE_EXECUTOR_SELECTED',
+          level: 'info' as const,
+          message: `Prompt-recipe preview resolution is using ${context.llm.adapter.kind}.`,
+          metadata: {
+            llmAdapter: context.llm.adapter.kind,
+            llmModel: context.llm.model,
+            llmReasoningEffort: context.llm.reasoningEffort ?? PROMPT_RECIPE_DEFAULT_REASONING_EFFORT,
+            timeoutMs: PROMPT_RECIPE_PREVIEW_TIMEOUT_MS,
+            checkCount: context.checks.length
+          }
+        },
+        ...baseResolution.diagnostics
+      ]
+    };
+
+    return {
+      compatibility: buildCompatibility(context),
+      resolution
+    };
+  }
 };
+
+function buildPromptRecipePrompt(context: PreviewAdapterContext, recipe: string) {
+  const repo = context.repo;
+  const task = context.task;
+  const run = context.run;
+
+  return [
+    'Resolve exactly one usable preview URL for this run.',
+    'Follow the customer recipe, use the supplied metadata and normalized SCM checks, and do not invent a URL.',
+    'Return only strict JSON matching this shape: {"previewUrl":"https://..."}',
+    'If you cannot determine a usable preview URL confidently, do not fabricate one.',
+    '',
+    'Customer recipe:',
+    recipe,
+    '',
+    'Repo and run context:',
+    JSON.stringify({
+      repo: {
+        repoId: repo.repoId,
+        projectPath: repo.projectPath ?? repo.slug,
+        scmProvider: repo.scmProvider ?? 'github',
+        scmBaseUrl: repo.scmBaseUrl,
+        defaultBranch: repo.defaultBranch,
+        baselineUrl: repo.baselineUrl,
+        previewAdapter: repo.previewAdapter,
+        previewConfig: repo.previewConfig
+      },
+      task: {
+        taskId: task?.taskId,
+        title: task?.title,
+        sourceRef: task?.sourceRef,
+        baselineUrlOverride: task?.baselineUrlOverride
+      },
+      run: {
+        runId: run?.runId,
+        branchName: run?.branchName,
+        headSha: run?.headSha,
+        reviewUrl: run?.reviewUrl ?? run?.prUrl,
+        reviewNumber: run?.reviewNumber ?? run?.prNumber,
+        previewUrl: run?.previewUrl
+      },
+      checks: context.checks.map((check) => ({
+        name: check.name,
+        status: check.status,
+        conclusion: check.conclusion,
+        summary: check.summary,
+        detailsUrl: check.detailsUrl,
+        htmlUrl: check.htmlUrl,
+        appSlug: check.appSlug,
+        rawSource: check.rawSource
+      }))
+    }, null, 2)
+  ].join('\n');
+}
+
+function buildCompatibility(context: PreviewAdapterContext): PreviewAdapterResult['compatibility'] {
+  return {
+    adapter: 'prompt_recipe',
+    checks: context.checks.map((check) => ({
+      name: check.name,
+      appSlug: check.appSlug,
+      rawSource: check.rawSource,
+      status: check.status,
+      conclusion: check.conclusion,
+      score: 0,
+      matchedAdapter: 'prompt_recipe',
+      extracted: false
+    }))
+  };
+}
 
 function invalid(
   code: string,

--- a/src/server/run-orchestrator.ts
+++ b/src/server/run-orchestrator.ts
@@ -12,6 +12,7 @@ import type { ScmAdapter, ScmAdapterCredential } from './scm/adapter';
 import { getScmAdapter } from './scm/registry';
 import { getScmSourceRefFetchSpec } from './scm/source-ref';
 import { getLlmAdapter, resolveLlmAdapterKind } from './llm/registry';
+import { executePromptWithLlmAdapter } from './llm/runtime';
 import { getPreviewAdapter } from './preview/registry';
 import type { PreviewAdapterResult } from './preview/adapter';
 
@@ -357,6 +358,7 @@ npx -y playwright install chromium
 async function waitForPreview(
   env: Stage3Env,
   repoBoard: DurableObjectStub<RepoBoardDO>,
+  task: Task,
   repo: Repo,
   runId: string,
   sleepFn: SleepFn,
@@ -370,7 +372,23 @@ async function waitForPreview(
   }
 
   for (let attempt = 1; attempt <= attempts; attempt += 1) {
-    const discovery = await lookupPreviewUrl(repo, headSha, scmAdapter, scmCredential);
+    const run = await repoBoard.getRun(runId);
+    const discovery = await lookupPreviewUrl(env, repoBoard, task, repo, run, headSha, sleepFn, scmAdapter, scmCredential);
+    await repoBoard.transitionRun(runId, {
+      executionSummary: {
+        previewResolution: {
+          adapter: discovery.resolution.adapter,
+          status: discovery.resolution.status,
+          explanation: discovery.resolution.explanation,
+          checkedAt: new Date().toISOString(),
+          previewUrl: discovery.resolution.previewUrl,
+          diagnostics: discovery.resolution.diagnostics.map((diagnostic) => ({
+            ...diagnostic,
+            metadata: diagnostic.metadata ? { ...diagnostic.metadata } : undefined
+          }))
+        }
+      }
+    });
     await repoBoard.appendRunLogs(runId, [
       buildRunLog(runId, `Preview discovery attempt ${attempt}/${attempts}.`, 'preview', 'info', { headSha }),
       buildRunLog(
@@ -413,9 +431,9 @@ async function discoverPreviewAndRunEvidence(
   await repoBoard.transitionRun(runId, {
     status: 'WAITING_PREVIEW',
     previewStatus: 'DISCOVERING',
-    appendTimelineNote: 'Polling SCM checks for preview URL.'
+    appendTimelineNote: 'Resolving preview URL.'
   });
-  const preview = await waitForPreview(env, repoBoard, repo, runId, sleepFn, scmAdapter, scmCredential);
+  const preview = await waitForPreview(env, repoBoard, task, repo, runId, sleepFn, scmAdapter, scmCredential);
   if (preview.status !== 'ready') {
     const timeoutMessage = preview.status === 'timed_out'
       ? 'Preview URL did not appear before timeout. Completing run without preview evidence.'
@@ -471,16 +489,55 @@ async function finishRunWithoutEvidence(repoBoard: DurableObjectStub<RepoBoardDO
 }
 
 async function lookupPreviewUrl(
+  env: Stage3Env,
+  repoBoard: DurableObjectStub<RepoBoardDO>,
+  task: Task,
   repo: Repo,
+  run: Awaited<ReturnType<RepoBoardDO['getRun']>>,
   headSha: string,
+  sleepFn: SleepFn,
   scmAdapter: ScmAdapter,
   scmCredential: ScmAdapterCredential
 ) {
   const checks = await scmAdapter.listCommitChecks(repo, headSha, scmCredential);
   const previewAdapter = getPreviewAdapter(repo);
+  const llmAdapterKind = resolveLlmAdapterKind(task, run.llmAdapter);
+  const llmAdapter = getLlmAdapter(llmAdapterKind);
+  const sandbox = getSandbox(env.Sandbox, run.sandboxId ?? run.runId);
+  const llmModel = run.llmModel ?? task.uiMeta?.llmModel ?? task.uiMeta?.codexModel ?? 'gpt-5.3-codex';
+  const llmReasoningEffort = run.llmReasoningEffort ?? task.uiMeta?.llmReasoningEffort ?? task.uiMeta?.codexReasoningEffort ?? 'medium';
+
   return previewAdapter.resolve({
     repo,
-    checks
+    task,
+    run,
+    checks,
+    llm: {
+      adapter: llmAdapter,
+      runtimeContext: { env, sandbox, repoBoard, runId: run.runId },
+      model: llmModel,
+      reasoningEffort: llmReasoningEffort,
+      cwd: '/workspace/repo',
+      sleepFn,
+      runPrompt: (prompt, options) =>
+        executePromptWithLlmAdapter(
+          llmAdapter,
+          { env, sandbox, repoBoard, runId: run.runId },
+          {
+            repo,
+            task,
+            run,
+            cwd: '/workspace/repo',
+            prompt,
+            model: llmModel,
+            reasoningEffort: llmReasoningEffort,
+            timeoutMs: options?.timeoutMs,
+            outputSchema: options?.outputSchema,
+            phase: 'preview'
+          },
+          sleepFn
+        )
+    }
   });
 }
 
@@ -508,6 +565,9 @@ function formatPreviewDiscoveryLog(discovery: PreviewAdapterResult) {
     : '';
 
   if (discovery.resolution.previewUrl) {
+    if (discovery.resolution.adapter === 'prompt_recipe') {
+      return `${discovery.resolution.explanation}: ${discovery.resolution.previewUrl} | checks: ${checks}${diagnostics}`;
+    }
     return `Preview discovery matched ${discovery.compatibility.matchedCheck ?? 'unknown check'} via ${discovery.compatibility.adapter ?? discovery.resolution.adapter} from ${discovery.compatibility.source ?? 'unknown source'}: ${discovery.resolution.previewUrl} | checks: ${checks}${diagnostics}`;
   }
 

--- a/src/ui/domain/types.ts
+++ b/src/ui/domain/types.ts
@@ -25,6 +25,21 @@ export type RepoPreviewConfig = {
   checkName?: string;
   promptRecipe?: string;
 };
+export type PreviewResolutionStatus = 'ready' | 'pending' | 'failed' | 'timed_out';
+export type PreviewDiagnostic = {
+  code: string;
+  level: 'info' | 'error';
+  message: string;
+  metadata?: Record<string, string | number | boolean>;
+};
+export type RunPreviewResolution = {
+  adapter: PreviewAdapterKind;
+  status: PreviewResolutionStatus;
+  explanation: string;
+  checkedAt: string;
+  previewUrl?: string;
+  diagnostics: PreviewDiagnostic[];
+};
 
 export type RunEventType =
   | 'run.status_changed'
@@ -317,6 +332,7 @@ export type AgentRun = {
     codexOutcome?: 'changes' | 'no_changes' | 'failed';
     testsOutcome?: 'passed' | 'failed' | 'skipped';
     prCommented?: boolean;
+    previewResolution?: RunPreviewResolution;
   };
   artifacts?: string[];
   artifactManifest?: ArtifactManifest;


### PR DESCRIPTION
Task: S35-P5 Implement prompt-recipe preview adapter on the LLM seam

Implement the customer-defined prompt-recipe preview adapter using the generic LLM adapter/runtime and structured diagnostics contract.


Acceptance criteria:
- Prompt-recipe preview resolution works through the generic LLM adapter seam.
- Repo-defined prompt recipes can resolve a validated preview URL.
- The adapter remains opt-in and is not used as an implicit fallback.
- Structured diagnostics are persisted for success and failure cases.

Run ID: run_repo_abuiles_minions_mm9gnvue701h