### PR TITLE
S45-60 Usage ledger emission

### DIFF
--- a/src/server/durable/repo-board.ts
+++ b/src/server/durable/repo-board.ts
@@ -26,6 +26,7 @@ import { resolveRunSource } from '../shared/run-source-resolution';
 import { normalizeOperatorSession, normalizeRunLlmState, normalizeTaskUiMeta } from '../../shared/llm';
 import { hasRunReview, normalizeDependencyReviewMetadata, normalizeRunReviewMetadata, normalizeTaskBranchSourceReviewMetadata } from '../../shared/scm';
 import { DEFAULT_TENANT_ID, normalizeTenantId } from '../../shared/tenant';
+import { writeUsageLedgerEntriesBestEffort } from '../usage-ledger';
 
 const STORAGE_KEY = 'repo-board-state';
 const LOCAL_JOBS_KEY = 'repo-board-local-jobs';
@@ -563,14 +564,31 @@ export class RepoBoardDO extends DurableObject<Env> {
     }
     const repo = await this.getRepo(run.repoId);
     const manifest = buildArtifactManifest(run, task, repo, this.ctx.id.toString());
-    return this.transitionRun(runId, {
+    const updated = await this.transitionRun(runId, {
       artifactManifest: manifest,
       artifacts: [manifest.logs.key, manifest.before?.key, manifest.after?.key, manifest.trace?.key, manifest.video?.key].filter(Boolean) as string[]
     });
+    await this.recordUsage(updated, [
+      {
+        category: 'r2_write_ops',
+        quantity: 1,
+        source: 'workflow',
+        metadata: { object: 'artifact_manifest' }
+      }
+    ]);
+    return updated;
   }
 
   async getRunArtifacts(runId: string) {
     const run = await this.getRun(runId);
+    await this.recordUsage(run, [
+      {
+        category: 'artifact_download',
+        quantity: 1,
+        source: 'worker',
+        metadata: { endpoint: '/api/runs/:runId/artifacts' }
+      }
+    ]);
     return run.artifactManifest;
   }
 
@@ -619,6 +637,16 @@ export class RepoBoardDO extends DurableObject<Env> {
     await this.persist();
     await this.emit({ type: 'run.updated', payload: { run: updated } }, updated.repoId);
     await this.emit({ type: 'run.operator_session_updated', payload: { runId, session: normalizedSession } }, updated.repoId);
+    if (normalizedSession) {
+      await this.recordUsage(updated, [
+        {
+          category: 'operator_session_ms',
+          quantity: 1,
+          source: 'operator',
+          metadata: { event: 'operator_session_updated', state: normalizedSession.connectionState }
+        }
+      ]);
+    }
     return updated;
   }
 
@@ -761,6 +789,14 @@ export class RepoBoardDO extends DurableObject<Env> {
     await this.emit({ type: 'run.operator_session_updated', payload: { runId, session: nextSession } }, updated.repoId);
     await this.emit({ type: 'run.events_appended', payload: { runId, events } }, updated.repoId);
     await this.emitDependencyRefreshUpdates(updated.repoId, refreshedTasks, [finalTask.taskId]);
+    await this.recordUsage(updated, [
+      {
+        category: 'operator_session_ms',
+        quantity: 1,
+        source: 'operator',
+        metadata: { event: 'operator_takeover_started', sessionName: nextSession.sessionName }
+      }
+    ]);
     return updated;
   }
 
@@ -828,6 +864,31 @@ export class RepoBoardDO extends DurableObject<Env> {
   private async getRepo(repoId: string): Promise<Repo> {
     const board = this.env.BOARD_INDEX.getByName('agentboard');
     return board.getRepo(repoId);
+  }
+
+  private async recordUsage(
+    run: Pick<AgentRun, 'tenantId' | 'repoId' | 'taskId' | 'runId'>,
+    entries: Array<{
+      category: import('../usage-ledger').UsageLedgerCategory;
+      quantity: number;
+      unit?: string;
+      source: import('../usage-ledger').UsageLedgerSource;
+      metadata?: Record<string, string | number | boolean>;
+    }>
+  ) {
+    if (!entries.length) {
+      return;
+    }
+    await writeUsageLedgerEntriesBestEffort(
+      this.env,
+      entries.map((entry) => ({
+        tenantId: normalizeTenantId(run.tenantId),
+        repoId: run.repoId,
+        taskId: run.taskId,
+        runId: run.runId,
+        ...entry
+      }))
+    );
   }
 
   private async buildBoardPayload() {

--- a/src/server/run-orchestrator.llm.test.ts
+++ b/src/server/run-orchestrator.llm.test.ts
@@ -34,6 +34,7 @@ const scmState: {
       }
     | undefined;
 } = { current: undefined };
+const usageLedgerWritesState: { entries: Array<Record<string, unknown>> } = { entries: [] };
 
 vi.mock('@cloudflare/sandbox', () => ({
   getSandbox: () => {
@@ -57,6 +58,12 @@ vi.mock('./scm/registry', () => ({
       throw new Error('SCM adapter was not configured for this test.');
     }
     return scmState.current;
+  }
+}));
+
+vi.mock('./usage-ledger', () => ({
+  writeUsageLedgerEntriesBestEffort: async (_env: Env, entries: Array<Record<string, unknown>>) => {
+    usageLedgerWritesState.entries.push(...entries);
   }
 }));
 
@@ -260,6 +267,7 @@ function createHarness(task: Task, repo: Repo) {
 }
 
 beforeEach(() => {
+  usageLedgerWritesState.entries = [];
   scmState.current = {
     provider: 'github',
     buildCloneUrl: (_repo, credential) => `https://x-access-token:${credential.token}@github.com/abuiles/minions.git`,
@@ -363,5 +371,34 @@ describe('executeRunJob LLM adapter coverage', () => {
     expect(sandboxState.current?.startProcessCommand).toContain('CURSOR_BIN');
     expect(harness.commands.some((command) => command.command.includes('CURSOR_BIN'))).toBe(true);
     expect(harness.logs.some((entry) => entry.message.includes('Cursor CLI was responsible for choosing and running validation commands.'))).toBe(true);
+  });
+
+  it('emits partial usage entries when the run fails', async () => {
+    const task = buildTask({
+      uiMeta: {
+        llmAdapter: 'codex',
+        llmModel: 'gpt-5.3-codex',
+        llmReasoningEffort: 'medium'
+      }
+    });
+    const repo = buildRepo();
+    const harness = createHarness(task, repo);
+
+    sandboxState.current = buildSandbox([
+      { type: 'stderr', data: 'Codex failed with a non-zero exit.\n' },
+      { type: 'exit', exitCode: 1 }
+    ]);
+
+    await expect(
+      executeRunJob(harness.env, { repoId: repo.repoId, taskId: task.taskId, runId: 'run_1', mode: 'full_run' }, async () => {})
+    ).rejects.toThrow();
+
+    expect(usageLedgerWritesState.entries.length).toBeGreaterThan(0);
+    for (const entry of usageLedgerWritesState.entries) {
+      expect(entry.tenantId).toBeTruthy();
+      expect(entry.source).toBeTruthy();
+    }
+    expect(usageLedgerWritesState.entries.some((entry) => entry.category === 'workflow_execution')).toBe(true);
+    expect(usageLedgerWritesState.entries.some((entry) => entry.category === 'workflow_duration_ms')).toBe(true);
   });
 });

--- a/src/server/run-orchestrator.ts
+++ b/src/server/run-orchestrator.ts
@@ -14,6 +14,8 @@ import { getScmSourceRefFetchSpec } from './scm/source-ref';
 import { getLlmAdapter, resolveLlmAdapterKind } from './llm/registry';
 import { getPreviewAdapter } from './preview/registry';
 import type { PreviewAdapterContext, PreviewAdapterResult } from './preview/adapter';
+import { writeUsageLedgerEntriesBestEffort } from './usage-ledger';
+import { normalizeTenantId } from '../shared/tenant';
 
 type WorkflowBinding<T> = {
   create(options?: { id?: string; params?: T; retention?: { successRetention?: string | number; errorRetention?: string | number } }): Promise<{ id: string }>;
@@ -59,24 +61,292 @@ export async function executeRunJob(env: Env, params: RunJobParams, sleepFn: Sle
   const llmExecutorLabel = llmAdapter.kind === 'codex' ? 'Codex' : 'Cursor CLI';
   const llmModel = detail.task.uiMeta?.llmModel ?? detail.task.uiMeta?.codexModel ?? 'gpt-5.1-codex-mini';
   const llmReasoningEffort = detail.task.uiMeta?.llmReasoningEffort ?? detail.task.uiMeta?.codexReasoningEffort ?? 'medium';
+  const workflowStartedAtMs = Date.now();
+  let sandboxStartedAtMs: number | undefined;
+  const emitUsage = async (
+    entries: Array<{
+      category: import('./usage-ledger').UsageLedgerCategory;
+      quantity: number;
+      unit?: string;
+      source: import('./usage-ledger').UsageLedgerSource;
+      metadata?: Record<string, string | number | boolean>;
+    }>
+  ) => {
+    await writeUsageLedgerEntriesBestEffort(
+      env,
+      entries.map((entry) => ({
+        tenantId: normalizeTenantId(run.tenantId),
+        repoId: run.repoId,
+        taskId: run.taskId,
+        runId: run.runId,
+        ...entry
+      }))
+    );
+  };
 
-  if (params.mode === 'evidence_only') {
-    if (!shouldRunEvidence(repo)) {
-      await finishRunWithoutEvidence(repoBoard, params.runId, 'Evidence execution is disabled for this repo.');
-      return;
+  try {
+    await emitUsage([
+      {
+        category: 'workflow_execution',
+        quantity: 1,
+        source: 'workflow',
+        metadata: { mode: params.mode, event: 'workflow_started' }
+      },
+      {
+        category: 'workflow_step',
+        quantity: 1,
+        source: 'workflow',
+        metadata: { mode: params.mode, step: 'run_entered' }
+      }
+    ]);
+
+    if (params.mode === 'evidence_only') {
+      if (!shouldRunEvidence(repo)) {
+        await finishRunWithoutEvidence(repoBoard, params.runId, 'Evidence execution is disabled for this repo.');
+        return;
+      }
+      return runEvidence(env as Stage3Env, board, repoBoard, detail.task, repo, params.runId, sleepFn);
     }
-    return runEvidence(env as Stage3Env, board, repoBoard, detail.task, repo, params.runId, sleepFn);
-  }
 
-  if (params.mode === 'preview_only') {
+    if (params.mode === 'preview_only') {
+      if (!shouldRunPreview(repo)) {
+        await finishRunWithoutPreview(repoBoard, params.runId, 'Preview discovery is disabled for this repo.');
+        return;
+      }
+      const promptRecipeRuntime = repo.previewAdapter === 'prompt_recipe'
+        ? createPromptRecipeRuntime(env as Stage3Env, repoBoard, params.runId, repo, llmAdapter, llmModel, llmReasoningEffort)
+        : undefined;
+      return discoverPreviewAndRunEvidence(
+        env as Stage3Env,
+        repoBoard,
+        detail.task,
+        repo,
+        params.runId,
+        sleepFn,
+        scmAdapter,
+        await getScmCredential(env as Stage3Env, board, repo, scmAdapter),
+        promptRecipeRuntime
+      );
+    }
+
+    const scmCredential = await getScmCredential(env as Stage3Env, board, repo, scmAdapter);
+    const sandbox = getSandbox(env.Sandbox, params.runId);
+    const llmContext = { env, sandbox, repoBoard, runId: params.runId };
+    sandboxStartedAtMs = Date.now();
+
+    await emitUsage([
+      {
+        category: 'workflow_step',
+        quantity: 1,
+        source: 'workflow',
+        metadata: { step: 'sandbox_allocated' }
+      }
+    ]);
+
+    await repoBoard.appendRunLogs(params.runId, [buildRunLog(params.runId, `Starting sandbox run for ${repo.slug}.`, 'bootstrap')]);
+    await repoBoard.transitionRun(params.runId, {
+      status: 'BOOTSTRAPPING',
+      sandboxId: params.runId,
+      llmAdapter: llmAdapter.kind,
+      llmSupportsResume: llmAdapter.capabilities.supportsResume,
+      appendTimelineNote: 'Sandbox bootstrapped.'
+    });
+
+    try {
+      await emitCommandLifecycle(repoBoard, params.runId, 'bootstrap', 'mkdir -p /workspace/repo', () => sandbox.exec('mkdir -p /workspace/repo'));
+      await repoBoard.appendRunLogs(params.runId, [buildRunLog(params.runId, `${scmAdapter.provider} token suffix: ${scmCredential.token.slice(-4)}`, 'bootstrap')]);
+      await llmAdapter.restoreAuth({ ...llmContext, repo });
+      await sandbox.gitCheckout(scmAdapter.buildCloneUrl(repo, scmCredential), {
+        branch: repo.defaultBranch,
+        targetDir: '/workspace/repo'
+      });
+      await emitCommandLifecycle(
+        repoBoard,
+        params.runId,
+        'bootstrap',
+        `cd /workspace/repo && git config user.name 'AgentsKanban' && git config user.email 'agentskanban@local'`,
+        () => sandbox.exec(`cd /workspace/repo && git config user.name 'AgentsKanban' && git config user.email 'agentskanban@local'`)
+      );
+      await prepareRunBranchFromTaskSource(sandbox, repoBoard, params.runId, detail.task, repo, run, scmAdapter);
+    } catch (error) {
+      await failRun(repoBoard, params.runId, 'BOOTSTRAP_FAILED', 'bootstrap', error);
+      throw error;
+    }
+
+    await repoBoard.transitionRun(params.runId, { status: 'RUNNING_CODEX', appendTimelineNote: `${llmExecutorLabel} executing with full sandbox permissions.` });
+
+    try {
+      const prompt = buildLlmPrompt(detail.task, repo, run);
+      const request = {
+        repo,
+        task: detail.task,
+        run,
+        cwd: '/workspace/repo',
+        prompt,
+        model: llmModel,
+        reasoningEffort: llmReasoningEffort
+      } as const;
+      await llmAdapter.ensureInstalled(llmContext);
+      await llmAdapter.logDiagnostics(llmContext, request);
+      await llmAdapter.waitForCapacityIfNeeded?.(llmContext, request, sleepFn);
+      const llmResult = await llmAdapter.run(llmContext, request);
+      if (llmResult.stoppedForTakeover) {
+        await repoBoard.appendRunLogs(params.runId, [
+          buildRunLog(params.runId, `${llmExecutorLabel} execution stopped after operator takeover. Leaving the sandbox under operator control.`, 'codex')
+        ]);
+        return;
+      }
+      if (!llmResult.success) {
+        throw new NonRetryableError(llmResult.stderr || `${llmExecutorLabel} execution failed.`);
+      }
+    } catch (error) {
+      const currentRun = await repoBoard.getRun(params.runId);
+      if (currentRun.status === 'OPERATOR_CONTROLLED') {
+        return;
+      }
+      await failRun(repoBoard, params.runId, 'LLM_FAILED', 'codex', error, false);
+      throw error;
+    }
+
+    await repoBoard.transitionRun(params.runId, {
+      status: 'RUNNING_TESTS',
+      appendTimelineNote: `${llmExecutorLabel}-selected validation commands executed inside the sandbox.`,
+      executionSummary: { testsOutcome: 'skipped' }
+    });
+    await repoBoard.appendRunLogs(params.runId, [buildRunLog(params.runId, `${llmExecutorLabel} was responsible for choosing and running validation commands.`, 'tests')]);
+
+    await repoBoard.transitionRun(params.runId, { status: 'PUSHING_BRANCH', appendTimelineNote: 'Preparing git diff and push.' });
+
+    try {
+      const branchResult = await emitCommandLifecycle(repoBoard, params.runId, 'push', 'cd /workspace/repo && git branch --show-current', () =>
+        sandbox.exec('cd /workspace/repo && git branch --show-current')
+      );
+      if (!branchResult.success) {
+        throw new Error(branchResult.stderr || 'Failed to resolve the current branch.');
+      }
+
+      const currentBranch = branchResult.stdout.trim();
+      if (currentBranch !== run.branchName) {
+        await repoBoard.appendRunLogs(params.runId, [
+          buildRunLog(params.runId, `${llmExecutorLabel} changed the checked out branch to ${currentBranch}. Normalizing push to ${run.branchName} from current HEAD.`, 'push')
+        ]);
+      }
+
+      const statusResult = await emitCommandLifecycle(repoBoard, params.runId, 'push', 'cd /workspace/repo && git status --short', () =>
+        sandbox.exec('cd /workspace/repo && git status --short')
+      );
+      const hasWorkingTreeChanges = Boolean(statusResult.stdout.trim());
+      const baseHeadResult = await emitCommandLifecycle(repoBoard, params.runId, 'push', `cd /workspace/repo && git rev-parse origin/${shellEscape(repo.defaultBranch)}`, () =>
+        sandbox.exec(`cd /workspace/repo && git rev-parse origin/${shellEscape(repo.defaultBranch)}`)
+      );
+      if (!baseHeadResult.success) {
+        throw new Error(baseHeadResult.stderr || `Failed to resolve origin/${repo.defaultBranch}.`);
+      }
+
+      const currentHeadResult = await emitCommandLifecycle(repoBoard, params.runId, 'push', 'cd /workspace/repo && git rev-parse HEAD', () =>
+        sandbox.exec('cd /workspace/repo && git rev-parse HEAD')
+      );
+      if (!currentHeadResult.success) {
+        throw new Error(currentHeadResult.stderr || 'Failed to resolve HEAD.');
+      }
+
+      const hasLocalCommit = currentHeadResult.stdout.trim() !== baseHeadResult.stdout.trim();
+      if (!hasWorkingTreeChanges && !hasLocalCommit) {
+        await failRun(repoBoard, params.runId, 'NO_CHANGES', 'push', `${llmExecutorLabel} finished without producing a diff.`, false);
+        return;
+      }
+
+      let commitMessage: string;
+      if (hasWorkingTreeChanges) {
+        commitMessage = `AgentsKanban: ${detail.task.title}`;
+        const commitResult = await emitCommandLifecycle(
+          repoBoard,
+          params.runId,
+          'push',
+          `cd /workspace/repo && git add -A && git commit -m ${shellQuote(commitMessage)} && git push origin HEAD:${shellEscape(run.branchName)}`,
+          () => sandbox.exec(`cd /workspace/repo && git add -A && git commit -m ${shellQuote(commitMessage)} && git push origin HEAD:${shellEscape(run.branchName)}`)
+        );
+        if (!commitResult.success) {
+          throw new Error(commitResult.stderr || 'Commit and push failed.');
+        }
+      } else {
+        const commitMessageResult = await emitCommandLifecycle(repoBoard, params.runId, 'push', 'cd /workspace/repo && git log -1 --pretty=%s', () =>
+          sandbox.exec('cd /workspace/repo && git log -1 --pretty=%s')
+        );
+        if (!commitMessageResult.success) {
+          throw new Error(commitMessageResult.stderr || 'Failed to read the existing commit message.');
+        }
+        commitMessage = commitMessageResult.stdout.trim() || `AgentsKanban: ${detail.task.title}`;
+        await repoBoard.appendRunLogs(params.runId, [
+          buildRunLog(params.runId, `Detected an existing local commit from ${llmExecutorLabel}; pushing it without creating another commit.`, 'push')
+        ]);
+        const pushResult = await emitCommandLifecycle(repoBoard, params.runId, 'push', `cd /workspace/repo && git push origin HEAD:${shellEscape(run.branchName)}`, () =>
+          sandbox.exec(`cd /workspace/repo && git push origin HEAD:${shellEscape(run.branchName)}`)
+        );
+        if (!pushResult.success) {
+          throw new Error(pushResult.stderr || 'Push failed.');
+        }
+      }
+
+      const shaResult = await emitCommandLifecycle(repoBoard, params.runId, 'push', 'cd /workspace/repo && git rev-parse HEAD', () =>
+        sandbox.exec('cd /workspace/repo && git rev-parse HEAD')
+      );
+      if (!shaResult.success) {
+        throw new Error(shaResult.stderr || 'Failed to resolve the pushed commit SHA.');
+      }
+      await repoBoard.transitionRun(params.runId, {
+        commitSha: shaResult.stdout.trim(),
+        commitMessage,
+        headSha: shaResult.stdout.trim(),
+        executionSummary: { codexOutcome: 'changes' }
+      });
+    } catch (error) {
+      await failRun(repoBoard, params.runId, 'PUSH_FAILED', 'push', error);
+      throw error;
+    }
+
+    try {
+      const latestRun = await repoBoard.getRun(params.runId);
+      if (getRunReviewUrl(latestRun) && getRunReviewNumber(latestRun)) {
+        await repoBoard.transitionRun(params.runId, {
+          status: 'PR_OPEN',
+          reviewState: 'open',
+          landedOnDefaultBranch: false,
+          landedOnDefaultBranchAt: undefined,
+          previewStatus: 'DISCOVERING',
+          appendTimelineNote: 'Existing pull request updated with requested changes.'
+        });
+      } else {
+        const pr = await scmAdapter.createReviewRequest(repo, detail.task, latestRun, scmCredential);
+        await repoBoard.transitionRun(params.runId, {
+          status: 'PR_OPEN',
+          reviewUrl: pr.url,
+          reviewNumber: pr.number,
+          reviewProvider: pr.provider,
+          reviewState: 'open',
+          prNumber: pr.number,
+          prUrl: pr.url,
+          landedOnDefaultBranch: false,
+          landedOnDefaultBranchAt: undefined,
+          previewStatus: 'DISCOVERING',
+          appendTimelineNote: 'Pull request opened.'
+        });
+      }
+    } catch (error) {
+      await failRun(repoBoard, params.runId, 'PR_CREATE_FAILED', 'pr', error);
+      throw error;
+    }
+
     if (!shouldRunPreview(repo)) {
-      await finishRunWithoutPreview(repoBoard, params.runId, 'Preview discovery is disabled for this repo.');
+      await finishRunWithoutPreview(repoBoard, params.runId, 'Preview discovery and evidence are disabled for this repo.');
       return;
     }
+
     const promptRecipeRuntime = repo.previewAdapter === 'prompt_recipe'
       ? createPromptRecipeRuntime(env as Stage3Env, repoBoard, params.runId, repo, llmAdapter, llmModel, llmReasoningEffort)
       : undefined;
-    return discoverPreviewAndRunEvidence(
+
+    await discoverPreviewAndRunEvidence(
       env as Stage3Env,
       repoBoard,
       detail.task,
@@ -84,229 +354,30 @@ export async function executeRunJob(env: Env, params: RunJobParams, sleepFn: Sle
       params.runId,
       sleepFn,
       scmAdapter,
-      await getScmCredential(env as Stage3Env, board, repo, scmAdapter),
+      scmCredential,
       promptRecipeRuntime
     );
-  }
-
-  const scmCredential = await getScmCredential(env as Stage3Env, board, repo, scmAdapter);
-  const sandbox = getSandbox(env.Sandbox, params.runId);
-  const llmContext = { env, sandbox, repoBoard, runId: params.runId };
-
-  await repoBoard.appendRunLogs(params.runId, [buildRunLog(params.runId, `Starting sandbox run for ${repo.slug}.`, 'bootstrap')]);
-  await repoBoard.transitionRun(params.runId, {
-    status: 'BOOTSTRAPPING',
-    sandboxId: params.runId,
-    llmAdapter: llmAdapter.kind,
-    llmSupportsResume: llmAdapter.capabilities.supportsResume,
-    appendTimelineNote: 'Sandbox bootstrapped.'
-  });
-
-  try {
-    await emitCommandLifecycle(repoBoard, params.runId, 'bootstrap', 'mkdir -p /workspace/repo', () => sandbox.exec('mkdir -p /workspace/repo'));
-    await repoBoard.appendRunLogs(params.runId, [buildRunLog(params.runId, `${scmAdapter.provider} token suffix: ${scmCredential.token.slice(-4)}`, 'bootstrap')]);
-    await llmAdapter.restoreAuth({ ...llmContext, repo });
-    await sandbox.gitCheckout(scmAdapter.buildCloneUrl(repo, scmCredential), {
-      branch: repo.defaultBranch,
-      targetDir: '/workspace/repo'
-    });
-    await emitCommandLifecycle(
-      repoBoard,
-      params.runId,
-      'bootstrap',
-      `cd /workspace/repo && git config user.name 'AgentsKanban' && git config user.email 'agentskanban@local'`,
-      () => sandbox.exec(`cd /workspace/repo && git config user.name 'AgentsKanban' && git config user.email 'agentskanban@local'`)
-    );
-    await prepareRunBranchFromTaskSource(sandbox, repoBoard, params.runId, detail.task, repo, run, scmAdapter);
-  } catch (error) {
-    await failRun(repoBoard, params.runId, 'BOOTSTRAP_FAILED', 'bootstrap', error);
-    throw error;
-  }
-
-  await repoBoard.transitionRun(params.runId, { status: 'RUNNING_CODEX', appendTimelineNote: `${llmExecutorLabel} executing with full sandbox permissions.` });
-
-  try {
-    const prompt = buildLlmPrompt(detail.task, repo, run);
-    const request = {
-      repo,
-      task: detail.task,
-      run,
-      cwd: '/workspace/repo',
-      prompt,
-      model: llmModel,
-      reasoningEffort: llmReasoningEffort
-    } as const;
-    await llmAdapter.ensureInstalled(llmContext);
-    await llmAdapter.logDiagnostics(llmContext, request);
-    await llmAdapter.waitForCapacityIfNeeded?.(llmContext, request, sleepFn);
-    const llmResult = await llmAdapter.run(llmContext, request);
-    if (llmResult.stoppedForTakeover) {
-      await repoBoard.appendRunLogs(params.runId, [
-        buildRunLog(params.runId, `${llmExecutorLabel} execution stopped after operator takeover. Leaving the sandbox under operator control.`, 'codex')
-      ]);
-      return;
-    }
-    if (!llmResult.success) {
-      throw new NonRetryableError(llmResult.stderr || `${llmExecutorLabel} execution failed.`);
-    }
-  } catch (error) {
-    const currentRun = await repoBoard.getRun(params.runId);
-    if (currentRun.status === 'OPERATOR_CONTROLLED') {
-      return;
-    }
-    await failRun(repoBoard, params.runId, 'LLM_FAILED', 'codex', error, false);
-    throw error;
-  }
-
-  await repoBoard.transitionRun(params.runId, {
-    status: 'RUNNING_TESTS',
-    appendTimelineNote: `${llmExecutorLabel}-selected validation commands executed inside the sandbox.`,
-    executionSummary: { testsOutcome: 'skipped' }
-  });
-  await repoBoard.appendRunLogs(params.runId, [buildRunLog(params.runId, `${llmExecutorLabel} was responsible for choosing and running validation commands.`, 'tests')]);
-
-  await repoBoard.transitionRun(params.runId, { status: 'PUSHING_BRANCH', appendTimelineNote: 'Preparing git diff and push.' });
-
-  try {
-    const branchResult = await emitCommandLifecycle(repoBoard, params.runId, 'push', 'cd /workspace/repo && git branch --show-current', () =>
-      sandbox.exec('cd /workspace/repo && git branch --show-current')
-    );
-    if (!branchResult.success) {
-      throw new Error(branchResult.stderr || 'Failed to resolve the current branch.');
-    }
-
-    const currentBranch = branchResult.stdout.trim();
-    if (currentBranch !== run.branchName) {
-      await repoBoard.appendRunLogs(params.runId, [
-        buildRunLog(params.runId, `${llmExecutorLabel} changed the checked out branch to ${currentBranch}. Normalizing push to ${run.branchName} from current HEAD.`, 'push')
+  } finally {
+    const endedAtMs = Date.now();
+    await emitUsage([
+      {
+        category: 'workflow_duration_ms',
+        quantity: Math.max(0, endedAtMs - workflowStartedAtMs),
+        source: 'workflow',
+        metadata: { mode: params.mode }
+      }
+    ]);
+    if (sandboxStartedAtMs !== undefined) {
+      await emitUsage([
+        {
+          category: 'sandbox_runtime_ms',
+          quantity: Math.max(0, endedAtMs - sandboxStartedAtMs),
+          source: 'sandbox',
+          metadata: { sandboxId: params.runId }
+        }
       ]);
     }
-
-    const statusResult = await emitCommandLifecycle(repoBoard, params.runId, 'push', 'cd /workspace/repo && git status --short', () =>
-      sandbox.exec('cd /workspace/repo && git status --short')
-    );
-    const hasWorkingTreeChanges = Boolean(statusResult.stdout.trim());
-    const baseHeadResult = await emitCommandLifecycle(repoBoard, params.runId, 'push', `cd /workspace/repo && git rev-parse origin/${shellEscape(repo.defaultBranch)}`, () =>
-      sandbox.exec(`cd /workspace/repo && git rev-parse origin/${shellEscape(repo.defaultBranch)}`)
-    );
-    if (!baseHeadResult.success) {
-      throw new Error(baseHeadResult.stderr || `Failed to resolve origin/${repo.defaultBranch}.`);
-    }
-
-    const currentHeadResult = await emitCommandLifecycle(repoBoard, params.runId, 'push', 'cd /workspace/repo && git rev-parse HEAD', () =>
-      sandbox.exec('cd /workspace/repo && git rev-parse HEAD')
-    );
-    if (!currentHeadResult.success) {
-      throw new Error(currentHeadResult.stderr || 'Failed to resolve HEAD.');
-    }
-
-    const hasLocalCommit = currentHeadResult.stdout.trim() !== baseHeadResult.stdout.trim();
-    if (!hasWorkingTreeChanges && !hasLocalCommit) {
-      await failRun(repoBoard, params.runId, 'NO_CHANGES', 'push', `${llmExecutorLabel} finished without producing a diff.`, false);
-      return;
-    }
-
-    let commitMessage: string;
-    if (hasWorkingTreeChanges) {
-      commitMessage = `AgentsKanban: ${detail.task.title}`;
-      const commitResult = await emitCommandLifecycle(
-        repoBoard,
-        params.runId,
-        'push',
-        `cd /workspace/repo && git add -A && git commit -m ${shellQuote(commitMessage)} && git push origin HEAD:${shellEscape(run.branchName)}`,
-        () => sandbox.exec(`cd /workspace/repo && git add -A && git commit -m ${shellQuote(commitMessage)} && git push origin HEAD:${shellEscape(run.branchName)}`)
-      );
-      if (!commitResult.success) {
-        throw new Error(commitResult.stderr || 'Commit and push failed.');
-      }
-    } else {
-      const commitMessageResult = await emitCommandLifecycle(repoBoard, params.runId, 'push', 'cd /workspace/repo && git log -1 --pretty=%s', () =>
-        sandbox.exec('cd /workspace/repo && git log -1 --pretty=%s')
-      );
-      if (!commitMessageResult.success) {
-        throw new Error(commitMessageResult.stderr || 'Failed to read the existing commit message.');
-      }
-      commitMessage = commitMessageResult.stdout.trim() || `AgentsKanban: ${detail.task.title}`;
-      await repoBoard.appendRunLogs(params.runId, [
-        buildRunLog(params.runId, `Detected an existing local commit from ${llmExecutorLabel}; pushing it without creating another commit.`, 'push')
-      ]);
-      const pushResult = await emitCommandLifecycle(repoBoard, params.runId, 'push', `cd /workspace/repo && git push origin HEAD:${shellEscape(run.branchName)}`, () =>
-        sandbox.exec(`cd /workspace/repo && git push origin HEAD:${shellEscape(run.branchName)}`)
-      );
-      if (!pushResult.success) {
-        throw new Error(pushResult.stderr || 'Push failed.');
-      }
-    }
-
-    const shaResult = await emitCommandLifecycle(repoBoard, params.runId, 'push', 'cd /workspace/repo && git rev-parse HEAD', () =>
-      sandbox.exec('cd /workspace/repo && git rev-parse HEAD')
-    );
-    if (!shaResult.success) {
-      throw new Error(shaResult.stderr || 'Failed to resolve the pushed commit SHA.');
-    }
-    await repoBoard.transitionRun(params.runId, {
-      commitSha: shaResult.stdout.trim(),
-      commitMessage,
-      headSha: shaResult.stdout.trim(),
-      executionSummary: { codexOutcome: 'changes' }
-    });
-  } catch (error) {
-    await failRun(repoBoard, params.runId, 'PUSH_FAILED', 'push', error);
-    throw error;
   }
-
-  try {
-    const latestRun = await repoBoard.getRun(params.runId);
-    if (getRunReviewUrl(latestRun) && getRunReviewNumber(latestRun)) {
-      await repoBoard.transitionRun(params.runId, {
-        status: 'PR_OPEN',
-        reviewState: 'open',
-        landedOnDefaultBranch: false,
-        landedOnDefaultBranchAt: undefined,
-        previewStatus: 'DISCOVERING',
-        appendTimelineNote: 'Existing pull request updated with requested changes.'
-      });
-    } else {
-      const pr = await scmAdapter.createReviewRequest(repo, detail.task, latestRun, scmCredential);
-      await repoBoard.transitionRun(params.runId, {
-        status: 'PR_OPEN',
-        reviewUrl: pr.url,
-        reviewNumber: pr.number,
-        reviewProvider: pr.provider,
-        reviewState: 'open',
-        prNumber: pr.number,
-        prUrl: pr.url,
-        landedOnDefaultBranch: false,
-        landedOnDefaultBranchAt: undefined,
-        previewStatus: 'DISCOVERING',
-        appendTimelineNote: 'Pull request opened.'
-      });
-    }
-  } catch (error) {
-    await failRun(repoBoard, params.runId, 'PR_CREATE_FAILED', 'pr', error);
-    throw error;
-  }
-
-  if (!shouldRunPreview(repo)) {
-    await finishRunWithoutPreview(repoBoard, params.runId, 'Preview discovery and evidence are disabled for this repo.');
-    return;
-  }
-
-  const promptRecipeRuntime = repo.previewAdapter === 'prompt_recipe'
-    ? createPromptRecipeRuntime(env as Stage3Env, repoBoard, params.runId, repo, llmAdapter, llmModel, llmReasoningEffort)
-    : undefined;
-
-  await discoverPreviewAndRunEvidence(
-    env as Stage3Env,
-    repoBoard,
-    detail.task,
-    repo,
-    params.runId,
-    sleepFn,
-    scmAdapter,
-    scmCredential,
-    promptRecipeRuntime
-  );
 }
 
 async function runEvidence(
@@ -363,7 +434,7 @@ npx -y playwright install chromium
   }
 
   const updated = await repoBoard.storeArtifactManifest(runId);
-  await persistArtifactManifest(env, updated.runId, updated.artifactManifest);
+  await persistArtifactManifest(env, updated);
   if (getRunReviewNumber(updated)) {
     const scmAdapter = getScmAdapter(repo);
     const scmCredential = await getScmCredential(env, board, repo, scmAdapter);
@@ -624,13 +695,37 @@ async function getScmCredential(
   throw new NonRetryableError(`Missing SCM credential for provider ${scmAdapter.provider} host ${getRepoHost(repo)}.`);
 }
 
-async function persistArtifactManifest(env: Stage3Env, runId: string, manifest: Awaited<ReturnType<RepoBoardDO['getRunArtifacts']>>) {
+async function persistArtifactManifest(env: Stage3Env, run: Awaited<ReturnType<RepoBoardDO['getRun']>>) {
+  const manifest = run.artifactManifest;
   if (!manifest || !env.RUN_ARTIFACTS) {
     return;
   }
-  await env.RUN_ARTIFACTS.put(`runs/${runId}/manifest.json`, JSON.stringify(manifest, null, 2), {
+  const payload = JSON.stringify(manifest, null, 2);
+  await env.RUN_ARTIFACTS.put(`runs/${run.runId}/manifest.json`, payload, {
     httpMetadata: { contentType: 'application/json' }
   });
+  await writeUsageLedgerEntriesBestEffort(env, [
+    {
+      tenantId: normalizeTenantId(run.tenantId),
+      repoId: run.repoId,
+      taskId: run.taskId,
+      runId: run.runId,
+      category: 'r2_write_ops',
+      quantity: 1,
+      source: 'workflow',
+      metadata: { object: 'manifest.json' }
+    },
+    {
+      tenantId: normalizeTenantId(run.tenantId),
+      repoId: run.repoId,
+      taskId: run.taskId,
+      runId: run.runId,
+      category: 'r2_storage_bytes',
+      quantity: payload.length,
+      source: 'workflow',
+      metadata: { object: 'manifest.json' }
+    }
+  ]);
 }
 
 async function failRun(repoBoard: DurableObjectStub<RepoBoardDO>, runId: string, code: string, phase: NonNullable<ReturnType<typeof buildRunLog>['phase']>, error: unknown, retryable = true) {

--- a/src/server/usage-ledger.test.ts
+++ b/src/server/usage-ledger.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest';
+import { writeUsageLedgerEntries } from './usage-ledger';
+
+type InsertedRow = Record<string, unknown>;
+
+class FakeD1Statement {
+  private bindings: unknown[] = [];
+
+  constructor(
+    public readonly sql: string,
+    private readonly execute: (sql: string, bindings: unknown[]) => Promise<{ results?: unknown[] }>
+  ) {}
+
+  bind(...values: unknown[]) {
+    this.bindings = values;
+    return this;
+  }
+
+  async run() {
+    return this.execute(this.sql, this.bindings);
+  }
+
+  async all<T>() {
+    return this.execute(this.sql, this.bindings) as Promise<{ results: T[] }>;
+  }
+}
+
+class FakeUsageDb {
+  rows: InsertedRow[] = [];
+
+  prepare(sql: string) {
+    return new FakeD1Statement(sql, async (statement, bindings) => this.execute(statement, bindings));
+  }
+
+  private async execute(sql: string, bindings: unknown[]): Promise<{ results?: unknown[] }> {
+    if (sql.includes('FROM sqlite_master')) {
+      return { results: [{ name: 'usage_ledger_entries' }] };
+    }
+    if (sql.startsWith('PRAGMA table_info')) {
+      return {
+        results: [
+          { name: 'id' },
+          { name: 'tenant_id' },
+          { name: 'repo_id' },
+          { name: 'task_id' },
+          { name: 'run_id' },
+          { name: 'at' },
+          { name: 'category' },
+          { name: 'quantity' },
+          { name: 'unit' },
+          { name: 'source' },
+          { name: 'metadata' },
+          { name: 'rate_version' },
+          { name: 'estimated_cost_usd' },
+          { name: 'unit_rate_usd' }
+        ]
+      };
+    }
+    if (sql.startsWith('INSERT INTO')) {
+      const columnList = sql.slice(sql.indexOf('(') + 1, sql.indexOf(')')).split(',').map((value) => value.trim().replaceAll('"', ''));
+      const row: InsertedRow = {};
+      for (let index = 0; index < columnList.length; index += 1) {
+        row[columnList[index]] = bindings[index];
+      }
+      this.rows.push(row);
+      return {};
+    }
+    throw new Error(`Unhandled SQL in fake DB: ${sql}`);
+  }
+}
+
+describe('usage-ledger writes', () => {
+  it('writes tenant-attributed entries with source and rate-version metadata', async () => {
+    const db = new FakeUsageDb();
+    const env = { USAGE_DB: db } as unknown as Env;
+
+    await writeUsageLedgerEntries(env, [
+      {
+        tenantId: 'tenant_acme',
+        repoId: 'repo_1',
+        taskId: 'task_1',
+        runId: 'run_1',
+        category: 'workflow_execution',
+        quantity: 1,
+        source: 'workflow',
+        metadata: { event: 'start' }
+      }
+    ]);
+
+    expect(db.rows).toHaveLength(1);
+    expect(db.rows[0].tenant_id).toBe('tenant_acme');
+    expect(db.rows[0].source).toBe('workflow');
+    expect(db.rows[0].rate_version).toBe('v1');
+    expect(String(db.rows[0].metadata)).toContain('"rateVersion":"v1"');
+  });
+
+  it('is a no-op when a usage database binding is unavailable', async () => {
+    const env = {} as Env;
+    await expect(
+      writeUsageLedgerEntries(env, [
+        {
+          tenantId: 'tenant_acme',
+          category: 'worker_request',
+          quantity: 1,
+          source: 'worker'
+        }
+      ])
+    ).resolves.toBe(0);
+  });
+});

--- a/src/server/usage-ledger.ts
+++ b/src/server/usage-ledger.ts
@@ -1,0 +1,219 @@
+import { normalizeTenantId } from '../shared/tenant';
+
+export type UsageLedgerCategory =
+  | 'worker_request'
+  | 'workflow_execution'
+  | 'workflow_step'
+  | 'workflow_duration_ms'
+  | 'sandbox_runtime_ms'
+  | 'operator_session_ms'
+  | 'r2_storage_bytes'
+  | 'r2_write_ops'
+  | 'r2_read_ops'
+  | 'artifact_download'
+  | 'durable_object_request'
+  | 'durable_object_storage_bytes';
+
+export type UsageLedgerSource = 'worker' | 'workflow' | 'sandbox' | 'operator' | 'system';
+
+export type UsageLedgerWriteInput = {
+  tenantId: string;
+  repoId?: string;
+  taskId?: string;
+  runId?: string;
+  at?: string;
+  category: UsageLedgerCategory;
+  quantity: number;
+  unit?: string;
+  source: UsageLedgerSource;
+  metadata?: Record<string, string | number | boolean>;
+};
+
+type UsageTableConfig = {
+  table: string;
+  columns: {
+    id?: string;
+    tenantId: string;
+    repoId?: string;
+    taskId?: string;
+    runId?: string;
+    at: string;
+    category: string;
+    quantity: string;
+    unit?: string;
+    source?: string;
+    metadata?: string;
+    rateVersion?: string;
+    estimatedCostUsd?: string;
+    unitRateUsd?: string;
+  };
+};
+
+const TABLE_CANDIDATES = ['usage_ledger_entries', 'usage_ledger', 'tenant_usage_ledger', 'run_usage_ledger'] as const;
+const RATE_VERSION = 'v1';
+
+const RATE_CONFIG: Record<UsageLedgerCategory, { unit: string; usdRate: number }> = {
+  worker_request: { unit: 'request', usdRate: 0.000002 },
+  workflow_execution: { unit: 'execution', usdRate: 0.001 },
+  workflow_step: { unit: 'step', usdRate: 0.0001 },
+  workflow_duration_ms: { unit: 'ms', usdRate: 0.00000002 },
+  sandbox_runtime_ms: { unit: 'ms', usdRate: 0.00000005 },
+  operator_session_ms: { unit: 'ms', usdRate: 0.00000002 },
+  r2_storage_bytes: { unit: 'byte', usdRate: 0.0000000000008 },
+  r2_write_ops: { unit: 'op', usdRate: 0.0000045 },
+  r2_read_ops: { unit: 'op', usdRate: 0.00000036 },
+  artifact_download: { unit: 'download', usdRate: 0.000005 },
+  durable_object_request: { unit: 'request', usdRate: 0.000002 },
+  durable_object_storage_bytes: { unit: 'byte', usdRate: 0.0000000000006 }
+};
+
+function asD1Database(value: unknown): D1Database | undefined {
+  if (value && typeof value === 'object' && 'prepare' in value && typeof (value as { prepare?: unknown }).prepare === 'function') {
+    return value as D1Database;
+  }
+  return undefined;
+}
+
+function resolveUsageDatabase(env: Env): D1Database | undefined {
+  const record = env as unknown as Record<string, unknown>;
+  for (const preferred of ['USAGE_DB', 'TENANT_USAGE_DB', 'APP_DB', 'DB']) {
+    const db = asD1Database(record[preferred]);
+    if (db) {
+      return db;
+    }
+  }
+  for (const candidate of Object.values(record)) {
+    const db = asD1Database(candidate);
+    if (db) {
+      return db;
+    }
+  }
+  return undefined;
+}
+
+function quoteIdentifier(identifier: string): string {
+  return `"${identifier.replace(/"/g, '""')}"`;
+}
+
+function selectColumn(columns: Set<string>, candidates: string[], required = false): string | undefined {
+  const hit = candidates.find((candidate) => columns.has(candidate));
+  if (!hit && required) {
+    throw new Error(`Usage ledger schema is missing required columns (${candidates.join(' or ')}).`);
+  }
+  return hit;
+}
+
+async function resolveUsageTable(db: D1Database): Promise<UsageTableConfig | undefined> {
+  const tables = await db.prepare(`SELECT name FROM sqlite_master WHERE type = 'table'`).all<{ name: string }>();
+  const tableNames = new Set((tables.results ?? []).map((row) => row.name));
+  const table = TABLE_CANDIDATES.find((candidate) => tableNames.has(candidate));
+  if (!table) {
+    return undefined;
+  }
+
+  const pragmaRows = await db.prepare(`PRAGMA table_info(${quoteIdentifier(table)})`).all<{ name: string }>();
+  const columnNames = new Set((pragmaRows.results ?? []).map((row) => row.name));
+  const columns = {
+    id: selectColumn(columnNames, ['id', 'entry_id']),
+    tenantId: selectColumn(columnNames, ['tenant_id', 'tenantId'], true)!,
+    repoId: selectColumn(columnNames, ['repo_id', 'repoId']),
+    taskId: selectColumn(columnNames, ['task_id', 'taskId']),
+    runId: selectColumn(columnNames, ['run_id', 'runId']),
+    at: selectColumn(columnNames, ['at', 'created_at', 'recorded_at'], true)!,
+    category: selectColumn(columnNames, ['category', 'usage_category'], true)!,
+    quantity: selectColumn(columnNames, ['quantity', 'amount'], true)!,
+    unit: selectColumn(columnNames, ['unit']),
+    source: selectColumn(columnNames, ['source']),
+    metadata: selectColumn(columnNames, ['metadata']),
+    rateVersion: selectColumn(columnNames, ['rate_version', 'rateVersion']),
+    estimatedCostUsd: selectColumn(columnNames, ['estimated_cost_usd', 'estimatedCostUsd', 'estimated_usd']),
+    unitRateUsd: selectColumn(columnNames, ['unit_rate_usd', 'rate_usd', 'cost_rate_usd'])
+  } satisfies UsageTableConfig['columns'];
+  return { table, columns };
+}
+
+function toFiniteNumber(value: number) {
+  return Number.isFinite(value) ? value : 0;
+}
+
+function toJsonString(metadata: Record<string, string | number | boolean> | undefined): string | undefined {
+  if (!metadata || !Object.keys(metadata).length) {
+    return undefined;
+  }
+  return JSON.stringify(metadata);
+}
+
+export async function writeUsageLedgerEntries(env: Env, entries: UsageLedgerWriteInput[]): Promise<number> {
+  if (!entries.length) {
+    return 0;
+  }
+
+  const db = resolveUsageDatabase(env);
+  if (!db) {
+    return 0;
+  }
+
+  const usage = await resolveUsageTable(db);
+  if (!usage) {
+    return 0;
+  }
+
+  let written = 0;
+  for (const entry of entries) {
+    const at = entry.at ?? new Date().toISOString();
+    const rate = RATE_CONFIG[entry.category];
+    const rateVersion = RATE_VERSION;
+    const unit = entry.unit ?? rate.unit;
+    const estimatedCostUsd = toFiniteNumber(entry.quantity * rate.usdRate);
+    const metadata = {
+      ...(entry.metadata ?? {}),
+      rateVersion
+    };
+
+    const columns: string[] = [];
+    const values: unknown[] = [];
+    const pushValue = (column: string | undefined, value: unknown) => {
+      if (!column) {
+        return;
+      }
+      columns.push(quoteIdentifier(column));
+      values.push(value);
+    };
+
+    pushValue(usage.columns.id, crypto.randomUUID());
+    pushValue(usage.columns.tenantId, normalizeTenantId(entry.tenantId));
+    pushValue(usage.columns.repoId, entry.repoId ?? '');
+    pushValue(usage.columns.taskId, entry.taskId ?? '');
+    pushValue(usage.columns.runId, entry.runId ?? '');
+    pushValue(usage.columns.at, at);
+    pushValue(usage.columns.category, entry.category);
+    pushValue(usage.columns.quantity, toFiniteNumber(entry.quantity));
+    pushValue(usage.columns.unit, unit);
+    pushValue(usage.columns.source, entry.source);
+    pushValue(usage.columns.metadata, toJsonString(metadata));
+    pushValue(usage.columns.rateVersion, rateVersion);
+    pushValue(usage.columns.unitRateUsd, rate.usdRate);
+    pushValue(usage.columns.estimatedCostUsd, estimatedCostUsd);
+
+    if (!columns.length) {
+      continue;
+    }
+
+    const placeholders = columns.map(() => '?').join(', ');
+    await db
+      .prepare(`INSERT INTO ${quoteIdentifier(usage.table)} (${columns.join(', ')}) VALUES (${placeholders})`)
+      .bind(...values)
+      .run();
+    written += 1;
+  }
+
+  return written;
+}
+
+export async function writeUsageLedgerEntriesBestEffort(env: Env, entries: UsageLedgerWriteInput[]): Promise<void> {
+  try {
+    await writeUsageLedgerEntries(env, entries);
+  } catch (error) {
+    console.warn('Usage ledger write failed', { error });
+  }
+}


### PR DESCRIPTION
Task: S45-60 Usage ledger emission

Emit tenant-attributed usage entries across workflow, sandbox, operator, and artifacts.


Acceptance criteria:
- Usage entries include tenantId and source
- Failed runs still emit partial usage
- Rate-version metadata is captured

Run ID: run_repo_abuiles_minions_mm9mzo5rosdf