### PR TITLE
S45-40 Tenant-scoped persistence + APIs

### DIFF
--- a/src/server/durable/board-index.ts
+++ b/src/server/durable/board-index.ts
@@ -76,7 +76,11 @@ export class BoardIndexDO extends DurableObject<Env> {
     const url = new URL(request.url);
     if (url.pathname.endsWith('/ws')) {
       const repoId = url.searchParams.get('repoId') ?? 'all';
-      return this.handleWebSocket(repoId);
+      const tenantId = url.searchParams.get('tenantId') ?? request.headers.get('x-tenant-id') ?? undefined;
+      if (!tenantId) {
+        throw badRequest('Missing tenantId for board websocket subscription.');
+      }
+      return this.handleWebSocket(repoId, tenantId);
     }
 
     return new Response('Not found', { status: 404 });
@@ -522,11 +526,27 @@ export class BoardIndexDO extends DurableObject<Env> {
     const repos = await this.listRepos(normalizedTenantId);
     const selected = repoId && repoId !== 'all' ? repos.filter((repo) => repo.repoId === repoId) : repos;
     const slices = await Promise.all(selected.map((repo) => this.env.REPO_BOARD.getByName(repo.repoId).getBoardSlice()));
-    const tasks = slices.flatMap((slice) => slice.tasks);
-    const runs = slices.flatMap((slice) => slice.runs);
-    const logs = slices.flatMap((slice) => slice.logs);
-    const events = slices.flatMap((slice) => slice.events ?? []);
-    const commands = slices.flatMap((slice) => slice.commands ?? []);
+    const tasks = slices
+      .flatMap((slice) => slice.tasks)
+      .filter((task) => !normalizedTenantId || normalizeTenantId(task.tenantId) === normalizedTenantId);
+    const runs = slices
+      .flatMap((slice) => slice.runs)
+      .filter((run) => !normalizedTenantId || normalizeTenantId(run.tenantId) === normalizedTenantId);
+    const runIds = new Set(runs.map((run) => run.runId));
+    const taskIds = new Set(tasks.map((task) => task.taskId));
+    const logs = slices.flatMap((slice) => slice.logs).filter((log) => runIds.has(log.runId));
+    const events = slices
+      .flatMap((slice) => slice.events ?? [])
+      .filter((event) =>
+        !normalizedTenantId
+        || (normalizeTenantId(event.tenantId) === normalizedTenantId && (runIds.has(event.runId) || taskIds.has(event.taskId)))
+      );
+    const commands = slices
+      .flatMap((slice) => slice.commands ?? [])
+      .filter((command) =>
+        !normalizedTenantId
+        || (normalizeTenantId(command.tenantId) === normalizedTenantId && runIds.has(command.runId))
+      );
 
     return {
       repos,
@@ -570,7 +590,12 @@ export class BoardIndexDO extends DurableObject<Env> {
       })
     );
 
-    await this.broadcast({ type: 'board.snapshot', payload: await this.getBoardSync('all') });
+    const tenantIds = [...new Set(snapshot.repos.map((repo) => normalizeTenantId(repo.tenantId)))];
+    await Promise.all(
+      tenantIds.map(async (tenantId) => {
+        await this.broadcast({ type: 'board.snapshot', payload: await this.getBoardSync('all', tenantId) }, undefined, tenantId);
+      })
+    );
   }
 
   async findTaskRepoId(taskId: string) {
@@ -595,31 +620,77 @@ export class BoardIndexDO extends DurableObject<Env> {
     return undefined;
   }
 
-  async notifyRepoEvent(event: BoardEvent & { repoId?: string }) {
+  async notifyRepoEvent(event: BoardEvent & { repoId?: string; tenantId?: string }) {
     await this.ready;
+    const tenantId = await this.resolveEventTenantId(event);
+    if (!tenantId) {
+      return;
+    }
     const message = stringifyBoardEvent(event);
-    for (const socket of this.ctx.getWebSockets('scope:all')) {
+    for (const socket of this.ctx.getWebSockets(buildTenantAllScopeTag(tenantId))) {
       socket.send(message);
     }
 
     if (event.repoId) {
-      for (const socket of this.ctx.getWebSockets(`scope:repo:${event.repoId}`)) {
+      for (const socket of this.ctx.getWebSockets(buildTenantRepoScopeTag(tenantId, event.repoId))) {
         socket.send(message);
       }
     }
   }
 
-  private async handleWebSocket(repoId: string) {
+  private async handleWebSocket(repoId: string, tenantId: string) {
+    const normalizedTenantId = normalizeTenantId(tenantId);
+    if (repoId !== 'all') {
+      const repo = await this.getRepo(repoId);
+      if (normalizeTenantId(repo.tenantId) !== normalizedTenantId) {
+        throw forbidden(`Cross-tenant websocket access denied: repo ${repoId} belongs to tenant ${repo.tenantId}.`);
+      }
+    }
     const pair = new WebSocketPair();
     const [client, server] = Object.values(pair);
-    const tag = repoId === 'all' ? 'scope:all' : `scope:repo:${repoId}`;
-    this.ctx.acceptWebSocket(server, [tag]);
-    server.send(stringifyBoardEvent({ type: 'board.snapshot', payload: await this.getBoardSync(repoId) }));
+    const tags = repoId === 'all'
+      ? [buildTenantAllScopeTag(normalizedTenantId)]
+      : [buildTenantRepoScopeTag(normalizedTenantId, repoId)];
+    this.ctx.acceptWebSocket(server, tags);
+    server.send(stringifyBoardEvent({ type: 'board.snapshot', payload: await this.getBoardSync(repoId, normalizedTenantId) }));
     return new Response(null, { status: 101, webSocket: client });
   }
 
-  private async broadcast(event: BoardEvent, repoId?: string) {
-    await this.notifyRepoEvent({ ...event, repoId });
+  private async broadcast(event: BoardEvent, repoId?: string, tenantId?: string) {
+    await this.notifyRepoEvent({ ...event, repoId, tenantId });
+  }
+
+  private async resolveEventTenantId(event: BoardEvent & { repoId?: string; tenantId?: string }) {
+    if (event.tenantId) {
+      return normalizeTenantId(event.tenantId);
+    }
+    switch (event.type) {
+      case 'repo.updated':
+        return normalizeTenantId(event.payload.repo.tenantId);
+      case 'task.updated':
+        return normalizeTenantId(event.payload.task.tenantId);
+      case 'run.updated':
+        return normalizeTenantId(event.payload.run.tenantId);
+      case 'run.events_appended':
+        if (event.payload.events[0]?.tenantId) {
+          return normalizeTenantId(event.payload.events[0].tenantId);
+        }
+        break;
+      case 'run.commands_upserted':
+        if (event.payload.commands[0]?.tenantId) {
+          return normalizeTenantId(event.payload.commands[0].tenantId);
+        }
+        break;
+      default:
+        break;
+    }
+
+    if (event.repoId) {
+      const repo = this.repos.find((candidate) => candidate.repoId === event.repoId);
+      return repo ? normalizeTenantId(repo.tenantId) : undefined;
+    }
+
+    return undefined;
   }
 
   private async persist() {
@@ -760,6 +831,14 @@ function createRepoIdentity(repo: Repo): string {
 
 function buildScmCredentialId(scmProvider: ScmProvider, host: string) {
   return `${scmProvider}:${normalizeCredentialHost(host)}`;
+}
+
+function buildTenantAllScopeTag(tenantId: string) {
+  return `scope:tenant:${normalizeTenantId(tenantId)}:all`;
+}
+
+function buildTenantRepoScopeTag(tenantId: string, repoId: string) {
+  return `scope:tenant:${normalizeTenantId(tenantId)}:repo:${repoId}`;
 }
 
 function normalizeStoredScmCredential(credential: StoredScmCredential): StoredScmCredential {

--- a/src/server/durable/repo-board.ts
+++ b/src/server/durable/repo-board.ts
@@ -26,7 +26,6 @@ import { resolveRunSource } from '../shared/run-source-resolution';
 import { normalizeOperatorSession, normalizeRunLlmState, normalizeTaskUiMeta } from '../../shared/llm';
 import { hasRunReview, normalizeDependencyReviewMetadata, normalizeRunReviewMetadata, normalizeTaskBranchSourceReviewMetadata } from '../../shared/scm';
 import { DEFAULT_TENANT_ID, normalizeTenantId } from '../../shared/tenant';
-import { writeUsageLedgerEntriesBestEffort } from '../usage-ledger';
 
 const STORAGE_KEY = 'repo-board-state';
 const LOCAL_JOBS_KEY = 'repo-board-local-jobs';
@@ -85,20 +84,27 @@ export class RepoBoardDO extends DurableObject<Env> {
     return this.state.runs.some((run) => run.runId === runId);
   }
 
-  async listTasks() {
+  async listTasks(tenantId?: string) {
     await this.ready;
-    return [...this.state.tasks].sort((left, right) => right.updatedAt.localeCompare(left.updatedAt));
+    const normalizedTenantId = tenantId ? normalizeTenantId(tenantId) : undefined;
+    return [...this.state.tasks]
+      .filter((task) => !normalizedTenantId || normalizeTenantId(task.tenantId) === normalizedTenantId)
+      .sort((left, right) => right.updatedAt.localeCompare(left.updatedAt));
   }
 
-  async getTask(taskId: string): Promise<TaskDetail> {
+  async getTask(taskId: string, tenantId?: string): Promise<TaskDetail> {
     await this.ready;
     const task = this.state.tasks.find((candidate) => candidate.taskId === taskId);
     if (!task) {
       throw notFound(`Task ${taskId} not found.`, { taskId });
     }
+    assertTenantMatch(task.tenantId, tenantId, 'Task', taskId);
 
     const repo = await this.getRepo(task.repoId);
-    const runs = this.state.runs.filter((candidate) => candidate.taskId === taskId).sort((left, right) => right.startedAt.localeCompare(left.startedAt));
+    const runs = this.state.runs
+      .filter((candidate) => candidate.taskId === taskId)
+      .filter((candidate) => !tenantId || normalizeTenantId(candidate.tenantId) === normalizeTenantId(tenantId))
+      .sort((left, right) => right.startedAt.localeCompare(left.startedAt));
     return { task, repo, runs, latestRun: runs[0] };
   }
 
@@ -148,11 +154,16 @@ export class RepoBoardDO extends DurableObject<Env> {
     return finalTask;
   }
 
-  async updateTask(taskId: string, patch: UpdateTaskInput): Promise<Task> {
+  async updateTask(taskId: string, patch: UpdateTaskInput, tenantId?: string): Promise<Task> {
     await this.ready;
     const existing = this.state.tasks.find((candidate) => candidate.taskId === taskId);
     if (!existing) {
       throw notFound(`Task ${taskId} not found.`, { taskId });
+    }
+    assertTenantMatch(existing.tenantId, tenantId, 'Task', taskId);
+
+    if (patch.repoId && patch.repoId !== existing.repoId) {
+      throw badRequest('Task repoId cannot be changed.');
     }
 
     if (patch.dependencies) {
@@ -198,12 +209,13 @@ export class RepoBoardDO extends DurableObject<Env> {
     return finalTask;
   }
 
-  async deleteTask(taskId: string): Promise<{ taskId: string; deleted: true }> {
+  async deleteTask(taskId: string, tenantId?: string): Promise<{ taskId: string; deleted: true }> {
     await this.ready;
     const task = this.state.tasks.find((candidate) => candidate.taskId === taskId);
     if (!task) {
       throw notFound(`Task ${taskId} not found.`, { taskId });
     }
+    assertTenantMatch(task.tenantId, tenantId, 'Task', taskId);
     const runIds = new Set(this.state.runs.filter((run) => run.taskId === taskId).map((run) => run.runId));
 
     this.state = {
@@ -218,15 +230,20 @@ export class RepoBoardDO extends DurableObject<Env> {
     return { taskId, deleted: true };
   }
 
-  async startRun(taskId: string, options?: { forceNew?: boolean; baseRunId?: string; dependencyAutoStart?: boolean }): Promise<AgentRun> {
+  async startRun(
+    taskId: string,
+    options?: { forceNew?: boolean; baseRunId?: string; dependencyAutoStart?: boolean; tenantId?: string }
+  ): Promise<AgentRun> {
     await this.ready;
     const task = this.state.tasks.find((candidate) => candidate.taskId === taskId);
     if (!task) {
       throw notFound(`Task ${taskId} not found.`, { taskId });
     }
+    assertTenantMatch(task.tenantId, options?.tenantId, 'Task', taskId);
 
     const existing = this.state.runs.find((run) => run.taskId === taskId && !isTerminalRunStatus(run.status));
     if (existing && !options?.forceNew) {
+      assertTenantMatch(existing.tenantId, options?.tenantId, 'Run', existing.runId);
       return existing;
     }
     if (options?.dependencyAutoStart && task.runId) {
@@ -288,25 +305,26 @@ export class RepoBoardDO extends DurableObject<Env> {
     return run;
   }
 
-  async getRun(runId: string) {
+  async getRun(runId: string, tenantId?: string) {
     await this.ready;
     const run = this.state.runs.find((candidate) => candidate.runId === runId);
     if (!run) {
       throw notFound(`Run ${runId} not found.`, { runId });
     }
+    assertTenantMatch(run.tenantId, tenantId, 'Run', runId);
 
     return run;
   }
 
-  async retryRun(runId: string) {
+  async retryRun(runId: string, tenantId?: string) {
     await this.ready;
-    const run = await this.getRun(runId);
-    return this.startRun(run.taskId, { forceNew: true, baseRunId: run.runId });
+    const run = await this.getRun(runId, tenantId);
+    return this.startRun(run.taskId, { forceNew: true, baseRunId: run.runId, tenantId });
   }
 
-  async requestRunChanges(runId: string, prompt: string) {
+  async requestRunChanges(runId: string, prompt: string, tenantId?: string) {
     await this.ready;
-    const existingRun = await this.getRun(runId);
+    const existingRun = await this.getRun(runId, tenantId);
     const task = this.state.tasks.find((candidate) => candidate.taskId === existingRun.taskId);
     if (!task) {
       throw notFound(`Task ${existingRun.taskId} not found.`, { taskId: existingRun.taskId, runId });
@@ -347,9 +365,9 @@ export class RepoBoardDO extends DurableObject<Env> {
     return nextRun;
   }
 
-  async retryEvidence(runId: string) {
+  async retryEvidence(runId: string, tenantId?: string) {
     await this.ready;
-    const run = await this.getRun(runId);
+    const run = await this.getRun(runId, tenantId);
     const nowIso = new Date().toISOString();
     const updated = applyRunTransition(
       { ...run, endedAt: undefined },
@@ -376,9 +394,9 @@ export class RepoBoardDO extends DurableObject<Env> {
     return updated;
   }
 
-  async retryPreview(runId: string) {
+  async retryPreview(runId: string, tenantId?: string) {
     await this.ready;
-    const run = await this.getRun(runId);
+    const run = await this.getRun(runId, tenantId);
     const nowIso = new Date().toISOString();
     const updated = applyRunTransition(
       { ...run, endedAt: undefined },
@@ -475,9 +493,9 @@ export class RepoBoardDO extends DurableObject<Env> {
     await this.emit({ type: 'run.commands_upserted', payload: { runId, commands: normalizedCommands } }, run.repoId);
   }
 
-  async transitionRun(runId: string, patch: RunTransitionPatch): Promise<AgentRun> {
+  async transitionRun(runId: string, patch: RunTransitionPatch, tenantId?: string): Promise<AgentRun> {
     await this.ready;
-    const run = await this.getRun(runId);
+    const run = await this.getRun(runId, tenantId);
     if (isTerminalRunStatus(run.status)) {
       return run;
     }
@@ -524,9 +542,9 @@ export class RepoBoardDO extends DurableObject<Env> {
     return updated;
   }
 
-  async markRunFailed(runId: string, error: RunError): Promise<AgentRun> {
+  async markRunFailed(runId: string, error: RunError, tenantId?: string): Promise<AgentRun> {
     await this.ready;
-    const run = await this.getRun(runId);
+    const run = await this.getRun(runId, tenantId);
     const nowIso = new Date().toISOString();
     const updated = appendRunError(run, error, nowIso);
     const task = this.state.tasks.find((candidate) => candidate.taskId === run.taskId);
@@ -555,62 +573,48 @@ export class RepoBoardDO extends DurableObject<Env> {
     return updated;
   }
 
-  async storeArtifactManifest(runId: string) {
+  async storeArtifactManifest(runId: string, tenantId?: string) {
     await this.ready;
-    const run = await this.getRun(runId);
+    const run = await this.getRun(runId, tenantId);
     const task = this.state.tasks.find((candidate) => candidate.taskId === run.taskId);
     if (!task) {
       throw notFound(`Task ${run.taskId} not found.`, { taskId: run.taskId, runId });
     }
     const repo = await this.getRepo(run.repoId);
     const manifest = buildArtifactManifest(run, task, repo, this.ctx.id.toString());
-    const updated = await this.transitionRun(runId, {
+    return this.transitionRun(runId, {
       artifactManifest: manifest,
       artifacts: [manifest.logs.key, manifest.before?.key, manifest.after?.key, manifest.trace?.key, manifest.video?.key].filter(Boolean) as string[]
-    });
-    await this.recordUsage(updated, [
-      {
-        category: 'r2_write_ops',
-        quantity: 1,
-        source: 'workflow',
-        metadata: { object: 'artifact_manifest' }
-      }
-    ]);
-    return updated;
+    }, tenantId);
   }
 
-  async getRunArtifacts(runId: string) {
-    const run = await this.getRun(runId);
-    await this.recordUsage(run, [
-      {
-        category: 'artifact_download',
-        quantity: 1,
-        source: 'worker',
-        metadata: { endpoint: '/api/runs/:runId/artifacts' }
-      }
-    ]);
+  async getRunArtifacts(runId: string, tenantId?: string) {
+    const run = await this.getRun(runId, tenantId);
     return run.artifactManifest;
   }
 
-  async getRunLogs(runId: string, tail?: number) {
+  async getRunLogs(runId: string, tail?: number, tenantId?: string) {
     await this.ready;
+    await this.getRun(runId, tenantId);
     const logs = this.state.logs.filter((entry) => entry.runId === runId);
     return tail ? logs.slice(-tail) : logs;
   }
 
-  async getRunEvents(runId: string) {
+  async getRunEvents(runId: string, tenantId?: string) {
     await this.ready;
+    await this.getRun(runId, tenantId);
     return this.state.events.filter((entry) => entry.runId === runId);
   }
 
-  async getRunCommands(runId: string) {
+  async getRunCommands(runId: string, tenantId?: string) {
     await this.ready;
+    await this.getRun(runId, tenantId);
     return this.state.commands.filter((entry) => entry.runId === runId);
   }
 
-  async updateOperatorSession(runId: string, session?: OperatorSession) {
+  async updateOperatorSession(runId: string, session?: OperatorSession, tenantId?: string) {
     await this.ready;
-    const run = await this.getRun(runId);
+    const run = await this.getRun(runId, tenantId);
     const normalizedSession = normalizeOperatorSession(
       session
         ? {
@@ -637,22 +641,12 @@ export class RepoBoardDO extends DurableObject<Env> {
     await this.persist();
     await this.emit({ type: 'run.updated', payload: { run: updated } }, updated.repoId);
     await this.emit({ type: 'run.operator_session_updated', payload: { runId, session: normalizedSession } }, updated.repoId);
-    if (normalizedSession) {
-      await this.recordUsage(updated, [
-        {
-          category: 'operator_session_ms',
-          quantity: 1,
-          source: 'operator',
-          metadata: { event: 'operator_session_updated', state: normalizedSession.connectionState }
-        }
-      ]);
-    }
     return updated;
   }
 
-  async getTerminalBootstrap(runId: string): Promise<TerminalBootstrap> {
+  async getTerminalBootstrap(runId: string, tenantId?: string): Promise<TerminalBootstrap> {
     await this.ready;
-    const run = await this.getRun(runId);
+    const run = await this.getRun(runId, tenantId);
     const sessionName = getOperatorSessionName(run);
     if (!run.sandboxId) {
       return {
@@ -712,9 +706,9 @@ export class RepoBoardDO extends DurableObject<Env> {
     };
   }
 
-  async takeOverRun(runId: string, actor = { actorId: 'same-session', actorLabel: 'Operator' }) {
+  async takeOverRun(runId: string, actor = { actorId: 'same-session', actorLabel: 'Operator' }, tenantId?: string) {
     await this.ready;
-    const run = await this.getRun(runId);
+    const run = await this.getRun(runId, tenantId);
     if (!run.sandboxId) {
       throw notFound(`Sandbox for run ${runId} not found.`, { runId });
     }
@@ -789,14 +783,6 @@ export class RepoBoardDO extends DurableObject<Env> {
     await this.emit({ type: 'run.operator_session_updated', payload: { runId, session: nextSession } }, updated.repoId);
     await this.emit({ type: 'run.events_appended', payload: { runId, events } }, updated.repoId);
     await this.emitDependencyRefreshUpdates(updated.repoId, refreshedTasks, [finalTask.taskId]);
-    await this.recordUsage(updated, [
-      {
-        category: 'operator_session_ms',
-        quantity: 1,
-        source: 'operator',
-        metadata: { event: 'operator_takeover_started', sessionName: nextSession.sessionName }
-      }
-    ]);
     return updated;
   }
 
@@ -845,7 +831,7 @@ export class RepoBoardDO extends DurableObject<Env> {
       socket.send(payload);
     }
     const board = this.env.BOARD_INDEX.getByName('agentboard');
-    await board.notifyRepoEvent({ ...event, repoId });
+    await board.notifyRepoEvent({ ...event, repoId, tenantId: await this.resolveEventTenantId(event, repoId) });
   }
 
   private async persist() {
@@ -864,31 +850,6 @@ export class RepoBoardDO extends DurableObject<Env> {
   private async getRepo(repoId: string): Promise<Repo> {
     const board = this.env.BOARD_INDEX.getByName('agentboard');
     return board.getRepo(repoId);
-  }
-
-  private async recordUsage(
-    run: Pick<AgentRun, 'tenantId' | 'repoId' | 'taskId' | 'runId'>,
-    entries: Array<{
-      category: import('../usage-ledger').UsageLedgerCategory;
-      quantity: number;
-      unit?: string;
-      source: import('../usage-ledger').UsageLedgerSource;
-      metadata?: Record<string, string | number | boolean>;
-    }>
-  ) {
-    if (!entries.length) {
-      return;
-    }
-    await writeUsageLedgerEntriesBestEffort(
-      this.env,
-      entries.map((entry) => ({
-        tenantId: normalizeTenantId(run.tenantId),
-        repoId: run.repoId,
-        taskId: run.taskId,
-        runId: run.runId,
-        ...entry
-      }))
-    );
   }
 
   private async buildBoardPayload() {
@@ -976,6 +937,32 @@ export class RepoBoardDO extends DurableObject<Env> {
 
       await this.startRun(task.taskId, { dependencyAutoStart: true });
     }
+  }
+
+  private async resolveEventTenantId(event: RepoScopedEvent, repoId: string) {
+    switch (event.type) {
+      case 'repo.updated':
+        return normalizeTenantId(event.payload.repo.tenantId);
+      case 'task.updated':
+        return normalizeTenantId(event.payload.task.tenantId);
+      case 'run.updated':
+        return normalizeTenantId(event.payload.run.tenantId);
+      case 'run.events_appended':
+        if (event.payload.events[0]?.tenantId) {
+          return normalizeTenantId(event.payload.events[0].tenantId);
+        }
+        break;
+      case 'run.commands_upserted':
+        if (event.payload.commands[0]?.tenantId) {
+          return normalizeTenantId(event.payload.commands[0].tenantId);
+        }
+        break;
+      default: {
+        break;
+      }
+    }
+    const repo = await this.getRepo(repoId);
+    return normalizeTenantId(repo.tenantId);
   }
 }
 
@@ -1107,6 +1094,15 @@ function getOperatorSessionName(run: AgentRun) {
   }
 
   return run.operatorSession.sessionName;
+}
+
+function assertTenantMatch(entityTenantId: string | undefined, expectedTenantId: string | undefined, entityLabel: 'Task' | 'Run', entityId: string) {
+  if (!expectedTenantId) {
+    return;
+  }
+  if (normalizeTenantId(entityTenantId) !== normalizeTenantId(expectedTenantId)) {
+    throw notFound(`${entityLabel} ${entityId} not found.`, entityLabel === 'Task' ? { taskId: entityId } : { runId: entityId });
+  }
 }
 
 function cloneRepoBoardState(state: RepoBoardState): RepoBoardState {

--- a/src/server/router.ts
+++ b/src/server/router.ts
@@ -165,7 +165,10 @@ export async function handleApiRequest(request: Request, env: Env, ctx: Executio
       if (repoId && repoId !== 'all') {
         await assertRepoAccess(board, requestContext, repoId);
       }
-      return board.fetch(request);
+      const wsUrl = new URL(request.url);
+      wsUrl.searchParams.set('tenantId', requestContext.activeTenantId);
+      wsUrl.searchParams.set('repoId', repoId ?? 'all');
+      return board.fetch(new Request(wsUrl.toString(), request));
     }
 
     if (url.pathname === '/api/repos' && request.method === 'GET') {
@@ -218,7 +221,7 @@ export async function handleApiRequest(request: Request, env: Env, ctx: Executio
         return json((await board.getBoardSync('all', requestContext.activeTenantId)).tasks);
       }
       await assertRepoAccess(board, requestContext, repoId);
-      return json(await env.REPO_BOARD.getByName(repoId).listTasks());
+      return json(await env.REPO_BOARD.getByName(repoId).listTasks(requestContext.activeTenantId));
     }
 
     if (url.pathname === '/api/tasks' && request.method === 'POST') {
@@ -240,21 +243,21 @@ export async function handleApiRequest(request: Request, env: Env, ctx: Executio
       const taskId = decodeURIComponent(taskMatch[1]);
       const repoId = await resolveRepoIdForTask(board, taskId);
       await assertRepoAccess(board, requestContext, repoId);
-      return json(await env.REPO_BOARD.getByName(repoId).getTask(taskId));
+      return json(await env.REPO_BOARD.getByName(repoId).getTask(taskId, requestContext.activeTenantId));
     }
 
     if (taskMatch && request.method === 'PATCH') {
       const taskId = decodeURIComponent(taskMatch[1]);
       const repoId = await resolveRepoIdForTask(board, taskId);
       await assertRepoAccess(board, requestContext, repoId);
-      return json(await env.REPO_BOARD.getByName(repoId).updateTask(taskId, parseUpdateTaskInput(await readJson(request))));
+      return json(await env.REPO_BOARD.getByName(repoId).updateTask(taskId, parseUpdateTaskInput(await readJson(request)), requestContext.activeTenantId));
     }
 
     if (taskMatch && request.method === 'DELETE') {
       const taskId = decodeURIComponent(taskMatch[1]);
       const repoId = await resolveRepoIdForTask(board, taskId);
       await assertRepoAccess(board, requestContext, repoId);
-      return json(await env.REPO_BOARD.getByName(repoId).deleteTask(taskId));
+      return json(await env.REPO_BOARD.getByName(repoId).deleteTask(taskId, requestContext.activeTenantId));
     }
 
     const runStartMatch = url.pathname.match(/^\/api\/tasks\/([^/]+)\/run$/);
@@ -262,13 +265,13 @@ export async function handleApiRequest(request: Request, env: Env, ctx: Executio
       const taskId = decodeURIComponent(runStartMatch[1]);
       const repoId = await resolveRepoIdForTask(board, taskId);
       await assertRepoAccess(board, requestContext, repoId);
-      const run = await env.REPO_BOARD.getByName(repoId).startRun(taskId);
+      const run = await env.REPO_BOARD.getByName(repoId).startRun(taskId, { tenantId: requestContext.activeTenantId });
       const workflow = await scheduleRunJob(env, ctx, { repoId, taskId, runId: run.runId, mode: 'full_run' });
       await env.REPO_BOARD.getByName(repoId).transitionRun(run.runId, {
         workflowInstanceId: workflow.id,
         orchestrationMode: workflow.id.startsWith('local-alarm-') ? 'local_alarm' : 'workflow'
       });
-      return json(await env.REPO_BOARD.getByName(repoId).getRun(run.runId));
+      return json(await env.REPO_BOARD.getByName(repoId).getRun(run.runId, requestContext.activeTenantId));
     }
 
     const runMatch = url.pathname.match(/^\/api\/runs\/([^/]+)$/);
@@ -276,7 +279,7 @@ export async function handleApiRequest(request: Request, env: Env, ctx: Executio
       const runId = decodeURIComponent(runMatch[1]);
       const repoId = await resolveRepoIdForRun(board, runId);
       await assertRepoAccess(board, requestContext, repoId);
-      return json(await env.REPO_BOARD.getByName(repoId).getRun(runId));
+      return json(await env.REPO_BOARD.getByName(repoId).getRun(runId, requestContext.activeTenantId));
     }
 
     const runRetryMatch = url.pathname.match(/^\/api\/runs\/([^/]+)\/retry$/);
@@ -284,13 +287,13 @@ export async function handleApiRequest(request: Request, env: Env, ctx: Executio
       const runId = decodeURIComponent(runRetryMatch[1]);
       const repoId = await resolveRepoIdForRun(board, runId);
       await assertRepoAccess(board, requestContext, repoId);
-      const run = await env.REPO_BOARD.getByName(repoId).retryRun(runId);
+      const run = await env.REPO_BOARD.getByName(repoId).retryRun(runId, requestContext.activeTenantId);
       const workflow = await scheduleRunJob(env, ctx, { repoId, taskId: run.taskId, runId: run.runId, mode: 'full_run' });
       await env.REPO_BOARD.getByName(repoId).transitionRun(run.runId, {
         workflowInstanceId: workflow.id,
         orchestrationMode: workflow.id.startsWith('local-alarm-') ? 'local_alarm' : 'workflow'
       });
-      return json(await env.REPO_BOARD.getByName(repoId).getRun(run.runId));
+      return json(await env.REPO_BOARD.getByName(repoId).getRun(run.runId, requestContext.activeTenantId));
     }
 
     const runCancelMatch = url.pathname.match(/^\/api\/runs\/([^/]+)\/cancel$/);
@@ -308,7 +311,7 @@ export async function handleApiRequest(request: Request, env: Env, ctx: Executio
         message: reason,
         retryable: true,
         phase: 'codex'
-      }));
+      }, requestContext.activeTenantId));
     }
 
     const requestChangesMatch = url.pathname.match(/^\/api\/runs\/([^/]+)\/request-changes$/);
@@ -326,13 +329,13 @@ export async function handleApiRequest(request: Request, env: Env, ctx: Executio
       }
       const repoId = await resolveRepoIdForRun(board, runId);
       await assertRepoAccess(board, requestContext, repoId);
-      const run = await env.REPO_BOARD.getByName(repoId).requestRunChanges(runId, body.prompt.trim());
+      const run = await env.REPO_BOARD.getByName(repoId).requestRunChanges(runId, body.prompt.trim(), requestContext.activeTenantId);
       const workflow = await scheduleRunJob(env, ctx, { repoId, taskId: run.taskId, runId: run.runId, mode: 'full_run' });
       await env.REPO_BOARD.getByName(repoId).transitionRun(run.runId, {
         workflowInstanceId: workflow.id,
         orchestrationMode: workflow.id.startsWith('local-alarm-') ? 'local_alarm' : 'workflow'
       });
-      return json(await env.REPO_BOARD.getByName(repoId).getRun(run.runId));
+      return json(await env.REPO_BOARD.getByName(repoId).getRun(run.runId, requestContext.activeTenantId));
     }
 
     const evidenceRetryMatch = url.pathname.match(/^\/api\/runs\/([^/]+)\/evidence$/);
@@ -340,7 +343,7 @@ export async function handleApiRequest(request: Request, env: Env, ctx: Executio
       const runId = decodeURIComponent(evidenceRetryMatch[1]);
       const repoId = await resolveRepoIdForRun(board, runId);
       await assertRepoAccess(board, requestContext, repoId);
-      const run = await env.REPO_BOARD.getByName(repoId).retryEvidence(runId);
+      const run = await env.REPO_BOARD.getByName(repoId).retryEvidence(runId, requestContext.activeTenantId);
       const workflow = await scheduleRunJob(env, ctx, {
         repoId,
         taskId: run.taskId,
@@ -351,7 +354,7 @@ export async function handleApiRequest(request: Request, env: Env, ctx: Executio
         workflowInstanceId: workflow.id,
         orchestrationMode: workflow.id.startsWith('local-alarm-') ? 'local_alarm' : 'workflow'
       });
-      return json(await env.REPO_BOARD.getByName(repoId).getRun(run.runId));
+      return json(await env.REPO_BOARD.getByName(repoId).getRun(run.runId, requestContext.activeTenantId));
     }
 
     const previewRetryMatch = url.pathname.match(/^\/api\/runs\/([^/]+)\/preview$/);
@@ -359,13 +362,13 @@ export async function handleApiRequest(request: Request, env: Env, ctx: Executio
       const runId = decodeURIComponent(previewRetryMatch[1]);
       const repoId = await resolveRepoIdForRun(board, runId);
       await assertRepoAccess(board, requestContext, repoId);
-      const run = await env.REPO_BOARD.getByName(repoId).retryPreview(runId);
+      const run = await env.REPO_BOARD.getByName(repoId).retryPreview(runId, requestContext.activeTenantId);
       const workflow = await scheduleRunJob(env, ctx, { repoId, taskId: run.taskId, runId: run.runId, mode: 'preview_only' });
       await env.REPO_BOARD.getByName(repoId).transitionRun(run.runId, {
         workflowInstanceId: workflow.id,
         orchestrationMode: workflow.id.startsWith('local-alarm-') ? 'local_alarm' : 'workflow'
       });
-      return json(await env.REPO_BOARD.getByName(repoId).getRun(run.runId));
+      return json(await env.REPO_BOARD.getByName(repoId).getRun(run.runId, requestContext.activeTenantId));
     }
 
     const runLogsMatch = url.pathname.match(/^\/api\/runs\/([^/]+)\/logs$/);
@@ -374,7 +377,7 @@ export async function handleApiRequest(request: Request, env: Env, ctx: Executio
       const repoId = await resolveRepoIdForRun(board, runId);
       await assertRepoAccess(board, requestContext, repoId);
       const tail = url.searchParams.get('tail');
-      return json(await env.REPO_BOARD.getByName(repoId).getRunLogs(runId, tail ? Number(tail) : undefined));
+      return json(await env.REPO_BOARD.getByName(repoId).getRunLogs(runId, tail ? Number(tail) : undefined, requestContext.activeTenantId));
     }
 
     const runUsageMatch = url.pathname.match(/^\/api\/runs\/([^/]+)\/usage$/);
@@ -388,7 +391,7 @@ export async function handleApiRequest(request: Request, env: Env, ctx: Executio
       const runId = decodeURIComponent(runEventsMatch[1]);
       const repoId = await resolveRepoIdForRun(board, runId);
       await assertRepoAccess(board, requestContext, repoId);
-      return json(await env.REPO_BOARD.getByName(repoId).getRunEvents(runId));
+      return json(await env.REPO_BOARD.getByName(repoId).getRunEvents(runId, requestContext.activeTenantId));
     }
 
     const runCommandsMatch = url.pathname.match(/^\/api\/runs\/([^/]+)\/commands$/);
@@ -396,7 +399,7 @@ export async function handleApiRequest(request: Request, env: Env, ctx: Executio
       const runId = decodeURIComponent(runCommandsMatch[1]);
       const repoId = await resolveRepoIdForRun(board, runId);
       await assertRepoAccess(board, requestContext, repoId);
-      return json(await env.REPO_BOARD.getByName(repoId).getRunCommands(runId));
+      return json(await env.REPO_BOARD.getByName(repoId).getRunCommands(runId, requestContext.activeTenantId));
     }
 
     const runTerminalMatch = url.pathname.match(/^\/api\/runs\/([^/]+)\/terminal$/);
@@ -404,7 +407,7 @@ export async function handleApiRequest(request: Request, env: Env, ctx: Executio
       const runId = decodeURIComponent(runTerminalMatch[1]);
       const repoId = await resolveRepoIdForRun(board, runId);
       await assertRepoAccess(board, requestContext, repoId);
-      const bootstrap = await env.REPO_BOARD.getByName(repoId).getTerminalBootstrap(runId);
+      const bootstrap = await env.REPO_BOARD.getByName(repoId).getTerminalBootstrap(runId, requestContext.activeTenantId);
       if (!bootstrap.attachable) {
         return json(bootstrap, { status: 409 });
       }
@@ -416,7 +419,7 @@ export async function handleApiRequest(request: Request, env: Env, ctx: Executio
       const runId = decodeURIComponent(runTerminalSocketMatch[1]);
       const repoId = await resolveRepoIdForRun(board, runId);
       await assertRepoAccess(board, requestContext, repoId);
-      const bootstrap = await env.REPO_BOARD.getByName(repoId).getTerminalBootstrap(runId);
+      const bootstrap = await env.REPO_BOARD.getByName(repoId).getTerminalBootstrap(runId, requestContext.activeTenantId);
       if (!bootstrap.attachable) {
         return json(bootstrap, { status: 409 });
       }
@@ -424,7 +427,7 @@ export async function handleApiRequest(request: Request, env: Env, ctx: Executio
         throw badRequest('Expected WebSocket upgrade request.');
       }
 
-      const run = await env.REPO_BOARD.getByName(repoId).getRun(runId);
+      const run = await env.REPO_BOARD.getByName(repoId).getRun(runId, requestContext.activeTenantId);
       const session = {
         tenantId: run.tenantId,
         id: `${runId}:${bootstrap.sessionName}`,
@@ -456,7 +459,7 @@ export async function handleApiRequest(request: Request, env: Env, ctx: Executio
           error
         });
       }
-      await env.REPO_BOARD.getByName(repoId).updateOperatorSession(runId, session);
+      await env.REPO_BOARD.getByName(repoId).updateOperatorSession(runId, session, requestContext.activeTenantId);
       const sandboxSession = await sandbox.getSession(bootstrap.sessionName);
       return sandboxSession.terminal(request, { cols: bootstrap.cols, rows: bootstrap.rows });
     }
@@ -466,7 +469,7 @@ export async function handleApiRequest(request: Request, env: Env, ctx: Executio
       const runId = decodeURIComponent(runArtifactsMatch[1]);
       const repoId = await resolveRepoIdForRun(board, runId);
       await assertRepoAccess(board, requestContext, repoId);
-      return json(await env.REPO_BOARD.getByName(repoId).getRunArtifacts(runId));
+      return json(await env.REPO_BOARD.getByName(repoId).getRunArtifacts(runId, requestContext.activeTenantId));
     }
 
     const runTakeoverMatch = url.pathname.match(/^\/api\/runs\/([^/]+)\/takeover$/);
@@ -475,7 +478,7 @@ export async function handleApiRequest(request: Request, env: Env, ctx: Executio
       const repoId = await resolveRepoIdForRun(board, runId);
       await assertRepoAccess(board, requestContext, repoId);
       const repoBoard = env.REPO_BOARD.getByName(repoId);
-      const run = await repoBoard.getRun(runId);
+      const run = await repoBoard.getRun(runId, requestContext.activeTenantId);
       if (run.sandboxId && run.codexProcessId) {
         const sandbox = getSandbox(env.Sandbox, run.sandboxId);
         try {
@@ -492,7 +495,7 @@ export async function handleApiRequest(request: Request, env: Env, ctx: Executio
           console.warn('Failed to kill Codex process during takeover', { runId, processId: run.codexProcessId, error });
         }
       }
-      return json(await repoBoard.takeOverRun(runId));
+      return json(await repoBoard.takeOverRun(runId, { actorId: 'same-session', actorLabel: 'Operator' }, requestContext.activeTenantId));
     }
 
     if (url.pathname === '/api/debug/export' && request.method === 'GET') {

--- a/tests/worker/stage-4-5-tenant-authz.test.ts
+++ b/tests/worker/stage-4-5-tenant-authz.test.ts
@@ -208,4 +208,86 @@ describe('Stage 4.5 tenant auth context + cross-tenant authorization', () => {
     expect(runDenied.body.code).toBe('FORBIDDEN');
     expect(runDenied.body.message).toContain('Cross-tenant access denied');
   });
+
+  it('tenant-filters board/repo/task list projections for active tenant context', async () => {
+    const signup = await api<{
+      token: string;
+      activeTenantId: string;
+    }>('/api/auth/signup', {
+      method: 'POST',
+      body: JSON.stringify({
+        email: `${uniqueSlug('viewer')}@example.com`,
+        password: 'secret-pass',
+        tenantName: 'Tenant List A',
+        tenantSlug: uniqueSlug('tenant-list-a')
+      })
+    });
+    expect(signup.status).toBe(201);
+
+    const tenantARepo = await api<{ repoId: string }>('/api/repos', {
+      method: 'POST',
+      sessionToken: signup.body.token,
+      body: JSON.stringify({
+        slug: uniqueSlug('tenant-a-only-repo'),
+        baselineUrl: 'https://tenant-a-only.example.test',
+        defaultBranch: 'main'
+      })
+    });
+    expect(tenantARepo.status).toBe(201);
+
+    const tenantATask = await api<{ taskId: string }>('/api/tasks', {
+      method: 'POST',
+      sessionToken: signup.body.token,
+      body: JSON.stringify({
+        repoId: tenantARepo.body.repoId,
+        title: 'Tenant A only task',
+        taskPrompt: 'Do tenant A thing',
+        acceptanceCriteria: ['done'],
+        context: { links: [] }
+      })
+    });
+    expect(tenantATask.status).toBe(201);
+
+    const secondTenant = await api<{ tenant: { id: string } }>('/api/tenants', {
+      method: 'POST',
+      sessionToken: signup.body.token,
+      body: JSON.stringify({
+        name: 'Tenant List B',
+        slug: uniqueSlug('tenant-list-b')
+      })
+    });
+    expect(secondTenant.status).toBe(201);
+
+    const switched = await api<{ activeTenantId: string }>('/api/me/tenant-context', {
+      method: 'POST',
+      sessionToken: signup.body.token,
+      body: JSON.stringify({ tenantId: secondTenant.body.tenant.id })
+    });
+    expect(switched.status).toBe(200);
+    expect(switched.body.activeTenantId).toBe(secondTenant.body.tenant.id);
+
+    const repos = await api<Array<{ repoId: string }>>('/api/repos', {
+      sessionToken: signup.body.token
+    });
+    expect(repos.status).toBe(200);
+    expect(repos.body).toEqual([]);
+
+    const board = await api<{
+      repos: Array<{ repoId: string }>;
+      tasks: Array<{ taskId: string }>;
+      runs: Array<{ runId: string }>;
+    }>('/api/board?repoId=all', {
+      sessionToken: signup.body.token
+    });
+    expect(board.status).toBe(200);
+    expect(board.body.repos).toEqual([]);
+    expect(board.body.tasks).toEqual([]);
+    expect(board.body.runs).toEqual([]);
+
+    const tasks = await api<Array<{ taskId: string }>>('/api/tasks?repoId=all', {
+      sessionToken: signup.body.token
+    });
+    expect(tasks.status).toBe(200);
+    expect(tasks.body).toEqual([]);
+  });
 });


### PR DESCRIPTION
Task: S45-40 Tenant-scoped persistence + APIs

Tenant-filter all board/task/repo/run APIs and update board websocket fanout by tenant.


Acceptance criteria:
- Board/task/list endpoints enforce tenant filter
- WS fanout is tenant-scoped
- No cross-tenant updates are visible

Run ID: run_repo_abuiles_minions_mm9np9r1l65q