### PR TITLE
S45-50 Workflow + tenant-owned artifact layout

### DIFF
--- a/src/server/durable/repo-board.ts
+++ b/src/server/durable/repo-board.ts
@@ -810,7 +810,7 @@ export class RepoBoardDO extends DurableObject<Env> {
       delete this.localJobs[runId];
       await this.persistLocalJobs();
       try {
-        await executeRunJob(this.env, { repoId: run.repoId, taskId: run.taskId, runId, mode }, sleepForAlarm);
+        await executeRunJob(this.env, { tenantId: run.tenantId ?? DEFAULT_TENANT_ID, repoId: run.repoId, taskId: run.taskId, runId, mode }, sleepForAlarm);
       } catch (error) {
         console.error('Local alarm run execution failed', { runId, error });
       }
@@ -1086,7 +1086,6 @@ function nextStatusChanged(previous: AgentRun, next: AgentRun, note?: string) {
 function isTerminalRunStatus(status: AgentRun['status']) {
   return status === 'DONE' || status === 'FAILED';
 }
-
 
 function getOperatorSessionName(run: AgentRun) {
   if (!run.operatorSession?.sessionName || run.operatorSession.sessionName === 'operator') {

--- a/src/server/run-orchestrator.llm.test.ts
+++ b/src/server/run-orchestrator.llm.test.ts
@@ -317,7 +317,7 @@ describe('executeRunJob LLM adapter coverage', () => {
       { type: 'exit', exitCode: 0 }
     ]);
 
-    await executeRunJob(harness.env, { repoId: repo.repoId, taskId: task.taskId, runId: 'run_1', mode: 'full_run' }, async () => {});
+    await executeRunJob(harness.env, { tenantId: 'tenant_legacy', repoId: repo.repoId, taskId: task.taskId, runId: 'run_1', mode: 'full_run' }, async () => {});
 
     expect(harness.getRun()).toMatchObject({
       status: 'DONE',
@@ -357,7 +357,7 @@ describe('executeRunJob LLM adapter coverage', () => {
       { type: 'exit', exitCode: 0 }
     ]);
 
-    await executeRunJob(harness.env, { repoId: repo.repoId, taskId: task.taskId, runId: 'run_1', mode: 'full_run' }, async () => {});
+    await executeRunJob(harness.env, { tenantId: 'tenant_legacy', repoId: repo.repoId, taskId: task.taskId, runId: 'run_1', mode: 'full_run' }, async () => {});
 
     expect(harness.getRun()).toMatchObject({
       status: 'DONE',

--- a/src/server/run-orchestrator.preview.test.ts
+++ b/src/server/run-orchestrator.preview.test.ts
@@ -123,7 +123,7 @@ describe('executeRunJob preview flows', () => {
       ]
     }), { status: 200 })));
 
-    await executeRunJob(harness.env, { repoId: repo.repoId, taskId: 'task_1', runId: 'run_1', mode: 'preview_only' }, async () => {});
+    await executeRunJob(harness.env, { tenantId: 'tenant_legacy', repoId: repo.repoId, taskId: 'task_1', runId: 'run_1', mode: 'preview_only' }, async () => {});
 
     expect(harness.getRun()).toMatchObject({
       status: 'DONE',
@@ -173,7 +173,7 @@ describe('executeRunJob preview flows', () => {
       throw new Error(`Unexpected fetch URL: ${url}`);
     }));
 
-    await executeRunJob(harness.env, { repoId: repo.repoId, taskId: 'task_1', runId: 'run_1', mode: 'preview_only' }, async () => {});
+    await executeRunJob(harness.env, { tenantId: 'tenant_legacy', repoId: repo.repoId, taskId: 'task_1', runId: 'run_1', mode: 'preview_only' }, async () => {});
 
     expect(harness.getRun()).toMatchObject({
       status: 'DONE',
@@ -192,7 +192,7 @@ describe('executeRunJob preview flows', () => {
     const fetchMock = vi.fn();
     vi.stubGlobal('fetch', fetchMock);
 
-    await executeRunJob(harness.env, { repoId: repo.repoId, taskId: 'task_1', runId: 'run_1', mode: 'preview_only' }, async () => {});
+    await executeRunJob(harness.env, { tenantId: 'tenant_legacy', repoId: repo.repoId, taskId: 'task_1', runId: 'run_1', mode: 'preview_only' }, async () => {});
 
     expect(fetchMock).not.toHaveBeenCalled();
     expect(harness.getRun()).toMatchObject({

--- a/src/server/run-orchestrator.test.ts
+++ b/src/server/run-orchestrator.test.ts
@@ -1,11 +1,14 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { buildWorkflowInvocationId } from './workflow-id';
 import { getCodexCapacityDecision } from './codex-rate-limit';
 import { shouldRunEvidence, shouldRunPreview } from './shared/repo-execution-policy';
+import { scheduleRunJob } from './run-orchestrator';
+import { buildArtifactManifest } from './shared/real-run';
 
 describe('buildWorkflowInvocationId', () => {
   it('includes a time suffix so retries for the same run get a fresh workflow id', () => {
     const params = {
+      tenantId: 'tenant_legacy',
       repoId: 'repo_demo',
       taskId: 'task_demo',
       runId: 'run_demo',
@@ -109,5 +112,74 @@ describe('repo execution policies', () => {
 
     expect(shouldRunPreview(repo)).toBe(false);
     expect(shouldRunEvidence(repo)).toBe(false);
+  });
+});
+
+describe('tenant workflow and artifact layout', () => {
+  it('passes tenantId through workflow invocation params', async () => {
+    const create = vi.fn().mockResolvedValue({ id: 'wf_1' });
+    const env = {
+      RUN_WORKFLOW: { create }
+    } as unknown as Env;
+
+    await scheduleRunJob(env, {} as ExecutionContext, {
+      tenantId: 'tenant_acme',
+      repoId: 'repo_demo',
+      taskId: 'task_demo',
+      runId: 'run_demo',
+      mode: 'full_run'
+    });
+
+    expect(create).toHaveBeenCalledWith(expect.objectContaining({
+      params: expect.objectContaining({
+        tenantId: 'tenant_acme',
+        runId: 'run_demo'
+      })
+    }));
+  });
+
+  it('builds tenant-prefixed artifact keys', () => {
+    const manifest = buildArtifactManifest(
+      {
+        tenantId: 'tenant_acme',
+        runId: 'run_demo',
+        taskId: 'task_demo',
+        repoId: 'repo_demo',
+        status: 'DONE',
+        branchName: 'agent/task_demo/run_demo',
+        errors: [],
+        startedAt: '2026-03-02T00:00:00.000Z',
+        simulationProfile: 'happy_path',
+        timeline: [],
+        pendingEvents: []
+      },
+      {
+        tenantId: 'tenant_acme',
+        taskId: 'task_demo',
+        repoId: 'repo_demo',
+        title: 'Demo',
+        taskPrompt: 'Prompt',
+        acceptanceCriteria: ['Done'],
+        context: { links: [] },
+        status: 'REVIEW',
+        createdAt: '2026-03-02T00:00:00.000Z',
+        updatedAt: '2026-03-02T00:00:00.000Z'
+      },
+      {
+        tenantId: 'tenant_acme',
+        repoId: 'repo_demo',
+        slug: 'acme/demo',
+        defaultBranch: 'main',
+        baselineUrl: 'https://example.com',
+        enabled: true,
+        createdAt: '2026-03-02T00:00:00.000Z',
+        updatedAt: '2026-03-02T00:00:00.000Z'
+      },
+      'env_1'
+    );
+
+    expect(manifest.logs.key).toBe('tenants/tenant_acme/runs/run_demo/logs/executor.txt');
+    expect(manifest.before?.key).toBe('tenants/tenant_acme/runs/run_demo/evidence/before.png');
+    expect(manifest.metadata.tenantId).toBe('tenant_acme');
   });
 });

--- a/src/server/shared/mock-engine.ts
+++ b/src/server/shared/mock-engine.ts
@@ -10,6 +10,7 @@ import type {
   TaskStatus
 } from '../../ui/domain/types';
 import { getBaselineUrl } from '../../ui/domain/selectors';
+import { normalizeTenantId } from '../../shared/tenant';
 
 const OFFSETS: Record<Exclude<RunStatus, 'FAILED'>, number> = {
   QUEUED: 0,
@@ -161,7 +162,7 @@ export function deriveTaskStatus(currentStatus: TaskStatus, runStatus: RunStatus
 }
 
 export function buildArtifactManifest(run: AgentRun, task: Task, repo: Repo | undefined): ArtifactManifest {
-  const baseKey = `runs/${run.runId}`;
+  const baseKey = `tenants/${normalizeTenantId(run.tenantId)}/runs/${run.runId}`;
   return {
     logs: { key: `${baseKey}/logs.txt`, label: 'Mock logs' },
     before: {
@@ -185,6 +186,7 @@ export function buildArtifactManifest(run: AgentRun, task: Task, repo: Repo | un
       url: `https://artifacts.example.invalid/${baseKey}/video.mp4`
     },
     metadata: {
+      tenantId: normalizeTenantId(run.tenantId),
       generatedAt: new Date().toISOString(),
       simulatorVersion: 'stage-2',
       environmentId: 'worker-mock-executor'

--- a/src/server/shared/real-run.ts
+++ b/src/server/shared/real-run.ts
@@ -1,10 +1,12 @@
 import type { ArtifactManifest, AgentRun, Repo, RunError, RunLogEntry, RunStatus, Task } from '../../ui/domain/types';
 import { DEFAULT_SUPPORTS_RESUME_BY_ADAPTER, normalizeRunLlmState, normalizeTaskUiMeta } from '../../shared/llm';
 import { normalizeRunReviewMetadata } from '../../shared/scm';
+import { normalizeTenantId } from '../../shared/tenant';
 
 export type RunJobMode = 'full_run' | 'evidence_only' | 'preview_only';
 
 export type RunJobParams = {
+  tenantId: string;
   repoId: string;
   taskId: string;
   runId: string;
@@ -159,34 +161,36 @@ export function buildRunLog(runId: string, message: string, phase: RunError['pha
 }
 
 export function buildArtifactManifest(run: AgentRun, task: Task, repo: Repo, environmentId: string): ArtifactManifest {
+  const baseKey = buildTenantRunArtifactBaseKey(run.tenantId, run.runId);
   return {
     logs: {
-      key: `runs/${run.runId}/logs/executor.txt`,
+      key: `${baseKey}/logs/executor.txt`,
       label: 'Executor logs'
     },
     before: {
-      key: `runs/${run.runId}/evidence/before.png`,
+      key: `${baseKey}/evidence/before.png`,
       label: 'Before screenshot',
       url: repo.baselineUrl
     },
     after: run.previewUrl
       ? {
-          key: `runs/${run.runId}/evidence/after.png`,
+          key: `${baseKey}/evidence/after.png`,
           label: 'After screenshot',
           url: run.previewUrl
         }
       : undefined,
     trace: {
-      key: `runs/${run.runId}/evidence/trace.zip`,
+      key: `${baseKey}/evidence/trace.zip`,
       label: 'Playwright trace',
-      url: `r2://runs/${run.runId}/evidence/trace.zip`
+      url: `r2://${baseKey}/evidence/trace.zip`
     },
     video: {
-      key: `runs/${run.runId}/evidence/video.mp4`,
+      key: `${baseKey}/evidence/video.mp4`,
       label: 'Playwright video',
-      url: `r2://runs/${run.runId}/evidence/video.mp4`
+      url: `r2://${baseKey}/evidence/video.mp4`
     },
     metadata: {
+      tenantId: normalizeTenantId(run.tenantId),
       generatedAt: new Date().toISOString(),
       environmentId,
       workflowInstanceId: run.workflowInstanceId,
@@ -196,4 +200,8 @@ export function buildArtifactManifest(run: AgentRun, task: Task, repo: Repo, env
       baselineUrl: task.baselineUrlOverride ?? repo.baselineUrl
     }
   };
+}
+
+export function buildTenantRunArtifactBaseKey(tenantId: string | undefined, runId: string) {
+  return `tenants/${normalizeTenantId(tenantId)}/runs/${runId}`;
 }

--- a/src/server/workflows/run-workflow.ts
+++ b/src/server/workflows/run-workflow.ts
@@ -5,6 +5,6 @@ import { executeRunJob } from '../run-orchestrator';
 export class RunWorkflow extends WorkflowEntrypoint<Env, RunJobParams> {
   async run(event: Readonly<{ payload: Readonly<RunJobParams> }>, step: { sleep(name: string, duration: number | `${number} ${string}`): Promise<void> }) {
     await executeRunJob(this.env, event.payload, (name, duration) => step.sleep(name, duration));
-    return { ok: true, runId: event.payload.runId, mode: event.payload.mode };
+    return { ok: true, tenantId: event.payload.tenantId, runId: event.payload.runId, mode: event.payload.mode };
   }
 }

--- a/src/ui/domain/types.ts
+++ b/src/ui/domain/types.ts
@@ -300,6 +300,7 @@ export type ArtifactManifest = {
   trace?: ArtifactPointer;
   video?: ArtifactPointer;
   metadata: {
+    tenantId?: string;
     generatedAt: string;
     environmentId: string;
     simulatorVersion?: string;

--- a/tests/worker/stage-3-5-llm-dogfood.test.ts
+++ b/tests/worker/stage-3-5-llm-dogfood.test.ts
@@ -13,6 +13,14 @@ function createExecutionContext(): ExecutionContext {
 }
 
 async function api<T>(path: string, init?: RequestInit): Promise<T> {
+  const response = await apiResponse(path, init);
+  if (!response.ok) {
+    throw new Error(`API ${init?.method ?? 'GET'} ${path} failed with status ${response.status}.`);
+  }
+  return await response.json() as T;
+}
+
+async function apiResponse(path: string, init?: RequestInit): Promise<Response> {
   const request = new Request(`https://minions.example.test${path}`, {
     ...init,
     headers: {
@@ -20,11 +28,7 @@ async function api<T>(path: string, init?: RequestInit): Promise<T> {
       ...(init?.headers ?? {})
     }
   });
-  const response = await worker.fetch(request, env, createExecutionContext());
-  if (!response.ok) {
-    throw new Error(`API ${init?.method ?? 'GET'} ${path} failed with status ${response.status}.`);
-  }
-  return await response.json() as T;
+  return worker.fetch(request, env, createExecutionContext());
 }
 
 function taskInput(repoId: string, title: string, patch: Partial<JsonValue> = {}) {
@@ -209,5 +213,38 @@ describe('Stage 3.5 LLM adapter dogfood API coverage', () => {
       llmSupportsResume: false
     });
     expect(takenOver.operatorSession?.llmResumeCommand).toBeUndefined();
+  });
+
+  it('rejects cross-tenant terminal and artifact reads', async () => {
+    const repo = await api<Repo>('/api/repos', {
+      method: 'POST',
+      body: JSON.stringify({
+        tenantId: 'tenant_acme',
+        slug: 'acme/minions-tenant-checks',
+        baselineUrl: 'https://tenant-checks.example.com',
+        defaultBranch: 'main'
+      })
+    });
+    const task = await api<Task>('/api/tasks', {
+      method: 'POST',
+      body: JSON.stringify(taskInput(repo.repoId, 'Tenant access checks'))
+    });
+    const repoBoard = env.REPO_BOARD.getByName(repo.repoId);
+    const run = await repoBoard.startRun(task.taskId);
+    await repoBoard.transitionRun(run.runId, {
+      status: 'RUNNING_CODEX',
+      sandboxId: run.runId
+    });
+    await repoBoard.storeArtifactManifest(run.runId);
+
+    const terminalResponse = await apiResponse(`/api/runs/${encodeURIComponent(run.runId)}/terminal`, {
+      headers: { 'X-Tenant-Id': 'tenant_other' }
+    });
+    const artifactResponse = await apiResponse(`/api/runs/${encodeURIComponent(run.runId)}/artifacts`, {
+      headers: { 'X-Tenant-Id': 'tenant_other' }
+    });
+
+    expect(terminalResponse.status).toBe(404);
+    expect(artifactResponse.status).toBe(404);
   });
 });


### PR DESCRIPTION
Task: S45-50 Workflow + tenant-owned artifact layout

Pass tenantId into workflow payload and move artifact/log keys to tenant-prefixed R2 paths.


Acceptance criteria:
- tenantId appears in workflow input
- R2 keys include tenants/{tenantId}/runs/{runId}/...
- Tenant checks protect artifact and terminal reads

Run ID: run_repo_abuiles_minions_mm9oq969pvsu