### PR TITLE
ST-1 Schema reset + single-tenant auth store

### DIFF
--- a/migrations/0000_tenant_auth_schema.sql
+++ b/migrations/0000_tenant_auth_schema.sql
@@ -1,54 +1,39 @@
+CREATE TABLE IF NOT EXISTS app_tenant_config (
+  id INTEGER PRIMARY KEY CHECK (id = 1),
+  external_id TEXT NOT NULL UNIQUE,
+  slug TEXT NOT NULL,
+  name TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'active',
+  domain TEXT,
+  created_by_user_id TEXT,
+  seat_limit INTEGER NOT NULL DEFAULT 100,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
 CREATE TABLE IF NOT EXISTS users (
   id INTEGER PRIMARY KEY,
   external_id TEXT NOT NULL UNIQUE,
   email TEXT NOT NULL UNIQUE,
   display_name TEXT,
+  role TEXT NOT NULL,
   password_hash TEXT NOT NULL,
   created_at TEXT NOT NULL,
   updated_at TEXT NOT NULL
-);
-
-CREATE TABLE IF NOT EXISTS tenants (
-  id INTEGER PRIMARY KEY,
-  external_id TEXT NOT NULL UNIQUE,
-  slug TEXT NOT NULL UNIQUE,
-  name TEXT NOT NULL,
-  status TEXT NOT NULL,
-  domain TEXT,
-  created_by_user_id TEXT NOT NULL,
-  default_seat_limit INTEGER NOT NULL,
-  seat_limit INTEGER NOT NULL,
-  settings_json TEXT,
-  created_at TEXT NOT NULL,
-  updated_at TEXT NOT NULL
-);
-
-CREATE TABLE IF NOT EXISTS tenant_memberships (
-  id INTEGER PRIMARY KEY,
-  external_id TEXT NOT NULL UNIQUE,
-  tenant_id TEXT NOT NULL,
-  user_id TEXT NOT NULL,
-  role TEXT NOT NULL,
-  seat_state TEXT NOT NULL,
-  created_at TEXT NOT NULL,
-  updated_at TEXT NOT NULL,
-  UNIQUE(tenant_id, user_id)
 );
 
 CREATE TABLE IF NOT EXISTS user_sessions (
   id INTEGER PRIMARY KEY,
   external_id TEXT NOT NULL UNIQUE,
   user_id TEXT NOT NULL,
-  active_tenant_id TEXT NOT NULL,
   token_hash TEXT NOT NULL UNIQUE,
   expires_at TEXT NOT NULL,
   last_seen_at TEXT NOT NULL
 );
 
-CREATE TABLE IF NOT EXISTS tenant_invites (
+CREATE TABLE IF NOT EXISTS invites (
   id INTEGER PRIMARY KEY,
   external_id TEXT NOT NULL UNIQUE,
-  tenant_id TEXT NOT NULL,
   email TEXT NOT NULL,
   role TEXT NOT NULL,
   status TEXT NOT NULL,
@@ -62,25 +47,18 @@ CREATE TABLE IF NOT EXISTS tenant_invites (
   updated_at TEXT NOT NULL
 );
 
-CREATE TABLE IF NOT EXISTS platform_admins (
+CREATE TABLE IF NOT EXISTS user_api_tokens (
   id INTEGER PRIMARY KEY,
   external_id TEXT NOT NULL UNIQUE,
-  email TEXT NOT NULL UNIQUE,
-  password_hash TEXT NOT NULL,
+  user_id TEXT NOT NULL,
+  name TEXT NOT NULL,
+  scopes_json TEXT,
+  token_hash TEXT NOT NULL UNIQUE,
+  expires_at TEXT,
+  last_used_at TEXT,
+  revoked_at TEXT,
   created_at TEXT NOT NULL,
   updated_at TEXT NOT NULL
-);
-
-CREATE TABLE IF NOT EXISTS platform_support_sessions (
-  id INTEGER PRIMARY KEY,
-  external_id TEXT NOT NULL UNIQUE,
-  token_hash TEXT NOT NULL UNIQUE,
-  admin_id TEXT NOT NULL,
-  tenant_id TEXT NOT NULL,
-  reason TEXT NOT NULL,
-  created_at TEXT NOT NULL,
-  expires_at TEXT NOT NULL,
-  released_at TEXT
 );
 
 CREATE TABLE IF NOT EXISTS security_audit_log (
@@ -94,9 +72,9 @@ CREATE TABLE IF NOT EXISTS security_audit_log (
   metadata_json TEXT
 );
 
-CREATE INDEX IF NOT EXISTS idx_memberships_user ON tenant_memberships(user_id);
-CREATE INDEX IF NOT EXISTS idx_memberships_tenant ON tenant_memberships(tenant_id);
-CREATE INDEX IF NOT EXISTS idx_sessions_token ON user_sessions(token_hash);
-CREATE INDEX IF NOT EXISTS idx_invites_token ON tenant_invites(token_hash);
-CREATE INDEX IF NOT EXISTS idx_platform_sessions_token ON platform_support_sessions(token_hash);
+CREATE INDEX IF NOT EXISTS idx_user_sessions_token ON user_sessions(token_hash);
+CREATE INDEX IF NOT EXISTS idx_invites_token ON invites(token_hash);
+CREATE INDEX IF NOT EXISTS idx_invites_status_email ON invites(status, email);
+CREATE INDEX IF NOT EXISTS idx_user_api_tokens_user ON user_api_tokens(user_id);
+CREATE INDEX IF NOT EXISTS idx_user_api_tokens_token ON user_api_tokens(token_hash);
 CREATE INDEX IF NOT EXISTS idx_audit_at ON security_audit_log(at);

--- a/src/server/tenant-auth-db.test.ts
+++ b/src/server/tenant-auth-db.test.ts
@@ -1,0 +1,426 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  acceptTenantInvite,
+  createTenantInvite,
+  createUserApiToken,
+  listTenantInvites,
+  listUserApiTokens,
+  login,
+  resolveApiToken,
+  resolvePendingTenantInviteByToken,
+  resolveSessionByToken,
+  revokeUserApiToken,
+  signup
+} from './tenant-auth-db';
+
+type Row = Record<string, unknown>;
+
+class FakeD1Statement {
+  private bindings: unknown[] = [];
+
+  constructor(
+    private readonly sql: string,
+    private readonly execute: (sql: string, bindings: unknown[]) => Promise<{ results?: Row[] }>
+  ) {}
+
+  bind(...values: unknown[]) {
+    this.bindings = values;
+    return this;
+  }
+
+  async run() {
+    return this.execute(this.sql, this.bindings);
+  }
+
+  async all<T>() {
+    return this.execute(this.sql, this.bindings) as Promise<{ results: T[] }>;
+  }
+
+  async first<T>() {
+    const result = await this.execute(this.sql, this.bindings);
+    return (result.results?.[0] as T | undefined) ?? null;
+  }
+}
+
+class FakeTenantAuthDb {
+  appTenantConfig: Row = {
+    id: 1,
+    external_id: 'tenant_local',
+    slug: 'local',
+    name: 'Local Tenant',
+    status: 'active',
+    domain: null,
+    created_by_user_id: 'system',
+    seat_limit: 100,
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z'
+  };
+
+  users: Row[] = [];
+  userSessions: Row[] = [];
+  invites: Row[] = [];
+  userApiTokens: Row[] = [];
+  securityAuditLog: Row[] = [];
+
+  prepare(sql: string) {
+    return new FakeD1Statement(sql, (statement, bindings) => this.execute(statement, bindings));
+  }
+
+  async batch(statements: Array<{ run: () => Promise<unknown> }>) {
+    for (const statement of statements) {
+      await statement.run();
+    }
+    return [];
+  }
+
+  private async execute(sql: string, bindings: unknown[]): Promise<{ results?: Row[] }> {
+    if (sql.includes('FROM sqlite_master')) {
+      return {
+        results: [
+          { name: 'app_tenant_config' },
+          { name: 'users' },
+          { name: 'user_sessions' },
+          { name: 'invites' },
+          { name: 'user_api_tokens' },
+          { name: 'security_audit_log' }
+        ]
+      };
+    }
+
+    if (sql === 'SELECT * FROM app_tenant_config LIMIT 1') {
+      return { results: [this.appTenantConfig] };
+    }
+
+    if (sql === 'SELECT external_id FROM users WHERE email = ? LIMIT 1') {
+      const email = String(bindings[0]);
+      return { results: this.users.filter((row) => row.email === email).slice(0, 1) };
+    }
+
+    if (sql === 'SELECT COUNT(*) AS count FROM users') {
+      return { results: [{ count: this.users.length }] };
+    }
+
+    if (sql === 'INSERT INTO users (external_id, email, display_name, role, password_hash, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)') {
+      this.users.push({
+        external_id: bindings[0],
+        email: bindings[1],
+        display_name: bindings[2],
+        role: bindings[3],
+        password_hash: bindings[4],
+        created_at: bindings[5],
+        updated_at: bindings[6]
+      });
+      return {};
+    }
+
+    if (sql === 'SELECT * FROM users WHERE email = ? LIMIT 1') {
+      const email = String(bindings[0]);
+      return { results: this.users.filter((row) => row.email === email).slice(0, 1) };
+    }
+
+    if (sql === 'INSERT INTO user_sessions (external_id, user_id, token_hash, expires_at, last_seen_at) VALUES (?, ?, ?, ?, ?)') {
+      this.userSessions.push({
+        external_id: bindings[0],
+        user_id: bindings[1],
+        token_hash: bindings[2],
+        expires_at: bindings[3],
+        last_seen_at: bindings[4]
+      });
+      return {};
+    }
+
+    if (sql === 'SELECT * FROM user_sessions WHERE token_hash = ? AND expires_at > ? LIMIT 1') {
+      const tokenHash = String(bindings[0]);
+      const now = String(bindings[1]);
+      return {
+        results: this.userSessions
+          .filter((row) => row.token_hash === tokenHash && String(row.expires_at) > now)
+          .slice(0, 1)
+      };
+    }
+
+    if (sql === 'SELECT * FROM users WHERE external_id = ? LIMIT 1') {
+      const userId = String(bindings[0]);
+      return { results: this.users.filter((row) => row.external_id === userId).slice(0, 1) };
+    }
+
+    if (sql === 'UPDATE user_sessions SET last_seen_at = ? WHERE external_id = ?') {
+      const lastSeenAt = String(bindings[0]);
+      const sessionId = String(bindings[1]);
+      this.userSessions = this.userSessions.map((row) => (
+        row.external_id === sessionId ? { ...row, last_seen_at: lastSeenAt } : row
+      ));
+      return {};
+    }
+
+    if (sql === 'DELETE FROM user_sessions WHERE external_id = ?') {
+      const sessionId = String(bindings[0]);
+      this.userSessions = this.userSessions.filter((row) => row.external_id !== sessionId);
+      return {};
+    }
+
+    if (sql === 'SELECT role FROM users WHERE external_id = ? LIMIT 1') {
+      const userId = String(bindings[0]);
+      return { results: this.users.filter((row) => row.external_id === userId).map((row) => ({ role: row.role })).slice(0, 1) };
+    }
+
+    if (sql === "SELECT external_id FROM invites WHERE email = ? AND status = 'pending' AND expires_at > ? LIMIT 1") {
+      const email = String(bindings[0]);
+      const now = String(bindings[1]);
+      return {
+        results: this.invites
+          .filter((row) => row.email === email && row.status === 'pending' && String(row.expires_at) > now)
+          .map((row) => ({ external_id: row.external_id }))
+          .slice(0, 1)
+      };
+    }
+
+    if (sql.includes('INSERT INTO invites')) {
+      this.invites.push({
+        external_id: bindings[0],
+        email: bindings[1],
+        role: bindings[2],
+        status: bindings[3],
+        token_hash: bindings[4],
+        created_by_user_id: bindings[5],
+        accepted_by_user_id: null,
+        accepted_at: null,
+        revoked_at: null,
+        expires_at: bindings[6],
+        created_at: bindings[7],
+        updated_at: bindings[8]
+      });
+      return {};
+    }
+
+    if (sql === 'SELECT * FROM invites ORDER BY created_at DESC') {
+      return {
+        results: [...this.invites].sort((a, b) => String(b.created_at).localeCompare(String(a.created_at)))
+      };
+    }
+
+    if (sql === "SELECT * FROM invites WHERE token_hash = ? AND status = 'pending' AND expires_at > ? LIMIT 1") {
+      const tokenHash = String(bindings[0]);
+      const now = String(bindings[1]);
+      return {
+        results: this.invites
+          .filter((row) => row.token_hash === tokenHash && row.status === 'pending' && String(row.expires_at) > now)
+          .slice(0, 1)
+      };
+    }
+
+    if (sql === 'UPDATE users SET role = ?, updated_at = ? WHERE external_id = ?') {
+      const role = String(bindings[0]);
+      const updatedAt = String(bindings[1]);
+      const userId = String(bindings[2]);
+      this.users = this.users.map((row) => (row.external_id === userId ? { ...row, role, updated_at: updatedAt } : row));
+      return {};
+    }
+
+    if (sql === "UPDATE invites SET status = 'accepted', accepted_by_user_id = ?, accepted_at = ?, updated_at = ? WHERE external_id = ?") {
+      const acceptedByUserId = String(bindings[0]);
+      const acceptedAt = String(bindings[1]);
+      const updatedAt = String(bindings[2]);
+      const inviteId = String(bindings[3]);
+      this.invites = this.invites.map((row) => (
+        row.external_id === inviteId
+          ? { ...row, status: 'accepted', accepted_by_user_id: acceptedByUserId, accepted_at: acceptedAt, updated_at: updatedAt }
+          : row
+      ));
+      return {};
+    }
+
+    if (sql === 'INSERT INTO security_audit_log (external_id, at, actor_type, actor_id, action, tenant_id, metadata_json) VALUES (?, ?, ?, ?, ?, ?, ?)') {
+      this.securityAuditLog.push({
+        external_id: bindings[0],
+        at: bindings[1],
+        actor_type: bindings[2],
+        actor_id: bindings[3],
+        action: bindings[4],
+        tenant_id: bindings[5],
+        metadata_json: bindings[6]
+      });
+      return {};
+    }
+
+    if (sql === 'SELECT external_id FROM users WHERE external_id = ? LIMIT 1') {
+      const userId = String(bindings[0]);
+      return {
+        results: this.users
+          .filter((row) => row.external_id === userId)
+          .map((row) => ({ external_id: row.external_id }))
+          .slice(0, 1)
+      };
+    }
+
+    if (sql.includes('INSERT INTO user_api_tokens')) {
+      this.userApiTokens.push({
+        external_id: bindings[0],
+        user_id: bindings[1],
+        name: bindings[2],
+        scopes_json: bindings[3],
+        token_hash: bindings[4],
+        expires_at: bindings[5],
+        last_used_at: null,
+        revoked_at: null,
+        created_at: bindings[6],
+        updated_at: bindings[7]
+      });
+      return {};
+    }
+
+    if (sql === 'SELECT * FROM user_api_tokens WHERE user_id = ? AND revoked_at IS NULL ORDER BY created_at DESC') {
+      const userId = String(bindings[0]);
+      return {
+        results: this.userApiTokens
+          .filter((row) => row.user_id === userId && row.revoked_at === null)
+          .sort((a, b) => String(b.created_at).localeCompare(String(a.created_at)))
+      };
+    }
+
+    if (sql === 'SELECT * FROM user_api_tokens WHERE external_id = ? LIMIT 1') {
+      const tokenId = String(bindings[0]);
+      return { results: this.userApiTokens.filter((row) => row.external_id === tokenId).slice(0, 1) };
+    }
+
+    if (sql === 'UPDATE user_api_tokens SET revoked_at = ?, updated_at = ? WHERE external_id = ?') {
+      const revokedAt = String(bindings[0]);
+      const updatedAt = String(bindings[1]);
+      const tokenId = String(bindings[2]);
+      this.userApiTokens = this.userApiTokens.map((row) => (
+        row.external_id === tokenId ? { ...row, revoked_at: revokedAt, updated_at: updatedAt } : row
+      ));
+      return {};
+    }
+
+    if (sql === 'SELECT * FROM user_api_tokens WHERE token_hash = ? AND revoked_at IS NULL AND (expires_at IS NULL OR expires_at > ?) LIMIT 1') {
+      const tokenHash = String(bindings[0]);
+      const now = String(bindings[1]);
+      return {
+        results: this.userApiTokens
+          .filter((row) => row.token_hash === tokenHash && row.revoked_at === null && (!row.expires_at || String(row.expires_at) > now))
+          .slice(0, 1)
+      };
+    }
+
+    if (sql === 'UPDATE user_api_tokens SET last_used_at = ?, updated_at = ? WHERE external_id = ?') {
+      const lastUsedAt = String(bindings[0]);
+      const updatedAt = String(bindings[1]);
+      const tokenId = String(bindings[2]);
+      this.userApiTokens = this.userApiTokens.map((row) => (
+        row.external_id === tokenId ? { ...row, last_used_at: lastUsedAt, updated_at: updatedAt } : row
+      ));
+      return {};
+    }
+
+    if (sql === 'SELECT * FROM users ORDER BY created_at ASC') {
+      return { results: [...this.users] };
+    }
+
+    if (sql === 'SELECT COUNT(*) AS seats_used FROM users') {
+      return { results: [{ seats_used: this.users.length }] };
+    }
+
+    throw new Error(`Unhandled SQL in fake tenant auth DB: ${sql}`);
+  }
+}
+
+describe('tenant-auth-db single-tenant auth store', () => {
+  let db: FakeTenantAuthDb;
+  let env: Env;
+
+  beforeEach(() => {
+    db = new FakeTenantAuthDb();
+    env = { TENANT_DB: db } as unknown as Env;
+  });
+
+  it('creates first user as owner and resolves session with singleton tenant', async () => {
+    const created = await signup(env, {
+      email: 'owner@example.com',
+      password: 'secret-pass',
+      displayName: 'Owner',
+      tenant: { name: 'ignored' }
+    });
+
+    expect(created.user.email).toBe('owner@example.com');
+    expect(created.activeTenantId).toBe('tenant_local');
+    expect(created.memberships).toHaveLength(1);
+    expect(created.memberships[0].role).toBe('owner');
+
+    const resolved = await resolveSessionByToken(env, created.token);
+    expect(resolved.user.id).toBe(created.user.id);
+    expect(resolved.session.activeTenantId).toBe('tenant_local');
+  });
+
+  it('persists invites and accepts invite for matching user email', async () => {
+    const owner = await signup(env, {
+      email: 'owner@example.com',
+      password: 'secret-pass',
+      tenant: { name: 'ignored' }
+    });
+    const member = await signup(env, {
+      email: 'member@example.com',
+      password: 'secret-pass',
+      tenant: { name: 'ignored' }
+    });
+
+    const createdInvite = await createTenantInvite(env, 'tenant_local', { email: 'member@example.com', role: 'owner' }, owner.user.id);
+    expect(createdInvite.invite.email).toBe('member@example.com');
+    expect(createdInvite.invite.status).toBe('pending');
+
+    const listed = await listTenantInvites(env, 'tenant_local', owner.user.id);
+    expect(listed).toHaveLength(1);
+    expect(listed[0].id).toBe(createdInvite.invite.id);
+
+    const resolved = await resolvePendingTenantInviteByToken(env, createdInvite.token);
+    expect(resolved.invite.id).toBe(createdInvite.invite.id);
+
+    const accepted = await acceptTenantInvite(env, createdInvite.token, member.user.id);
+    expect(accepted.invite.status).toBe('accepted');
+    expect(accepted.membership.role).toBe('owner');
+  });
+
+  it('supports personal API token create/list/resolve/revoke lifecycle', async () => {
+    const created = await signup(env, {
+      email: 'owner@example.com',
+      password: 'secret-pass',
+      tenant: { name: 'ignored' }
+    });
+
+    const pat = await createUserApiToken(env, created.user.id, {
+      name: 'CI Token',
+      scopes: ['board:read', 'runs:write']
+    });
+    expect(pat.token).toBeTruthy();
+    expect(pat.tokenRecord.name).toBe('CI Token');
+
+    const listed = await listUserApiTokens(env, created.user.id);
+    expect(listed).toHaveLength(1);
+    expect(listed[0].scopes).toEqual(['board:read', 'runs:write']);
+
+    const resolved = await resolveApiToken(env, pat.token);
+    expect(resolved.user.id).toBe(created.user.id);
+    expect(resolved.tokenRecord.id).toBe(pat.tokenRecord.id);
+    expect(resolved.tokenRecord.lastUsedAt).toBeTruthy();
+
+    await revokeUserApiToken(env, created.user.id, pat.tokenRecord.id);
+    const afterRevoke = await listUserApiTokens(env, created.user.id);
+    expect(afterRevoke).toHaveLength(0);
+
+    await expect(resolveApiToken(env, pat.token)).rejects.toMatchObject({ body: { code: 'UNAUTHORIZED' } });
+  });
+
+  it('rejects login for unknown singleton tenant id override', async () => {
+    await signup(env, {
+      email: 'owner@example.com',
+      password: 'secret-pass',
+      tenant: { name: 'ignored' }
+    });
+
+    await expect(login(env, {
+      email: 'owner@example.com',
+      password: 'secret-pass',
+      tenantId: 'tenant_other'
+    })).rejects.toMatchObject({ body: { code: 'FORBIDDEN' } });
+  });
+});

--- a/src/server/tenant-auth-db.ts
+++ b/src/server/tenant-auth-db.ts
@@ -43,20 +43,31 @@ type PlatformSupportSession = {
 type SecurityAuditLogEntry = {
   id: string;
   at: string;
-  actorType: 'tenant_user' | 'platform_admin';
+  actorType: 'tenant_user';
   actorId: string;
   action: string;
   tenantId?: string;
   metadata?: Record<string, string | number | boolean>;
 };
 
-type StoredUser = User & { passwordHash: string };
-type PlatformAdmin = { id: string; email: string; passwordHash: string; createdAt: string; updatedAt: string };
+type StoredUser = User & { role: 'owner' | 'member'; passwordHash: string };
 
-const DEFAULT_SEAT_LIMIT = 5;
+type UserApiTokenRecord = {
+  id: string;
+  userId: string;
+  name: string;
+  scopes: string[];
+  createdAt: string;
+  updatedAt: string;
+  expiresAt?: string;
+  lastUsedAt?: string;
+  revokedAt?: string;
+};
+
+const DEFAULT_SEAT_LIMIT = 100;
 const SESSION_TTL_MS = 1000 * 60 * 60 * 24 * 30;
-const PLATFORM_SESSION_TTL_MS = 1000 * 60 * 60 * 8;
 const INVITE_TTL_MS = 1000 * 60 * 60 * 24 * 30;
+const SINGLE_TENANT_FALLBACK_ID = 'tenant_local';
 
 let schemaReady: Promise<void> | undefined;
 
@@ -76,19 +87,14 @@ async function ensureSchema(db: D1Database): Promise<void> {
   if (!schemaReady) {
     schemaReady = (async () => {
       const requiredTables = [
+        'app_tenant_config',
         'users',
-        'tenants',
-        'tenant_memberships',
         'user_sessions',
-        'tenant_invites',
-        'platform_admins',
-        'platform_support_sessions',
-        'security_audit_log'
+        'invites',
+        'user_api_tokens'
       ] as const;
       const quoted = requiredTables.map((table) => `'${table}'`).join(', ');
-      const result = await db.prepare(
-        `SELECT name FROM sqlite_master WHERE type = 'table' AND name IN (${quoted})`
-      ).all<{ name: string }>();
+      const result = await db.prepare(`SELECT name FROM sqlite_master WHERE type = 'table' AND name IN (${quoted})`).all<{ name: string }>();
       const found = new Set((result.results ?? []).map((row) => String(row.name)));
       const missing = requiredTables.filter((table) => !found.has(table));
       if (missing.length > 0) {
@@ -101,23 +107,6 @@ async function ensureSchema(db: D1Database): Promise<void> {
   await schemaReady;
 }
 
-async function ensurePlatformAdmin(db: D1Database, env: Env): Promise<void> {
-  const record = env as unknown as Record<string, unknown>;
-  const email = typeof record.PLATFORM_ADMIN_EMAIL === 'string' ? normalizeEmail(record.PLATFORM_ADMIN_EMAIL) : '';
-  const password = typeof record.PLATFORM_ADMIN_PASSWORD === 'string' ? record.PLATFORM_ADMIN_PASSWORD.trim() : '';
-  if (!email || !password) {
-    return;
-  }
-  const existing = await db.prepare('SELECT external_id FROM platform_admins WHERE email = ? LIMIT 1').bind(email).first<{ external_id: string }>();
-  if (existing) {
-    return;
-  }
-  const now = new Date().toISOString();
-  await db.prepare(
-    'INSERT INTO platform_admins (external_id, email, password_hash, created_at, updated_at) VALUES (?, ?, ?, ?, ?)'
-  ).bind(`admin_${crypto.randomUUID()}`, email, await hashSecret(password), now, now).run();
-}
-
 function normalizeEmail(value: string): string {
   const email = value.trim().toLowerCase();
   if (!email || !email.includes('@')) {
@@ -126,65 +115,8 @@ function normalizeEmail(value: string): string {
   return email;
 }
 
-function normalizeTenantSlug(value: string): string {
-  const slug = value.trim().toLowerCase().replace(/[^a-z0-9_-]+/g, '-').replace(/^-+|-+$/g, '');
-  if (!slug) {
-    throw badRequest('Invalid tenant slug.');
-  }
-  return slug;
-}
-
-function parseSettings(raw: string | null): Tenant['settings'] | undefined {
-  if (!raw) {
-    return undefined;
-  }
-  try {
-    const parsed = JSON.parse(raw);
-    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
-      return undefined;
-    }
-    const out: Record<string, string | number | boolean> = {};
-    for (const [key, value] of Object.entries(parsed as Record<string, unknown>)) {
-      if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
-        out[key] = value;
-      }
-    }
-    return Object.keys(out).length ? out : undefined;
-  } catch {
-    return undefined;
-  }
-}
-
 function externalId(row: Record<string, unknown>): string {
   return String(row.external_id ?? row.id);
-}
-
-function mapTenant(row: Record<string, unknown>): Tenant {
-  return {
-    id: externalId(row),
-    slug: String(row.slug),
-    name: String(row.name),
-    status: row.status === 'suspended' ? 'suspended' : 'active',
-    domain: row.domain ? String(row.domain) : undefined,
-    createdByUserId: String(row.created_by_user_id),
-    defaultSeatLimit: Number(row.default_seat_limit) || DEFAULT_SEAT_LIMIT,
-    seatLimit: Number(row.seat_limit) || DEFAULT_SEAT_LIMIT,
-    settings: parseSettings((row.settings_json as string | null) ?? null),
-    createdAt: String(row.created_at),
-    updatedAt: String(row.updated_at)
-  };
-}
-
-function mapMember(row: Record<string, unknown>): TenantMember {
-  return {
-    id: externalId(row),
-    tenantId: String(row.tenant_id),
-    userId: String(row.user_id),
-    role: row.role === 'owner' ? 'owner' : 'member',
-    seatState: row.seat_state === 'invited' || row.seat_state === 'revoked' ? row.seat_state : 'active',
-    createdAt: String(row.created_at),
-    updatedAt: String(row.updated_at)
-  };
 }
 
 function mapUser(row: Record<string, unknown>): User {
@@ -200,26 +132,84 @@ function mapUser(row: Record<string, unknown>): User {
 function mapStoredUser(row: Record<string, unknown>): StoredUser {
   return {
     ...mapUser(row),
+    role: row.role === 'owner' ? 'owner' : 'member',
     passwordHash: String(row.password_hash)
   };
 }
 
-function mapSession(row: Record<string, unknown>): UserSession {
+async function mapSession(row: Record<string, unknown>, tenantId: string): Promise<UserSession> {
   return {
     id: externalId(row),
     userId: String(row.user_id),
-    tenantId: String(row.active_tenant_id),
-    activeTenantId: String(row.active_tenant_id),
+    tenantId,
+    activeTenantId: tenantId,
     tokenHash: String(row.token_hash),
     expiresAt: String(row.expires_at),
     lastSeenAt: String(row.last_seen_at)
   };
 }
 
-async function hashSecret(input: string): Promise<string> {
-  const payload = new TextEncoder().encode(input);
-  const digest = await crypto.subtle.digest('SHA-256', payload);
-  return [...new Uint8Array(digest)].map((byte) => byte.toString(16).padStart(2, '0')).join('');
+function mapTenant(tenantId: string, row: Record<string, unknown>): Tenant {
+  const seatLimit = Number(row.seat_limit ?? DEFAULT_SEAT_LIMIT) || DEFAULT_SEAT_LIMIT;
+  return {
+    id: tenantId,
+    slug: String(row.slug ?? 'local'),
+    name: String(row.name ?? 'Local deployment'),
+    status: row.status === 'suspended' ? 'suspended' : 'active',
+    domain: row.domain ? String(row.domain) : undefined,
+    createdByUserId: String(row.created_by_user_id ?? 'system'),
+    defaultSeatLimit: seatLimit,
+    seatLimit,
+    settings: undefined,
+    createdAt: String(row.created_at),
+    updatedAt: String(row.updated_at)
+  };
+}
+
+function mapInvite(row: Record<string, unknown>, tenantId: string): TenantInvite {
+  return {
+    id: externalId(row),
+    tenantId,
+    email: String(row.email),
+    role: row.role === 'owner' ? 'owner' : 'member',
+    status: row.status === 'accepted' || row.status === 'revoked' ? row.status : 'pending',
+    createdByUserId: String(row.created_by_user_id),
+    acceptedByUserId: row.accepted_by_user_id ? String(row.accepted_by_user_id) : undefined,
+    acceptedAt: row.accepted_at ? String(row.accepted_at) : undefined,
+    revokedAt: row.revoked_at ? String(row.revoked_at) : undefined,
+    expiresAt: String(row.expires_at),
+    createdAt: String(row.created_at),
+    updatedAt: String(row.updated_at)
+  };
+}
+
+function parseScopes(scopes: unknown): string[] {
+  if (typeof scopes !== 'string' || !scopes) {
+    return [];
+  }
+  try {
+    const parsed = JSON.parse(scopes);
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+    return parsed.filter((entry): entry is string => typeof entry === 'string' && entry.trim().length > 0);
+  } catch {
+    return [];
+  }
+}
+
+function mapApiToken(row: Record<string, unknown>): UserApiTokenRecord {
+  return {
+    id: externalId(row),
+    userId: String(row.user_id),
+    name: String(row.name),
+    scopes: parseScopes(row.scopes_json),
+    createdAt: String(row.created_at),
+    updatedAt: String(row.updated_at),
+    expiresAt: row.expires_at ? String(row.expires_at) : undefined,
+    lastUsedAt: row.last_used_at ? String(row.last_used_at) : undefined,
+    revokedAt: row.revoked_at ? String(row.revoked_at) : undefined
+  };
 }
 
 function createAuthToken() {
@@ -233,34 +223,79 @@ function createUserId(email: string): string {
   return `${base}_${Math.random().toString(36).slice(2, 10)}`;
 }
 
-function createTenantId(slug: string): string {
-  return `tenant_${slug}`;
+async function hashSecret(input: string): Promise<string> {
+  const payload = new TextEncoder().encode(input);
+  const digest = await crypto.subtle.digest('SHA-256', payload);
+  return [...new Uint8Array(digest)].map((byte) => byte.toString(16).padStart(2, '0')).join('');
 }
 
-function createTenantMemberId(tenantId: string, userId: string): string {
-  return `${tenantId}:${userId}`;
+function stripUserSecret(user: StoredUser): User {
+  return { id: user.id, email: user.email, displayName: user.displayName, createdAt: user.createdAt, updatedAt: user.updatedAt };
 }
 
-async function nextAvailableTenantSlug(db: D1Database, baseSlug: string): Promise<string> {
-  let candidate = baseSlug;
-  let suffix = 2;
-  while (true) {
-    const existing = await db.prepare('SELECT external_id FROM tenants WHERE slug = ? LIMIT 1').bind(candidate).first<{ external_id: string }>();
-    if (!existing) {
-      return candidate;
-    }
-    candidate = `${baseSlug}-${suffix}`;
-    suffix += 1;
+async function getTenantConfigRow(db: D1Database): Promise<Record<string, unknown>> {
+  await ensureSchema(db);
+  const row = await db.prepare('SELECT * FROM app_tenant_config LIMIT 1').first<Record<string, unknown>>();
+  if (!row) {
+    throw new Error('app_tenant_config is empty. Seed one row before starting the app.');
+  }
+  return row;
+}
+
+async function getTenantId(db: D1Database): Promise<string> {
+  const row = await getTenantConfigRow(db);
+  const value = row.external_id ? String(row.external_id).trim() : '';
+  return value || SINGLE_TENANT_FALLBACK_ID;
+}
+
+async function ensureTenantIdMatch(db: D1Database, tenantId: string): Promise<string> {
+  const canonical = await getTenantId(db);
+  if (tenantId.trim() !== canonical) {
+    throw forbidden(`Tenant ${tenantId} is not available in single-tenant mode.`);
+  }
+  return canonical;
+}
+
+async function membershipForUser(env: Env, userId: string): Promise<TenantMember | undefined> {
+  const db = getDb(env);
+  await ensureSchema(db);
+  const row = await db.prepare('SELECT * FROM users WHERE external_id = ? LIMIT 1').bind(userId).first<Record<string, unknown>>();
+  if (!row) {
+    return undefined;
+  }
+  const tenantId = await getTenantId(db);
+  const now = String(row.updated_at ?? row.created_at ?? new Date().toISOString());
+  return {
+    id: `${tenantId}:${externalId(row)}`,
+    tenantId,
+    userId: externalId(row),
+    role: row.role === 'owner' ? 'owner' : 'member',
+    seatState: 'active',
+    createdAt: String(row.created_at ?? now),
+    updatedAt: now
+  };
+}
+
+async function assertOwner(env: Env, userId: string) {
+  const db = getDb(env);
+  await ensureSchema(db);
+  const row = await db.prepare('SELECT role FROM users WHERE external_id = ? LIMIT 1').bind(userId).first<{ role: string }>();
+  if (!row || row.role !== 'owner') {
+    throw forbidden('Only owner users may perform this action.');
   }
 }
 
-async function writeAuditLog(db: D1Database, entry: Omit<SecurityAuditLogEntry, 'id' | 'at'>): Promise<void> {
+async function writeAuditLog(
+  db: D1Database,
+  entry: Omit<SecurityAuditLogEntry, 'id' | 'at'>
+): Promise<void> {
+  const now = new Date().toISOString();
   await db.prepare(
     'INSERT INTO security_audit_log (external_id, at, actor_type, actor_id, action, tenant_id, metadata_json) VALUES (?, ?, ?, ?, ?, ?, ?)'
   ).bind(
     `audit_${crypto.randomUUID()}`,
-    new Date().toISOString(),
-    entry.actorType,
+    now,
+    'tenant_user',
     entry.actorId,
     entry.action,
     entry.tenantId ?? null,
@@ -276,41 +311,27 @@ export async function signup(env: Env, input: {
 }) {
   const db = getDb(env);
   await ensureSchema(db);
-  await ensurePlatformAdmin(db, env);
   const email = normalizeEmail(input.email);
   const existing = await db.prepare('SELECT external_id FROM users WHERE email = ? LIMIT 1').bind(email).first<{ external_id: string }>();
   if (existing) {
     throw conflict(`User with email ${email} already exists.`);
   }
-  const tenantName = input.tenant.name.trim();
-  if (!tenantName) {
-    throw badRequest('Invalid tenant name.');
-  }
-  const slug = await nextAvailableTenantSlug(db, normalizeTenantSlug(tenantName));
 
+  const countRow = await db.prepare('SELECT COUNT(*) AS count FROM users').first<{ count: number }>();
+  const role: 'owner' | 'member' = Number(countRow?.count ?? 0) === 0 ? 'owner' : 'member';
   const now = new Date().toISOString();
   const userId = createUserId(email);
-  const tenantId = createTenantId(slug);
-  const seatLimit = input.tenant.seatLimit ?? input.tenant.defaultSeatLimit ?? DEFAULT_SEAT_LIMIT;
-  const defaultSeatLimit = input.tenant.defaultSeatLimit ?? input.tenant.seatLimit ?? DEFAULT_SEAT_LIMIT;
-  await db.batch([
-    db.prepare(
-      'INSERT INTO users (external_id, email, display_name, password_hash, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)'
-    ).bind(userId, email, input.displayName?.trim() || null, await hashSecret(input.password), now, now),
-    db.prepare(
-      'INSERT INTO tenants (external_id, slug, name, status, domain, created_by_user_id, default_seat_limit, seat_limit, settings_json, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'
-    ).bind(tenantId, slug, tenantName, 'active', input.tenant.domain?.trim() || null, userId, defaultSeatLimit, seatLimit, null, now, now),
-    db.prepare(
-      'INSERT INTO tenant_memberships (external_id, tenant_id, user_id, role, seat_state, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)'
-    ).bind(createTenantMemberId(tenantId, userId), tenantId, userId, 'owner', 'active', now, now)
-  ]);
-  return login(env, { email, password: input.password, tenantId });
+
+  await db.prepare(
+    'INSERT INTO users (external_id, email, display_name, role, password_hash, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)'
+  ).bind(userId, email, input.displayName?.trim() || null, role, await hashSecret(input.password), now, now).run();
+
+  return login(env, { email, password: input.password });
 }
 
 export async function login(env: Env, input: { email: string; password: string; tenantId?: string }) {
   const db = getDb(env);
   await ensureSchema(db);
-  await ensurePlatformAdmin(db, env);
   const email = normalizeEmail(input.email);
   const userRow = await db.prepare('SELECT * FROM users WHERE email = ? LIMIT 1').bind(email).first<Record<string, unknown>>();
   if (!userRow) {
@@ -321,14 +342,9 @@ export async function login(env: Env, input: { email: string; password: string; 
     throw unauthorized('Invalid email or password.');
   }
 
-  const memberships = await listUserMemberships(env, user.id);
-  const activeMemberships = memberships.filter((membership) => membership.seatState === 'active');
-  if (!activeMemberships.length) {
-    throw forbidden(`User ${user.id} does not have an active seat in any tenant.`);
-  }
-  const activeTenantId = input.tenantId?.trim() || activeMemberships[0].tenantId;
-  if (!activeMemberships.some((membership) => membership.tenantId === activeTenantId)) {
-    throw forbidden(`User ${user.id} does not have an active seat in tenant ${activeTenantId}.`);
+  const tenantId = await getTenantId(db);
+  if (input.tenantId && input.tenantId.trim() !== tenantId) {
+    throw forbidden(`Tenant ${input.tenantId} is not available in single-tenant mode.`);
   }
 
   const now = Date.now();
@@ -337,22 +353,23 @@ export async function login(env: Env, input: { email: string; password: string; 
   const session: UserSession = {
     id: `sess_${crypto.randomUUID()}`,
     userId: user.id,
-    tenantId: activeTenantId,
-    activeTenantId,
+    tenantId,
+    activeTenantId: tenantId,
     tokenHash,
     expiresAt: new Date(now + SESSION_TTL_MS).toISOString(),
     lastSeenAt: new Date(now).toISOString()
   };
   await db.prepare(
-    'INSERT INTO user_sessions (external_id, user_id, active_tenant_id, token_hash, expires_at, last_seen_at) VALUES (?, ?, ?, ?, ?, ?)'
-  ).bind(session.id, session.userId, session.activeTenantId, session.tokenHash, session.expiresAt, session.lastSeenAt).run();
+    'INSERT INTO user_sessions (external_id, user_id, token_hash, expires_at, last_seen_at) VALUES (?, ?, ?, ?, ?)'
+  ).bind(session.id, session.userId, session.tokenHash, session.expiresAt, session.lastSeenAt).run();
 
+  const membership = await membershipForUser(env, user.id);
   return {
     user: stripUserSecret(user),
     session,
     token,
-    activeTenantId: session.activeTenantId,
-    memberships
+    activeTenantId: tenantId,
+    memberships: membership ? [membership] : []
   };
 }
 
@@ -360,45 +377,46 @@ export async function resolveSessionByToken(env: Env, token: string): Promise<{ 
   const db = getDb(env);
   await ensureSchema(db);
   const tokenHash = await hashSecret(token);
-  const sessionRow = await db.prepare(
+  const row = await db.prepare(
     'SELECT * FROM user_sessions WHERE token_hash = ? AND expires_at > ? LIMIT 1'
   ).bind(tokenHash, new Date().toISOString()).first<Record<string, unknown>>();
-  if (!sessionRow) {
+  if (!row) {
     throw unauthorized('Invalid or expired auth session.');
   }
-  const session = mapSession(sessionRow);
+
+  const tenantId = await getTenantId(db);
+  const session = await mapSession(row, tenantId);
   const userRow = await db.prepare('SELECT * FROM users WHERE external_id = ? LIMIT 1').bind(session.userId).first<Record<string, unknown>>();
   if (!userRow) {
     throw unauthorized('Auth session user no longer exists.');
   }
-  const memberships = await listUserMemberships(env, session.userId);
-  if (!memberships.some((membership) => membership.tenantId === session.activeTenantId && membership.seatState === 'active')) {
-    throw forbidden(`User ${session.userId} does not have an active seat in tenant ${session.activeTenantId}.`);
-  }
+
   const touchedAt = new Date().toISOString();
   await db.prepare('UPDATE user_sessions SET last_seen_at = ? WHERE external_id = ?').bind(touchedAt, session.id).run();
+  const membership = await membershipForUser(env, session.userId);
   return {
     user: mapUser(userRow),
     session: { ...session, lastSeenAt: touchedAt },
-    memberships
+    memberships: membership ? [membership] : []
   };
 }
 
 export async function setSessionActiveTenant(env: Env, sessionId: string, tenantId: string): Promise<UserSession> {
   const db = getDb(env);
   await ensureSchema(db);
-  const sessionRow = await db.prepare('SELECT * FROM user_sessions WHERE external_id = ? LIMIT 1').bind(sessionId).first<Record<string, unknown>>();
-  if (!sessionRow) {
+  const row = await db.prepare('SELECT * FROM user_sessions WHERE external_id = ? LIMIT 1').bind(sessionId).first<Record<string, unknown>>();
+  if (!row) {
     throw unauthorized('Invalid or expired auth session.');
   }
-  const session = mapSession(sessionRow);
-  const membership = await getTenantMembership(env, tenantId, session.userId);
-  if (!membership || membership.seatState !== 'active') {
-    throw forbidden(`User ${session.userId} does not have an active seat in tenant ${tenantId}.`);
-  }
+  const canonicalTenantId = await ensureTenantIdMatch(db, tenantId);
   const lastSeenAt = new Date().toISOString();
-  await db.prepare('UPDATE user_sessions SET active_tenant_id = ?, last_seen_at = ? WHERE external_id = ?').bind(tenantId, lastSeenAt, sessionId).run();
-  return { ...session, tenantId, activeTenantId: tenantId, lastSeenAt };
+  await db.prepare('UPDATE user_sessions SET last_seen_at = ? WHERE external_id = ?').bind(lastSeenAt, sessionId).run();
+  return {
+    ...(await mapSession(row, canonicalTenantId)),
+    tenantId: canonicalTenantId,
+    activeTenantId: canonicalTenantId,
+    lastSeenAt
+  };
 }
 
 export async function logout(env: Env, sessionId: string): Promise<{ ok: true }> {
@@ -416,39 +434,33 @@ export async function getUserById(env: Env, userId: string): Promise<User | unde
 }
 
 export async function listUserMemberships(env: Env, userId: string): Promise<TenantMember[]> {
-  const db = getDb(env);
-  await ensureSchema(db);
-  const result = await db.prepare('SELECT * FROM tenant_memberships WHERE user_id = ? ORDER BY created_at ASC').bind(userId).all<Record<string, unknown>>();
-  return (result.results ?? []).map(mapMember);
+  const membership = await membershipForUser(env, userId);
+  return membership ? [membership] : [];
 }
 
 export async function listTenantsForUser(env: Env, userId: string): Promise<Tenant[]> {
   const db = getDb(env);
   await ensureSchema(db);
-  const result = await db.prepare(
-    `SELECT t.* FROM tenants t
-     INNER JOIN tenant_memberships m ON m.tenant_id = t.external_id
-     WHERE m.user_id = ? AND m.seat_state = 'active'
-     ORDER BY t.slug ASC`
-  ).bind(userId).all<Record<string, unknown>>();
-  return (result.results ?? []).map(mapTenant);
+  const user = await db.prepare('SELECT external_id FROM users WHERE external_id = ? LIMIT 1').bind(userId).first<{ external_id: string }>();
+  if (!user) {
+    return [];
+  }
+  const tenantRow = await getTenantConfigRow(db);
+  return [mapTenant(await getTenantId(db), tenantRow)];
 }
 
 export async function getTenant(env: Env, tenantId: string): Promise<Tenant> {
   const db = getDb(env);
   await ensureSchema(db);
-  const row = await db.prepare('SELECT * FROM tenants WHERE external_id = ? LIMIT 1').bind(tenantId.trim()).first<Record<string, unknown>>();
-  if (!row) {
-    throw notFound(`Tenant ${tenantId} not found.`);
-  }
-  return mapTenant(row);
+  const canonical = await ensureTenantIdMatch(db, tenantId);
+  return mapTenant(canonical, await getTenantConfigRow(db));
 }
 
 export async function getTenantMembership(env: Env, tenantId: string, userId: string): Promise<TenantMember | undefined> {
   const db = getDb(env);
   await ensureSchema(db);
-  const row = await db.prepare('SELECT * FROM tenant_memberships WHERE tenant_id = ? AND user_id = ? LIMIT 1').bind(tenantId.trim(), userId.trim()).first<Record<string, unknown>>();
-  return row ? mapMember(row) : undefined;
+  await ensureTenantIdMatch(db, tenantId);
+  return membershipForUser(env, userId);
 }
 
 export async function hasActiveTenantAccess(env: Env, tenantId: string, userId: string): Promise<boolean> {
@@ -459,104 +471,46 @@ export async function hasActiveTenantAccess(env: Env, tenantId: string, userId: 
 export async function listTenantMembers(env: Env, tenantId: string): Promise<TenantMember[]> {
   const db = getDb(env);
   await ensureSchema(db);
-  const result = await db.prepare('SELECT * FROM tenant_memberships WHERE tenant_id = ? ORDER BY created_at ASC').bind(tenantId).all<Record<string, unknown>>();
-  return (result.results ?? []).map(mapMember);
+  const canonical = await ensureTenantIdMatch(db, tenantId);
+  const result = await db.prepare('SELECT * FROM users ORDER BY created_at ASC').all<Record<string, unknown>>();
+  return (result.results ?? []).map((row) => ({
+    id: `${canonical}:${externalId(row)}`,
+    tenantId: canonical,
+    userId: externalId(row),
+    role: row.role === 'owner' ? 'owner' : 'member',
+    seatState: 'active',
+    createdAt: String(row.created_at),
+    updatedAt: String(row.updated_at)
+  }));
 }
 
 export async function getTenantSeatSummary(env: Env, tenantId: string): Promise<TenantSeatSummary> {
   const db = getDb(env);
-  const tenant = await getTenant(env, tenantId);
-  const row = await db.prepare(
-    "SELECT COUNT(*) AS seats_used FROM tenant_memberships WHERE tenant_id = ? AND seat_state = 'active'"
-  ).bind(tenant.id).first<{ seats_used: number }>();
+  await ensureSchema(db);
+  const canonical = await ensureTenantIdMatch(db, tenantId);
+  const tenantRow = await getTenantConfigRow(db);
+  const seatLimit = Number(tenantRow.seat_limit ?? DEFAULT_SEAT_LIMIT) || DEFAULT_SEAT_LIMIT;
+  const row = await db.prepare('SELECT COUNT(*) AS seats_used FROM users').first<{ seats_used: number }>();
   const seatsUsed = Number(row?.seats_used ?? 0);
   return {
-    tenantId: tenant.id,
-    seatLimit: tenant.seatLimit,
+    tenantId: canonical,
+    seatLimit,
     seatsUsed,
-    seatsAvailable: Math.max(0, tenant.seatLimit - seatsUsed)
+    seatsAvailable: Math.max(0, seatLimit - seatsUsed)
   };
-}
-
-async function assertOwnerAccess(env: Env, tenantId: string, userId: string) {
-  const membership = await getTenantMembership(env, tenantId, userId);
-  if (!membership || membership.seatState !== 'active') {
-    throw forbidden(`User ${userId} does not have an active seat in tenant ${tenantId}.`);
-  }
-  if (membership.role !== 'owner') {
-    throw forbidden(`User ${userId} must be an owner of tenant ${tenantId}.`);
-  }
-}
-
-async function assertSeatCapacity(env: Env, tenantId: string) {
-  const summary = await getTenantSeatSummary(env, tenantId);
-  if (summary.seatsUsed >= summary.seatLimit) {
-    throw conflict(`Tenant ${tenantId} has no available seats.`);
-  }
 }
 
 export async function createTenant(env: Env, input: TenantRecordInput, actorUserId: string): Promise<{ tenant: Tenant; ownerMembership: TenantMember; seatSummary: TenantSeatSummary }> {
-  const db = getDb(env);
-  await ensureSchema(db);
-  const slug = normalizeTenantSlug(input.slug);
-  const existing = await db.prepare('SELECT external_id FROM tenants WHERE slug = ? LIMIT 1').bind(slug).first<{ external_id: string }>();
-  if (existing) {
-    throw conflict(`Tenant slug ${slug} already exists.`);
-  }
-  const now = new Date().toISOString();
-  const tenantId = createTenantId(slug);
-  const seatLimit = input.seatLimit ?? input.defaultSeatLimit ?? DEFAULT_SEAT_LIMIT;
-  const defaultSeatLimit = input.defaultSeatLimit ?? input.seatLimit ?? DEFAULT_SEAT_LIMIT;
-  const membership: TenantMember = {
-    id: createTenantMemberId(tenantId, actorUserId),
-    tenantId,
-    userId: actorUserId,
-    role: 'owner',
-    seatState: 'active',
-    createdAt: now,
-    updatedAt: now
-  };
-  await db.batch([
-    db.prepare(
-      'INSERT INTO tenants (external_id, slug, name, status, domain, created_by_user_id, default_seat_limit, seat_limit, settings_json, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'
-    ).bind(tenantId, slug, input.name.trim(), 'active', input.domain?.trim() || null, actorUserId, defaultSeatLimit, seatLimit, null, now, now),
-    db.prepare(
-      'INSERT INTO tenant_memberships (external_id, tenant_id, user_id, role, seat_state, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)'
-    ).bind(membership.id, membership.tenantId, membership.userId, membership.role, membership.seatState, membership.createdAt, membership.updatedAt)
-  ]);
-  return {
-    tenant: await getTenant(env, tenantId),
-    ownerMembership: membership,
-    seatSummary: await getTenantSeatSummary(env, tenantId)
-  };
+  void input;
+  void actorUserId;
+  throw forbidden('Single-tenant mode does not allow creating additional tenants.');
 }
 
 export async function createTenantMember(env: Env, tenantId: string, input: TenantMemberRecordInput, actorUserId: string): Promise<{ member: TenantMember; seatSummary: TenantSeatSummary }> {
-  const db = getDb(env);
-  await ensureSchema(db);
-  await assertOwnerAccess(env, tenantId, actorUserId);
-  const existing = await getTenantMembership(env, tenantId, input.userId);
-  if (existing) {
-    throw conflict(`Member ${input.userId} already exists in tenant ${tenantId}.`);
-  }
-  const seatState = input.seatState ?? 'active';
-  if (seatState === 'active') {
-    await assertSeatCapacity(env, tenantId);
-  }
-  const now = new Date().toISOString();
-  const member: TenantMember = {
-    id: createTenantMemberId(tenantId, input.userId),
-    tenantId,
-    userId: input.userId,
-    role: input.role ?? 'member',
-    seatState,
-    createdAt: now,
-    updatedAt: now
-  };
-  await db.prepare(
-    'INSERT INTO tenant_memberships (external_id, tenant_id, user_id, role, seat_state, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)'
-  ).bind(member.id, member.tenantId, member.userId, member.role, member.seatState, member.createdAt, member.updatedAt).run();
-  return { member, seatSummary: await getTenantSeatSummary(env, tenantId) };
+  void input;
+  await assertOwner(env, actorUserId);
+  await ensureTenantIdMatch(getDb(env), tenantId);
+  throw forbidden('Direct tenant membership management is not supported in single-tenant mode. Use invites instead.');
 }
 
 export async function updateTenantMember(
@@ -566,38 +520,11 @@ export async function updateTenantMember(
   patch: Pick<TenantMemberRecordInput, 'role' | 'seatState'>,
   actorUserId: string
 ): Promise<{ member: TenantMember; seatSummary: TenantSeatSummary }> {
-  const db = getDb(env);
-  await ensureSchema(db);
-  await assertOwnerAccess(env, tenantId, actorUserId);
-  const row = await db.prepare('SELECT * FROM tenant_memberships WHERE tenant_id = ? AND external_id = ? LIMIT 1').bind(tenantId, memberId).first<Record<string, unknown>>();
-  if (!row) {
-    throw notFound(`Member ${memberId} not found in tenant ${tenantId}.`);
-  }
-  const existing = mapMember(row);
-  const nextSeatState = patch.seatState ?? existing.seatState;
-  if (existing.seatState !== 'active' && nextSeatState === 'active') {
-    await assertSeatCapacity(env, tenantId);
-  }
-  const nextRole = patch.role ?? existing.role;
-  if (existing.role === 'owner' && (nextRole !== 'owner' || nextSeatState !== 'active')) {
-    const ownersRow = await db.prepare(
-      "SELECT COUNT(*) AS owners FROM tenant_memberships WHERE tenant_id = ? AND external_id <> ? AND role = 'owner' AND seat_state = 'active'"
-    ).bind(tenantId, memberId).first<{ owners: number }>();
-    if (Number(ownersRow?.owners ?? 0) === 0) {
-      throw forbidden(`Tenant ${tenantId} requires at least one active owner.`);
-    }
-  }
-  const updatedAt = new Date().toISOString();
-  await db.prepare('UPDATE tenant_memberships SET role = ?, seat_state = ?, updated_at = ? WHERE external_id = ?').bind(nextRole, nextSeatState, updatedAt, memberId).run();
-  return {
-    member: {
-      ...existing,
-      role: nextRole,
-      seatState: nextSeatState,
-      updatedAt
-    },
-    seatSummary: await getTenantSeatSummary(env, tenantId)
-  };
+  void memberId;
+  void patch;
+  await assertOwner(env, actorUserId);
+  await ensureTenantIdMatch(getDb(env), tenantId);
+  throw forbidden('Direct tenant membership updates are not supported in single-tenant mode.');
 }
 
 export async function createTenantInvite(
@@ -608,67 +535,59 @@ export async function createTenantInvite(
 ): Promise<{ invite: Omit<TenantInvite, 'tokenHash'>; token: string; seatSummary: TenantSeatSummary }> {
   const db = getDb(env);
   await ensureSchema(db);
-  await assertOwnerAccess(env, tenantId, actorUserId);
+  const canonicalTenantId = await ensureTenantIdMatch(db, tenantId);
+  await assertOwner(env, actorUserId);
+
   const email = normalizeEmail(input.email);
+  const nowIso = new Date().toISOString();
   const pending = await db.prepare(
-    "SELECT external_id FROM tenant_invites WHERE tenant_id = ? AND email = ? AND status = 'pending' AND expires_at > ? LIMIT 1"
-  ).bind(tenantId, email, new Date().toISOString()).first<{ external_id: string }>();
+    "SELECT external_id FROM invites WHERE email = ? AND status = 'pending' AND expires_at > ? LIMIT 1"
+  ).bind(email, nowIso).first<{ external_id: string }>();
   if (pending) {
-    throw conflict(`Pending invite for ${email} already exists in tenant ${tenantId}.`);
+    throw conflict(`Pending invite for ${email} already exists.`);
   }
-  const role = input.role ?? 'member';
-  if (role === 'owner') {
-    await assertSeatCapacity(env, tenantId);
-  }
-  const now = new Date().toISOString();
+
   const token = createAuthToken();
+  const now = new Date().toISOString();
   const invite: TenantInvite = {
     id: `invite_${crypto.randomUUID()}`,
-    tenantId,
+    tenantId: canonicalTenantId,
     email,
-    role,
+    role: input.role === 'owner' ? 'owner' : 'member',
     status: 'pending',
     createdByUserId: actorUserId,
     expiresAt: new Date(Date.now() + INVITE_TTL_MS).toISOString(),
     createdAt: now,
     updatedAt: now
   };
+
   await db.prepare(
-    `INSERT INTO tenant_invites
-     (external_id, tenant_id, email, role, status, token_hash, created_by_user_id, accepted_by_user_id, accepted_at, revoked_at, expires_at, created_at, updated_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?, NULL, NULL, NULL, ?, ?, ?)`
-  ).bind(invite.id, invite.tenantId, invite.email, invite.role, invite.status, await hashSecret(token), invite.createdByUserId, invite.expiresAt, invite.createdAt, invite.updatedAt).run();
+    `INSERT INTO invites
+     (external_id, email, role, status, token_hash, created_by_user_id, accepted_by_user_id, accepted_at, revoked_at, expires_at, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, NULL, NULL, NULL, ?, ?, ?)`
+  ).bind(invite.id, invite.email, invite.role, invite.status, await hashSecret(token), invite.createdByUserId, invite.expiresAt, invite.createdAt, invite.updatedAt).run();
+
   await writeAuditLog(db, {
     actorType: 'tenant_user',
     actorId: actorUserId,
-    action: 'tenant.invite.created',
-    tenantId,
+    action: 'invite.created',
+    tenantId: canonicalTenantId,
     metadata: { inviteId: invite.id, email: invite.email, role: invite.role }
   });
-  return { invite, token, seatSummary: await getTenantSeatSummary(env, tenantId) };
+
+  return { invite, token, seatSummary: await getTenantSeatSummary(env, canonicalTenantId) };
 }
 
 export async function listTenantInvites(env: Env, tenantId: string, actorUserId: string): Promise<Array<Omit<TenantInvite, 'tokenHash'>>> {
   const db = getDb(env);
   await ensureSchema(db);
-  await assertOwnerAccess(env, tenantId, actorUserId);
+  const canonicalTenantId = await ensureTenantIdMatch(db, tenantId);
+  await assertOwner(env, actorUserId);
+
   const result = await db.prepare(
-    'SELECT external_id as id, tenant_id, email, role, status, created_by_user_id, accepted_by_user_id, accepted_at, revoked_at, expires_at, created_at, updated_at FROM tenant_invites WHERE tenant_id = ? ORDER BY created_at DESC'
-  ).bind(tenantId).all<Record<string, unknown>>();
-  return (result.results ?? []).map((row) => ({
-    id: String(row.id),
-    tenantId: String(row.tenant_id),
-    email: String(row.email),
-    role: row.role === 'owner' ? 'owner' : 'member',
-    status: row.status === 'accepted' || row.status === 'revoked' ? row.status : 'pending',
-    createdByUserId: String(row.created_by_user_id),
-    acceptedByUserId: row.accepted_by_user_id ? String(row.accepted_by_user_id) : undefined,
-    acceptedAt: row.accepted_at ? String(row.accepted_at) : undefined,
-    revokedAt: row.revoked_at ? String(row.revoked_at) : undefined,
-    expiresAt: String(row.expires_at),
-    createdAt: String(row.created_at),
-    updatedAt: String(row.updated_at)
-  }));
+    'SELECT * FROM invites ORDER BY created_at DESC'
+  ).all<Record<string, unknown>>();
+  return (result.results ?? []).map((row) => mapInvite(row, canonicalTenantId));
 }
 
 export async function resolvePendingTenantInviteByToken(
@@ -679,27 +598,13 @@ export async function resolvePendingTenantInviteByToken(
   await ensureSchema(db);
   const tokenHash = await hashSecret(token);
   const row = await db.prepare(
-    "SELECT external_id as id, tenant_id, email, role, status, created_by_user_id, accepted_by_user_id, accepted_at, revoked_at, expires_at, created_at, updated_at FROM tenant_invites WHERE token_hash = ? AND status = 'pending' AND expires_at > ? LIMIT 1"
+    "SELECT * FROM invites WHERE token_hash = ? AND status = 'pending' AND expires_at > ? LIMIT 1"
   ).bind(tokenHash, new Date().toISOString()).first<Record<string, unknown>>();
   if (!row) {
     throw unauthorized('Invalid or expired invite.');
   }
-  return {
-    invite: {
-      id: String(row.id),
-      tenantId: String(row.tenant_id),
-      email: String(row.email),
-      role: row.role === 'owner' ? 'owner' : 'member',
-      status: 'pending',
-      createdByUserId: String(row.created_by_user_id),
-      acceptedByUserId: row.accepted_by_user_id ? String(row.accepted_by_user_id) : undefined,
-      acceptedAt: row.accepted_at ? String(row.accepted_at) : undefined,
-      revokedAt: row.revoked_at ? String(row.revoked_at) : undefined,
-      expiresAt: String(row.expires_at),
-      createdAt: String(row.created_at),
-      updatedAt: String(row.updated_at)
-    }
-  };
+
+  return { invite: mapInvite(row, await getTenantId(db)) };
 }
 
 export async function acceptTenantInvite(env: Env, token: string, actorUserId: string): Promise<{ membership: TenantMember; invite: Omit<TenantInvite, 'tokenHash'> }> {
@@ -707,245 +612,193 @@ export async function acceptTenantInvite(env: Env, token: string, actorUserId: s
   await ensureSchema(db);
   const tokenHash = await hashSecret(token);
   const row = await db.prepare(
-    "SELECT * FROM tenant_invites WHERE token_hash = ? AND status = 'pending' AND expires_at > ? LIMIT 1"
+    "SELECT * FROM invites WHERE token_hash = ? AND status = 'pending' AND expires_at > ? LIMIT 1"
   ).bind(tokenHash, new Date().toISOString()).first<Record<string, unknown>>();
   if (!row) {
     throw unauthorized('Invalid or expired invite.');
   }
-  const invite: TenantInvite = {
-    id: externalId(row),
-    tenantId: String(row.tenant_id),
-    email: String(row.email),
-    role: row.role === 'owner' ? 'owner' : 'member',
-    status: 'pending',
-    createdByUserId: String(row.created_by_user_id),
-    expiresAt: String(row.expires_at),
-    createdAt: String(row.created_at),
-    updatedAt: String(row.updated_at)
-  };
-  const user = await getUserById(env, actorUserId);
-  if (!user || normalizeEmail(user.email) !== invite.email) {
+
+  const tenantId = await getTenantId(db);
+  const invite = mapInvite(row, tenantId);
+  const userRow = await db.prepare('SELECT * FROM users WHERE external_id = ? LIMIT 1').bind(actorUserId).first<Record<string, unknown>>();
+  if (!userRow) {
+    throw unauthorized('Authenticated user not found.');
+  }
+  const user = mapUser(userRow);
+  if (normalizeEmail(user.email) !== invite.email) {
     throw forbidden('Invite email does not match authenticated user.');
   }
-  const existingMembership = await getTenantMembership(env, invite.tenantId, actorUserId);
-  if (existingMembership && existingMembership.seatState === 'active') {
-    throw conflict(`User ${actorUserId} already has an active seat in tenant ${invite.tenantId}.`);
-  }
-  await assertSeatCapacity(env, invite.tenantId);
+
   const now = new Date().toISOString();
+  await db.batch([
+    db.prepare('UPDATE users SET role = ?, updated_at = ? WHERE external_id = ?').bind(invite.role, now, actorUserId),
+    db.prepare("UPDATE invites SET status = 'accepted', accepted_by_user_id = ?, accepted_at = ?, updated_at = ? WHERE external_id = ?")
+      .bind(actorUserId, now, now, invite.id)
+  ]);
+
   const membership: TenantMember = {
-    id: createTenantMemberId(invite.tenantId, actorUserId),
-    tenantId: invite.tenantId,
+    id: `${tenantId}:${actorUserId}`,
+    tenantId,
     userId: actorUserId,
     role: invite.role,
     seatState: 'active',
-    createdAt: existingMembership?.createdAt ?? now,
+    createdAt: user.createdAt,
     updatedAt: now
   };
-  if (existingMembership) {
-    await db.prepare(
-      'UPDATE tenant_memberships SET role = ?, seat_state = ?, updated_at = ? WHERE external_id = ?'
-    ).bind(membership.role, membership.seatState, membership.updatedAt, existingMembership.id).run();
-  } else {
-    await db.prepare(
-      'INSERT INTO tenant_memberships (external_id, tenant_id, user_id, role, seat_state, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)'
-    ).bind(membership.id, membership.tenantId, membership.userId, membership.role, membership.seatState, membership.createdAt, membership.updatedAt).run();
-  }
-  await db.prepare(
-    "UPDATE tenant_invites SET status = 'accepted', accepted_by_user_id = ?, accepted_at = ?, updated_at = ? WHERE external_id = ?"
-  ).bind(actorUserId, now, now, invite.id).run();
+
   await writeAuditLog(db, {
     actorType: 'tenant_user',
     actorId: actorUserId,
-    action: 'tenant.invite.accepted',
-    tenantId: invite.tenantId,
-    metadata: { inviteId: invite.id, membershipId: membership.id }
+    action: 'invite.accepted',
+    tenantId,
+    metadata: { inviteId: invite.id, userId: actorUserId, role: invite.role }
   });
+
   return { membership, invite: { ...invite, status: 'accepted', acceptedByUserId: actorUserId, acceptedAt: now, updatedAt: now } };
 }
 
-function stripUserSecret(user: StoredUser): User {
-  return { id: user.id, email: user.email, displayName: user.displayName, createdAt: user.createdAt, updatedAt: user.updatedAt };
-}
+export async function createUserApiToken(
+  env: Env,
+  actorUserId: string,
+  input: { name: string; scopes?: string[]; expiresAt?: string }
+): Promise<{ tokenRecord: UserApiTokenRecord; token: string }> {
+  const db = getDb(env);
+  await ensureSchema(db);
+  const user = await db.prepare('SELECT external_id FROM users WHERE external_id = ? LIMIT 1').bind(actorUserId).first<{ external_id: string }>();
+  if (!user) {
+    throw unauthorized('User not found.');
+  }
 
-function mapPlatformSession(row: Record<string, unknown>): PlatformSupportSession {
-  return {
-    id: externalId(row),
-    adminId: String(row.admin_id),
-    tenantId: String(row.tenant_id),
-    reason: String(row.reason),
-    createdAt: String(row.created_at),
-    expiresAt: String(row.expires_at),
-    releasedAt: row.released_at ? String(row.released_at) : undefined
+  const name = input.name.trim();
+  if (!name) {
+    throw badRequest('API token name is required.');
+  }
+  const scopes = (input.scopes ?? []).map((scope) => scope.trim()).filter(Boolean);
+
+  const token = createAuthToken();
+  const now = new Date().toISOString();
+  const tokenRecord: UserApiTokenRecord = {
+    id: `pat_${crypto.randomUUID()}`,
+    userId: actorUserId,
+    name,
+    scopes,
+    createdAt: now,
+    updatedAt: now,
+    expiresAt: input.expiresAt?.trim() || undefined,
+    lastUsedAt: undefined,
+    revokedAt: undefined
   };
+
+  await db.prepare(
+    `INSERT INTO user_api_tokens
+     (external_id, user_id, name, scopes_json, token_hash, expires_at, last_used_at, revoked_at, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, NULL, NULL, ?, ?)`
+  ).bind(
+    tokenRecord.id,
+    tokenRecord.userId,
+    tokenRecord.name,
+    JSON.stringify(tokenRecord.scopes),
+    await hashSecret(token),
+    tokenRecord.expiresAt ?? null,
+    tokenRecord.createdAt,
+    tokenRecord.updatedAt
+  ).run();
+
+  return { tokenRecord, token };
 }
 
-function mapPlatformAdmin(row: Record<string, unknown>): PlatformAdmin {
+export async function listUserApiTokens(env: Env, actorUserId: string): Promise<UserApiTokenRecord[]> {
+  const db = getDb(env);
+  await ensureSchema(db);
+  const result = await db.prepare(
+    'SELECT * FROM user_api_tokens WHERE user_id = ? AND revoked_at IS NULL ORDER BY created_at DESC'
+  ).bind(actorUserId).all<Record<string, unknown>>();
+  return (result.results ?? []).map(mapApiToken);
+}
+
+export async function revokeUserApiToken(env: Env, actorUserId: string, tokenId: string): Promise<{ ok: true }> {
+  const db = getDb(env);
+  await ensureSchema(db);
+  const token = await db.prepare('SELECT * FROM user_api_tokens WHERE external_id = ? LIMIT 1').bind(tokenId).first<Record<string, unknown>>();
+  if (!token || String(token.user_id) !== actorUserId) {
+    throw notFound(`API token ${tokenId} not found.`);
+  }
+  await db.prepare('UPDATE user_api_tokens SET revoked_at = ?, updated_at = ? WHERE external_id = ?')
+    .bind(new Date().toISOString(), new Date().toISOString(), tokenId)
+    .run();
+  return { ok: true };
+}
+
+export async function resolveApiToken(env: Env, token: string): Promise<{ user: User; tokenRecord: UserApiTokenRecord }> {
+  const db = getDb(env);
+  await ensureSchema(db);
+
+  const tokenHash = await hashSecret(token);
+  const row = await db.prepare(
+    'SELECT * FROM user_api_tokens WHERE token_hash = ? AND revoked_at IS NULL AND (expires_at IS NULL OR expires_at > ?) LIMIT 1'
+  ).bind(tokenHash, new Date().toISOString()).first<Record<string, unknown>>();
+  if (!row) {
+    throw unauthorized('Invalid or expired API token.');
+  }
+
+  const userRow = await db.prepare('SELECT * FROM users WHERE external_id = ? LIMIT 1').bind(String(row.user_id)).first<Record<string, unknown>>();
+  if (!userRow) {
+    throw unauthorized('API token user no longer exists.');
+  }
+
+  const now = new Date().toISOString();
+  await db.prepare('UPDATE user_api_tokens SET last_used_at = ?, updated_at = ? WHERE external_id = ?')
+    .bind(now, now, externalId(row))
+    .run();
+
   return {
-    id: externalId(row),
-    email: String(row.email),
-    passwordHash: String(row.password_hash),
-    createdAt: String(row.created_at),
-    updatedAt: String(row.updated_at)
+    user: mapUser(userRow),
+    tokenRecord: { ...mapApiToken(row), lastUsedAt: now, updatedAt: now }
   };
 }
 
 export async function platformLogin(env: Env, input: { email: string; password: string }) {
-  const db = getDb(env);
-  await ensureSchema(db);
-  await ensurePlatformAdmin(db, env);
-  const email = normalizeEmail(input.email);
-  const row = await db.prepare('SELECT * FROM platform_admins WHERE email = ? LIMIT 1').bind(email).first<Record<string, unknown>>();
-  if (!row) {
-    throw unauthorized('Invalid platform admin credentials.');
-  }
-  const admin = mapPlatformAdmin(row);
-  if (admin.passwordHash !== await hashSecret(input.password)) {
-    throw unauthorized('Invalid platform admin credentials.');
-  }
-  const token = createAuthToken();
-  const sessionId = `psess_${crypto.randomUUID()}`;
-  await db.prepare(
-    'INSERT INTO platform_support_sessions (external_id, token_hash, admin_id, tenant_id, reason, created_at, expires_at, released_at) VALUES (?, ?, ?, ?, ?, ?, ?, NULL)'
-  ).bind(
-    sessionId,
-    await hashSecret(token),
-    admin.id,
-    '__platform__',
-    'platform-auth',
-    new Date().toISOString(),
-    new Date(Date.now() + PLATFORM_SESSION_TTL_MS).toISOString()
-  ).run();
-  await writeAuditLog(db, { actorType: 'platform_admin', actorId: admin.id, action: 'platform.auth.login' });
-  return { admin: { id: admin.id, email: admin.email }, token };
+  void env;
+  void input;
+  throw forbidden('Platform admin authentication is removed in single-tenant mode.');
 }
 
 export async function resolvePlatformAdminByToken(env: Env, token: string): Promise<{ admin: { id: string; email: string } }> {
-  const db = getDb(env);
-  await ensureSchema(db);
-  await ensurePlatformAdmin(db, env);
-  const tokenHash = await hashSecret(token);
-  const row = await db.prepare(
-    "SELECT p.* FROM platform_support_sessions s INNER JOIN platform_admins p ON p.external_id = s.admin_id WHERE s.token_hash = ? AND s.reason = 'platform-auth' AND s.released_at IS NULL AND s.expires_at > ? LIMIT 1"
-  ).bind(tokenHash, new Date().toISOString()).first<Record<string, unknown>>();
-  if (!row) {
-    throw unauthorized('Invalid or expired platform session.');
-  }
-  return { admin: { id: externalId(row), email: String(row.email) } };
+  void env;
+  void token;
+  throw forbidden('Platform admin authentication is removed in single-tenant mode.');
 }
 
 export async function createPlatformSupportSession(
   env: Env,
   input: { adminId: string; tenantId: string; reason: string; ttlMinutes?: number }
 ): Promise<{ session: PlatformSupportSession; token: string }> {
-  const db = getDb(env);
-  await ensureSchema(db);
-  await getTenant(env, input.tenantId);
-  const ttlMinutes = Math.min(Math.max(input.ttlMinutes ?? 60, 5), 8 * 60);
-  const token = createAuthToken();
-  const session: PlatformSupportSession = {
-    id: `support_${crypto.randomUUID()}`,
-    adminId: input.adminId,
-    tenantId: input.tenantId.trim(),
-    reason: input.reason.trim(),
-    createdAt: new Date().toISOString(),
-    expiresAt: new Date(Date.now() + ttlMinutes * 60 * 1000).toISOString()
-  };
-  await db.prepare(
-    'INSERT INTO platform_support_sessions (external_id, token_hash, admin_id, tenant_id, reason, created_at, expires_at, released_at) VALUES (?, ?, ?, ?, ?, ?, ?, NULL)'
-  ).bind(session.id, await hashSecret(token), session.adminId, session.tenantId, session.reason, session.createdAt, session.expiresAt).run();
-  await writeAuditLog(db, {
-    actorType: 'platform_admin',
-    actorId: input.adminId,
-    action: 'platform.support.assume_tenant',
-    tenantId: session.tenantId,
-    metadata: { reason: session.reason, ttlMinutes }
-  });
-  return { session, token };
+  void env;
+  void input;
+  throw forbidden('Platform support sessions are removed in single-tenant mode.');
 }
 
 export async function resolvePlatformSupportSessionByToken(env: Env, token: string): Promise<{ session: PlatformSupportSession }> {
-  const db = getDb(env);
-  await ensureSchema(db);
-  const tokenHash = await hashSecret(token);
-  const row = await db.prepare(
-    "SELECT * FROM platform_support_sessions WHERE token_hash = ? AND reason <> 'platform-auth' AND released_at IS NULL AND expires_at > ? LIMIT 1"
-  ).bind(tokenHash, new Date().toISOString()).first<Record<string, unknown>>();
-  if (!row) {
-    throw unauthorized('Invalid or expired support session.');
-  }
-  return { session: mapPlatformSession(row) };
+  void env;
+  void token;
+  throw forbidden('Platform support sessions are removed in single-tenant mode.');
 }
 
 export async function releasePlatformSupportSession(env: Env, token: string, adminId: string): Promise<{ ok: true }> {
-  const db = getDb(env);
-  await ensureSchema(db);
-  const tokenHash = await hashSecret(token);
-  const row = await db.prepare(
-    "SELECT * FROM platform_support_sessions WHERE token_hash = ? AND reason <> 'platform-auth' AND released_at IS NULL AND expires_at > ? LIMIT 1"
-  ).bind(tokenHash, new Date().toISOString()).first<Record<string, unknown>>();
-  if (!row) {
-    throw unauthorized('Invalid or expired support session.');
-  }
-  const session = mapPlatformSession(row);
-  if (session.adminId !== adminId) {
-    throw forbidden('Support session belongs to another platform admin.');
-  }
-  const releasedAt = new Date().toISOString();
-  await db.prepare('UPDATE platform_support_sessions SET released_at = ? WHERE external_id = ?').bind(releasedAt, session.id).run();
-  await writeAuditLog(db, {
-    actorType: 'platform_admin',
-    actorId: adminId,
-    action: 'platform.support.release_tenant',
-    tenantId: session.tenantId,
-    metadata: { sessionId: session.id }
-  });
-  return { ok: true };
+  void env;
+  void token;
+  void adminId;
+  throw forbidden('Platform support sessions are removed in single-tenant mode.');
 }
 
 export async function listPlatformSupportSessions(env: Env, adminId: string): Promise<PlatformSupportSession[]> {
-  const db = getDb(env);
-  await ensureSchema(db);
-  const result = await db.prepare(
-    'SELECT * FROM platform_support_sessions WHERE admin_id = ? ORDER BY created_at DESC'
-  ).bind(adminId).all<Record<string, unknown>>();
-  return (result.results ?? []).map(mapPlatformSession);
+  void env;
+  void adminId;
+  return [];
 }
 
 export async function listSecurityAuditLog(env: Env, adminId: string): Promise<SecurityAuditLogEntry[]> {
-  const db = getDb(env);
-  await ensureSchema(db);
-  const admin = await db.prepare('SELECT external_id FROM platform_admins WHERE external_id = ? LIMIT 1').bind(adminId).first<{ external_id: string }>();
-  if (!admin) {
-    throw forbidden('Only platform admins may view security audit log.');
-  }
-  const result = await db.prepare('SELECT * FROM security_audit_log ORDER BY at DESC LIMIT 500').all<Record<string, unknown>>();
-  return (result.results ?? []).map((row) => ({
-    id: externalId(row),
-    at: String(row.at),
-    actorType: row.actor_type === 'platform_admin' ? 'platform_admin' : 'tenant_user',
-    actorId: String(row.actor_id),
-    action: String(row.action),
-    tenantId: row.tenant_id ? String(row.tenant_id) : undefined,
-    metadata: (() => {
-      if (!row.metadata_json || typeof row.metadata_json !== 'string') {
-        return undefined;
-      }
-      try {
-        const parsed = JSON.parse(row.metadata_json);
-        if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
-          return undefined;
-        }
-        const out: Record<string, string | number | boolean> = {};
-        for (const [k, v] of Object.entries(parsed as Record<string, unknown>)) {
-          if (typeof v === 'string' || typeof v === 'number' || typeof v === 'boolean') {
-            out[k] = v;
-          }
-        }
-        return Object.keys(out).length ? out : undefined;
-      } catch {
-        return undefined;
-      }
-    })()
-  }));
+  void env;
+  void adminId;
+  return [];
 }


### PR DESCRIPTION
Task: ST-1 Schema reset + single-tenant auth store

Replace multi-tenant/platform tables with single-tenant auth + invites + PAT storage.


Acceptance criteria:
- New migration defines app_tenant_config/users/user_sessions/invites/user_api_tokens
- tenant-auth-db no longer references tenants/memberships/platform tables
- Unit tests for core auth store behavior added or updated

Run ID: run_repo_abuiles_minions_mmafsrqurmlm