### PR TITLE
T2 - Slack Ingress, Fast Ack, and Conversation Binding

### DIFF
--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -43,7 +43,10 @@ import {
   handleTenantUsageSummary,
   handleUpdateRepo,
   handleUpdateTask,
-  handleUpsertScmCredential
+  handleUpsertScmCredential,
+  handleSlackCommands,
+  handleSlackEvents,
+  handleSlackInteractions
 } from './router';
 import { json } from './http/response';
 
@@ -65,6 +68,15 @@ apiRouter.delete('/api/me/api-tokens/:tokenId', (c: Context) =>
 );
 
 apiRouter.get('/api/board', (c: Context) => handleBoard(c.req.raw, c.env as Env));
+apiRouter.post('/api/integrations/slack/commands', (c: Context) =>
+  handleSlackCommands(c.req.raw, c.env as Env, c.executionCtx as unknown as ExecutionContext<unknown>)
+);
+apiRouter.post('/api/integrations/slack/events', (c: Context) =>
+  handleSlackEvents(c.req.raw, c.env as Env)
+);
+apiRouter.post('/api/integrations/slack/interactions', (c: Context) =>
+  handleSlackInteractions(c.req.raw, c.env as Env)
+);
 apiRouter.get('/api/board/ws', (c: Context) => handleBoardWs(c.req.raw, c.env as Env));
 apiRouter.get('/api/repos', (c: Context) => handleListRepos(c.req.raw, c.env as Env));
 apiRouter.post('/api/repos', (c: Context) => handleCreateRepo(c.req.raw, c.env as Env));

--- a/src/server/integrations/slack/handlers.test.ts
+++ b/src/server/integrations/slack/handlers.test.ts
@@ -1,0 +1,249 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { buildSlackSignature } from './verification';
+import { handleSlackCommands, handleSlackEvents, handleSlackInteractions } from './handlers';
+
+const tenantAuthDbMocks = vi.hoisted(() => ({
+  deleteSlackThreadBinding: vi.fn(),
+  getPrimaryTenantId: vi.fn(),
+  upsertSlackThreadBinding: vi.fn()
+}));
+
+vi.mock('../tenant-auth-db', () => tenantAuthDbMocks);
+
+function createKv(secret: string) {
+  const values = new Map<string, string>([['slack/signing-secret', secret]]);
+  return {
+    async get(key: string) {
+      return values.get(key) ?? null;
+    },
+    async put(key: string, value: string) {
+      values.set(key, value);
+    }
+  };
+}
+
+function slackHeaders(timestamp: string, signature: string, teamId = 'T1') {
+  return {
+    'x-slack-request-timestamp': timestamp,
+    'x-slack-signature': signature,
+    'x-slack-team-id': teamId
+  };
+}
+
+function makeEnv(secret = 'secret') {
+  return {
+    SECRETS_KV: createKv(secret)
+  };
+}
+
+function taskBinding(taskId: string, channelId: string, threadTs: string) {
+  return {
+    id: `binding_${taskId}`,
+    tenantId: 'tenant_local',
+    taskId,
+    channelId,
+    threadTs,
+    latestReviewRound: 0,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z'
+  };
+}
+
+describe('slack handlers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    tenantAuthDbMocks.getPrimaryTenantId.mockResolvedValue('tenant_local');
+    tenantAuthDbMocks.upsertSlackThreadBinding.mockImplementation(async (input: {
+      taskId: string;
+      channelId: string;
+      threadTs: string;
+    }) => taskBinding(input.taskId, input.channelId, input.threadTs));
+    tenantAuthDbMocks.deleteSlackThreadBinding.mockResolvedValue({ ok: true });
+  });
+
+  it('acknowledges slash commands quickly and processes async via waitUntil', async () => {
+    const rawBody = new URLSearchParams({
+      command: '/kanvy',
+      text: 'fix ABC-100',
+      channel_id: 'C123',
+      thread_ts: '1672531200.1234',
+      team_id: 'team_one',
+      user_id: 'U1'
+    }).toString();
+    const timestamp = Math.floor(Date.now() / 1000).toString();
+    const signature = await buildSlackSignature('secret', timestamp, rawBody);
+    const request = new Request('https://example.test/api/integrations/slack/commands', {
+      method: 'POST',
+      headers: slackHeaders(timestamp, signature),
+      body: rawBody
+    });
+    const waitUntilTasks: Array<Promise<unknown>> = [];
+    const waitUntil = vi.fn((task: Promise<unknown>) => {
+      waitUntilTasks.push(task);
+    });
+    const response = await handleSlackCommands(request, makeEnv('secret') as Env, { waitUntil } as ExecutionContext<unknown>);
+    const body = await response.json() as { ok: boolean; text: string };
+
+    expect(response.status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(waitUntil).toHaveBeenCalledTimes(1);
+    expect(waitUntilTasks).toHaveLength(1);
+    await waitUntilTasks[0];
+    expect(tenantAuthDbMocks.upsertSlackThreadBinding).toHaveBeenCalledWith({
+      tenantId: 'tenant_local',
+      taskId: 'issue:ABC-100',
+      channelId: 'C123',
+      threadTs: '1672531200.1234',
+      latestReviewRound: 0
+    });
+  });
+
+  it('handles repo disambiguation and approve_rerun/pause actions in interactions', async () => {
+    const repoDisambiguationPayload = {
+      type: 'block_actions',
+      user: { id: 'U1' },
+      container: { channel_id: 'C123', thread_ts: '1672531200.1234' },
+      actions: [
+        {
+          action_id: 'repo_disambiguation',
+          value: JSON.stringify({
+            tenantId: 'tenant_local',
+            taskId: 'task_1',
+            channelId: 'C123',
+            threadTs: '1672531200.1234',
+            latestReviewRound: 1,
+            repoId: 'repo_alpha'
+          })
+        }
+      ]
+    };
+    const approvePayload = {
+      ...repoDisambiguationPayload,
+      actions: [
+        {
+          action_id: 'approve_rerun',
+          value: JSON.stringify({
+            taskId: 'task_1',
+            channelId: 'C123',
+            threadTs: '1672531200.1234',
+            currentRunId: 'run_1',
+            latestReviewRound: 2
+          })
+        }
+      ]
+    };
+    const pausePayload = {
+      ...repoDisambiguationPayload,
+      actions: [
+        {
+          action_id: 'pause',
+          value: JSON.stringify({
+            taskId: 'task_1',
+            channelId: 'C123',
+            threadTs: '1672531200.1234',
+            latestReviewRound: 3
+          })
+        }
+      ]
+    };
+
+    const repoBody = new URLSearchParams({ payload: JSON.stringify(repoDisambiguationPayload) }).toString();
+    const timestamp = Math.floor(Date.now() / 1000).toString();
+    const repoSig = await buildSlackSignature('secret', timestamp, repoBody);
+
+    const repoRequest = new Request('https://example.test/api/integrations/slack/interactions', {
+      method: 'POST',
+      headers: slackHeaders(timestamp, repoSig),
+      body: repoBody
+    });
+    const repoResponse = await handleSlackInteractions(repoRequest, makeEnv('secret') as Env);
+    expect(await repoResponse.json()).toMatchObject({ ok: true, action: 'repo_disambiguation' });
+    expect(tenantAuthDbMocks.upsertSlackThreadBinding).toHaveBeenCalledWith({
+      tenantId: 'tenant_local',
+      taskId: 'task_1',
+      channelId: 'C123',
+      threadTs: '1672531200.1234',
+      latestReviewRound: 1
+    });
+
+    const approveBody = new URLSearchParams({ payload: JSON.stringify(approvePayload) }).toString();
+    const approveSig = await buildSlackSignature('secret', timestamp, approveBody);
+    const approveRequest = new Request('https://example.test/api/integrations/slack/interactions', {
+      method: 'POST',
+      headers: slackHeaders(timestamp, approveSig),
+      body: approveBody
+    });
+    const approveResponse = await handleSlackInteractions(approveRequest, makeEnv('secret') as Env);
+    expect(await approveResponse.json()).toMatchObject({ ok: true, action: 'approve_rerun' });
+    expect(tenantAuthDbMocks.upsertSlackThreadBinding).toHaveBeenCalledWith({
+      tenantId: 'tenant_local',
+      taskId: 'task_1',
+      channelId: 'C123',
+      threadTs: '1672531200.1234',
+      currentRunId: 'run_1',
+      latestReviewRound: 3
+    });
+
+    const pauseBody = new URLSearchParams({ payload: JSON.stringify(pausePayload) }).toString();
+    const pauseSig = await buildSlackSignature('secret', timestamp, pauseBody);
+    const pauseRequest = new Request('https://example.test/api/integrations/slack/interactions', {
+      method: 'POST',
+      headers: slackHeaders(timestamp, pauseSig),
+      body: pauseBody
+    });
+    const pauseResponse = await handleSlackInteractions(pauseRequest, makeEnv('secret') as Env);
+    expect(await pauseResponse.json()).toMatchObject({ ok: true, action: 'pause' });
+    expect(tenantAuthDbMocks.upsertSlackThreadBinding).toHaveBeenCalledWith({
+      tenantId: 'tenant_local',
+      taskId: 'task_1',
+      channelId: 'C123',
+      threadTs: '1672531200.1234',
+      latestReviewRound: 3
+    });
+  });
+
+  it('supports close interaction by deleting the thread binding', async () => {
+    const payload = {
+      type: 'block_actions',
+      container: { channel_id: 'C123', thread_ts: '1672531200.1234' },
+      actions: [
+        {
+          action_id: 'close',
+          value: JSON.stringify({
+            taskId: 'task_1',
+            channelId: 'C123',
+            threadTs: '1672531200.1234'
+          })
+        }
+      ]
+    };
+
+    const rawBody = new URLSearchParams({ payload: JSON.stringify(payload) }).toString();
+    const timestamp = Math.floor(Date.now() / 1000).toString();
+    const signature = await buildSlackSignature('secret', timestamp, rawBody);
+    const request = new Request('https://example.test/api/integrations/slack/interactions', {
+      method: 'POST',
+      headers: slackHeaders(timestamp, signature),
+      body: rawBody
+    });
+
+    const response = await handleSlackInteractions(request, makeEnv('secret') as Env);
+    expect(await response.json()).toMatchObject({ ok: true, action: 'close' });
+    expect(tenantAuthDbMocks.deleteSlackThreadBinding).toHaveBeenCalledWith('tenant_local', 'task_1', 'C123');
+  });
+
+  it('acknowledges event verification challenge', async () => {
+    const event = { type: 'url_verification', challenge: 'challenge-123' };
+    const rawBody = JSON.stringify(event);
+    const timestamp = Math.floor(Date.now() / 1000).toString();
+    const signature = await buildSlackSignature('secret', timestamp, rawBody);
+    const request = new Request('https://example.test/api/integrations/slack/events', {
+      method: 'POST',
+      headers: slackHeaders(timestamp, signature),
+      body: rawBody
+    });
+    const response = await handleSlackEvents(request, makeEnv('secret') as Env);
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ challenge: 'challenge-123' });
+  });
+});

--- a/src/server/integrations/slack/handlers.ts
+++ b/src/server/integrations/slack/handlers.ts
@@ -1,0 +1,144 @@
+import { badRequest } from '../../http/errors';
+import { handleError, json } from '../../http/response';
+import * as tenantAuthDb from '../tenant-auth-db';
+import {
+  parseSlackEventBody,
+  parseSlackInteractionBody,
+  parseSlackSlashCommandBody,
+  type ParsedSlackInteraction
+} from './payload';
+import { resolveThreadTenant, verifySlackRequest } from './verification';
+
+const DEFAULT_TASK_ID_PREFIX = 'issue';
+const DEFAULT_REVIEW_ROUND = 0;
+
+function buildTaskIdFromIssue(issueKey: string) {
+  return `${DEFAULT_TASK_ID_PREFIX}:${issueKey}`;
+}
+
+function normalizeLatestReviewRound(value: number | undefined) {
+  return Number.isFinite(value) ? Number(value) : DEFAULT_REVIEW_ROUND;
+}
+
+async function createThreadBindingForSlashCommand(
+  env: Env,
+  tenantId: string,
+  commandIssueKey: string,
+  channelId: string,
+  threadTs: string
+) {
+  const taskId = buildTaskIdFromIssue(commandIssueKey);
+  return tenantAuthDb.upsertSlackThreadBinding(env, {
+    tenantId,
+    taskId,
+    channelId,
+    threadTs,
+    latestReviewRound: DEFAULT_REVIEW_ROUND
+  });
+}
+
+async function resolveThreadTenantId(env: Env, teamId: string | undefined) {
+  const fallbackTenantId = await tenantAuthDb.getPrimaryTenantId(env);
+  return resolveThreadTenant(fallbackTenantId, teamId);
+}
+
+async function updateBindingForAction(
+  env: Env,
+  tenantId: string,
+  interaction: ParsedSlackInteraction
+) {
+  if (!interaction.taskId) {
+    throw badRequest('Missing task identifier.');
+  }
+  const currentRunId = interaction.currentRunId?.trim();
+  const latestReviewRound = normalizeLatestReviewRound(interaction.latestReviewRound);
+
+  if (interaction.actionId === 'close') {
+    return tenantAuthDb.deleteSlackThreadBinding(env, tenantId, interaction.taskId, interaction.channelId);
+  }
+
+  if (interaction.actionId === 'approve_rerun') {
+    return tenantAuthDb.upsertSlackThreadBinding(env, {
+      tenantId,
+      taskId: interaction.taskId,
+      channelId: interaction.channelId,
+      threadTs: interaction.threadTs,
+      currentRunId,
+      latestReviewRound: latestReviewRound + 1
+    });
+  }
+
+  return tenantAuthDb.upsertSlackThreadBinding(env, {
+    tenantId,
+    taskId: interaction.taskId,
+    channelId: interaction.channelId,
+    threadTs: interaction.threadTs,
+    currentRunId,
+    latestReviewRound
+  });
+}
+
+async function runSlackCommandAsync(env: Env, payload: ReturnType<typeof parseSlackSlashCommandBody>) {
+  const tenantId = await resolveThreadTenantId(env, payload.teamId);
+  if (!payload.threadTs) {
+    return;
+  }
+  await createThreadBindingForSlashCommand(env, tenantId, payload.issueKey, payload.channelId, payload.threadTs);
+}
+
+export async function handleSlackCommands(
+  request: Request,
+  env: Env,
+  ctx: ExecutionContext<unknown>
+): Promise<Response> {
+  try {
+    const rawBody = await request.text();
+    await verifySlackRequest(env, request, rawBody);
+    const payload = parseSlackSlashCommandBody(rawBody);
+    const job = runSlackCommandAsync(env, payload);
+    if (ctx?.waitUntil) {
+      // Keep ack path fast and defer persistence to platform context.
+      ctx.waitUntil(job);
+    } else {
+      await job;
+    }
+    return json({
+      ok: true,
+      text: `Accepted /kanvy command for ${payload.issueKey}.`
+    });
+  } catch (error) {
+    return handleError(error);
+  }
+}
+
+export async function handleSlackEvents(request: Request, env: Env): Promise<Response> {
+  try {
+    const rawBody = await request.text();
+    await verifySlackRequest(env, request, rawBody);
+    const payload = parseSlackEventBody(rawBody);
+    if (payload.type === 'url_verification' && payload.challenge) {
+      return json({ challenge: payload.challenge });
+    }
+    return json({ ok: true, status: 'accepted' });
+  } catch (error) {
+    return handleError(error);
+  }
+}
+
+export async function handleSlackInteractions(request: Request, env: Env): Promise<Response> {
+  try {
+    const rawBody = await request.text();
+    await verifySlackRequest(env, request, rawBody);
+    const interaction = parseSlackInteractionBody(rawBody);
+    const tenantId = await resolveThreadTenantId(env, interaction.tenantId || interaction.teamId);
+    await updateBindingForAction(env, tenantId, interaction);
+    return json({
+      ok: true,
+      action: interaction.actionId,
+      taskId: interaction.taskId,
+      ...(interaction.repoId ? { repoId: interaction.repoId } : {})
+    });
+  } catch (error) {
+    return handleError(error);
+  }
+}

--- a/src/server/integrations/slack/payload.ts
+++ b/src/server/integrations/slack/payload.ts
@@ -1,0 +1,205 @@
+import { badRequest } from '../http/errors';
+
+export type SlackSlashCommandPayload = {
+  command: string;
+  text: string;
+  issueKey: string;
+  teamId: string | undefined;
+  channelId: string;
+  threadTs: string | undefined;
+  userId: string;
+  responseUrl: string | undefined;
+};
+
+export type SlackInteractionAction = 'repo_disambiguation' | 'approve_rerun' | 'pause' | 'close';
+
+export type SlackInteractionValue = {
+  tenantId?: string;
+  taskId?: string;
+  channelId?: string;
+  threadTs?: string;
+  currentRunId?: string;
+  latestReviewRound?: number;
+  repoId?: string;
+};
+
+export type ParsedSlackInteraction = {
+  actionId: SlackInteractionAction;
+  teamId: string | undefined;
+  tenantId: string | undefined;
+  taskId: string;
+  channelId: string;
+  threadTs: string;
+  currentRunId?: string;
+  latestReviewRound?: number;
+  repoId?: string;
+};
+
+type SlackEventPayload = {
+  type: string;
+  challenge?: string;
+  teamId?: string;
+};
+
+const ISSUE_KEY_PATTERN = /^[A-Z][A-Z0-9_]*-\d+$/i;
+const FIX_COMMAND_PATTERN = /^fix\s+([A-Z][A-Z0-9_]*-\d+)\s*$/i;
+const SUPPORTED_SLACK_COMMAND = '/kanvy';
+const SUPPORTED_ACTION_IDS: Set<string> = new Set([
+  'repo_disambiguation',
+  'approve_rerun',
+  'pause',
+  'close'
+]);
+
+function readFormValue(params: URLSearchParams, key: string, required: true): string;
+function readFormValue(params: URLSearchParams, key: string, required: false): string | undefined;
+function readFormValue(params: URLSearchParams, key: string, required: boolean): string | undefined {
+  const value = params.get(key)?.trim();
+  if (required && !value) {
+    throw badRequest(`Missing Slack payload field ${key}.`);
+  }
+  return value;
+}
+
+function parseInteractionValue(raw: string | undefined): SlackInteractionValue {
+  if (!raw) {
+    return {};
+  }
+  try {
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === 'object') {
+      return parsed as SlackInteractionValue;
+    }
+  } catch {
+    throw badRequest('Invalid Slack interaction action value.');
+  }
+  throw badRequest('Invalid Slack interaction action value.');
+}
+
+function readOptionalNumber(value: unknown, field: string): number | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value === 'string') {
+    const parsed = Number.parseInt(value, 10);
+    if (!Number.isFinite(parsed) || parsed < 0) {
+      throw badRequest(`Invalid Slack interaction value ${field}.`);
+    }
+    return parsed;
+  }
+  if (typeof value === 'number' && Number.isFinite(value) && value >= 0) {
+    return Math.trunc(value);
+  }
+  throw badRequest(`Invalid Slack interaction value ${field}.`);
+}
+
+export function parseSlackSlashCommandBody(rawBody: string): SlackSlashCommandPayload {
+  const params = new URLSearchParams(rawBody);
+  const command = readFormValue(params, 'command', true);
+  if (!command || command.toLowerCase() !== SUPPORTED_SLACK_COMMAND) {
+    throw badRequest('Unknown Slack slash command.');
+  }
+  const text = readFormValue(params, 'text', false) ?? '';
+  const match = FIX_COMMAND_PATTERN.exec(text);
+  if (!match || !match[1]) {
+    throw badRequest('Invalid slash command format. Expected: /kanvy fix <JIRA_KEY>.');
+  }
+  const issueKey = match[1].toUpperCase();
+  if (!ISSUE_KEY_PATTERN.test(issueKey)) {
+    throw badRequest('Invalid issue key.');
+  }
+
+  return {
+    command,
+    text,
+    issueKey,
+    teamId: readFormValue(params, 'team_id', false),
+    channelId: readFormValue(params, 'channel_id', true),
+    threadTs: readFormValue(params, 'thread_ts', false),
+    userId: readFormValue(params, 'user_id', false) ?? 'unknown',
+    responseUrl: readFormValue(params, 'response_url', false)
+  };
+}
+
+export function parseSlackInteractionBody(rawBody: string): ParsedSlackInteraction {
+  const params = new URLSearchParams(rawBody);
+  const payloadRaw = params.get('payload');
+  if (!payloadRaw) {
+    throw badRequest('Invalid Slack interaction payload.');
+  }
+  let payload: Record<string, unknown>;
+  try {
+    payload = JSON.parse(payloadRaw);
+  } catch {
+    throw badRequest('Invalid Slack interaction payload.');
+  }
+  if (payload.type !== 'block_actions') {
+    throw badRequest('Unsupported Slack interaction type.');
+  }
+  const actions = payload.actions;
+  if (!Array.isArray(actions) || actions.length === 0) {
+    throw badRequest('Slack interaction payload is missing actions.');
+  }
+  const firstAction = actions[0];
+  if (!firstAction || typeof firstAction !== 'object') {
+    throw badRequest('Slack interaction action payload is malformed.');
+  }
+  const actionIdRaw = (firstAction as Record<string, unknown>).action_id;
+  if (typeof actionIdRaw !== 'string' || !SUPPORTED_ACTION_IDS.has(actionIdRaw)) {
+    throw badRequest('Unsupported Slack interaction action.');
+  }
+  const actionId = actionIdRaw as SlackInteractionAction;
+
+  const value = parseInteractionValue((firstAction as Record<string, unknown>).value as string | undefined);
+  const container = payload.container as Record<string, unknown> | undefined;
+  const team = payload.team as Record<string, unknown> | undefined;
+  const tenantId = (value.tenantId ?? undefined) as string | undefined;
+
+  return {
+    actionId,
+    teamId: typeof team?.id === 'string' && team.id.trim() ? team.id.trim() : undefined,
+    tenantId,
+    taskId: typeof value.taskId === 'string' && value.taskId.trim()
+      ? value.taskId.trim()
+      : typeof payload.callback_id === 'string' && payload.callback_id.trim()
+        ? payload.callback_id.trim()
+        : undefined!,
+    channelId: typeof value.channelId === 'string' && value.channelId.trim()
+      ? value.channelId.trim()
+      : typeof (container?.channel_id) === 'string' && container?.channel_id.trim()
+        ? String(container.channel_id).trim()
+        : (() => { throw badRequest('Missing Slack interaction channel id.'); })(),
+    threadTs: typeof value.threadTs === 'string' && value.threadTs.trim()
+      ? value.threadTs.trim()
+      : typeof (container?.thread_ts) === 'string' && container?.thread_ts.trim()
+        ? String(container.thread_ts).trim()
+        : (() => { throw badRequest('Missing Slack interaction thread.'); })(),
+    currentRunId: typeof value.currentRunId === 'string' && value.currentRunId.trim() ? value.currentRunId.trim() : undefined,
+    latestReviewRound: readOptionalNumber(value.latestReviewRound, 'latestReviewRound'),
+    repoId: typeof value.repoId === 'string' && value.repoId.trim() ? value.repoId.trim() : undefined
+  };
+}
+
+export function parseSlackEventBody(rawBody: string): SlackEventPayload {
+  let payload: Record<string, unknown>;
+  try {
+    payload = JSON.parse(rawBody);
+  } catch {
+    throw badRequest('Invalid Slack event payload.');
+  }
+  if (!payload || typeof payload.type !== 'string') {
+    throw badRequest('Invalid Slack event payload.');
+  }
+  return {
+    type: payload.type,
+    challenge: typeof payload.challenge === 'string' ? payload.challenge : undefined,
+    teamId: (() => {
+      const event = payload as Record<string, unknown>;
+      if (typeof event.team_id === 'string' && event.team_id.trim()) {
+        return event.team_id.trim();
+      }
+      const team = event.team as Record<string, unknown> | undefined;
+      return typeof team?.id === 'string' && team.id.trim() ? team.id.trim() : undefined;
+    })()
+  };
+}

--- a/src/server/integrations/slack/verification.test.ts
+++ b/src/server/integrations/slack/verification.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { buildSlackSignature, verifySlackRequest } from './verification';
+
+type KvPutOptions = {
+  expirationTtl?: number;
+};
+
+function createKv(values: Map<string, string> = new Map()) {
+  return {
+    async get(key: string) {
+      return values.get(key) ?? null;
+    },
+    async put(key: string, value: string, _options?: KvPutOptions) {
+      values.set(key, value);
+    },
+    values
+  };
+}
+
+describe('slack verification', () => {
+  let kv: ReturnType<typeof createKv>;
+
+  beforeEach(() => {
+    kv = createKv();
+  });
+
+  it('accepts valid signatures and returns tenant context', async () => {
+    kv.values.set('slack/signing-secret', 'shared-secret');
+    const rawBody = 'token=abc&text=fix+ABC-42';
+    const timestamp = Math.floor(Date.now() / 1000).toString();
+    const signature = await buildSlackSignature('shared-secret', timestamp, rawBody);
+
+    const request = new Request('https://example.test/api/integrations/slack/commands', {
+      method: 'POST',
+      headers: {
+        'x-slack-request-timestamp': timestamp,
+        'x-slack-signature': signature,
+        'x-slack-team-id': 'team_one'
+      },
+      body: rawBody
+    });
+    const result = await verifySlackRequest({ SECRETS_KV: kv as unknown as KVNamespace }, request, rawBody);
+    expect(result.teamId).toBe('team_one');
+    expect(result.timestamp).toBe(timestamp);
+    expect(kv.values.size).toBeGreaterThan(1);
+  });
+
+  it('rejects invalid signatures', async () => {
+    kv.values.set('slack/signing-secret', 'shared-secret');
+    const rawBody = 'text=fix+ABC-42';
+    const timestamp = Math.floor(Date.now() / 1000).toString();
+    const request = new Request('https://example.test/api/integrations/slack/commands', {
+      method: 'POST',
+      headers: {
+        'x-slack-request-timestamp': timestamp,
+        'x-slack-signature': 'v0=bad',
+        'x-slack-team-id': 'team_one'
+      },
+      body: rawBody
+    });
+
+    await expect(
+      verifySlackRequest({ SECRETS_KV: kv as unknown as KVNamespace }, request, rawBody)
+    ).rejects.toMatchObject({ status: 401 });
+  });
+
+  it('rejects replayed requests using the same signature and timestamp', async () => {
+    kv.values.set('slack/signing-secret', 'shared-secret');
+    const rawBody = 'text=fix+ABC-42';
+    const timestamp = Math.floor(Date.now() / 1000).toString();
+    const signature = await buildSlackSignature('shared-secret', timestamp, rawBody);
+
+    const requestA = new Request('https://example.test/api/integrations/slack/events', {
+      method: 'POST',
+      headers: {
+        'x-slack-request-timestamp': timestamp,
+        'x-slack-signature': signature,
+        'x-slack-team-id': 'team_one'
+      },
+      body: rawBody
+    });
+    const requestB = new Request('https://example.test/api/integrations/slack/events', {
+      method: 'POST',
+      headers: {
+        'x-slack-request-timestamp': timestamp,
+        'x-slack-signature': signature,
+        'x-slack-team-id': 'team_one'
+      },
+      body: rawBody
+    });
+
+    await expect(verifySlackRequest({ SECRETS_KV: kv as unknown as KVNamespace }, requestA, rawBody)).resolves.toBeDefined();
+    await expect(
+      verifySlackRequest({ SECRETS_KV: kv as unknown as KVNamespace }, requestB, rawBody)
+    ).rejects.toMatchObject({ status: 401 });
+  });
+});

--- a/src/server/integrations/slack/verification.ts
+++ b/src/server/integrations/slack/verification.ts
@@ -1,0 +1,128 @@
+import { badRequest, unauthorized } from '../http/errors';
+
+const DEFAULT_SIGNING_SECRET_KEY = 'slack/signing-secret';
+const TEAM_SIGNING_SECRET_PREFIX = 'slack/signing-secret';
+const REPLAY_WINDOW_SECONDS = 5 * 60;
+const REPLAY_CACHE_TTL_SECONDS = 10 * 60;
+
+type ParsedSlackRequest = {
+  teamId: string | undefined;
+  timestamp: string;
+  signature: string;
+};
+
+function toHex(bytes: Uint8Array) {
+  return [...bytes].map((byte) => byte.toString(16).padStart(2, '0')).join('');
+}
+
+function timingSafeEqual(left: string, right: string): boolean {
+  if (left.length !== right.length) {
+    return false;
+  }
+  let diff = 0;
+  for (let index = 0; index < left.length; index += 1) {
+    diff |= left.charCodeAt(index) ^ right.charCodeAt(index);
+  }
+  return diff === 0;
+}
+
+function readSlackHeaders(request: Request): ParsedSlackRequest {
+  const teamId = request.headers.get('x-slack-team-id')?.trim();
+  const timestamp = request.headers.get('x-slack-request-timestamp')?.trim();
+  if (!timestamp) {
+    throw unauthorized('Missing Slack request timestamp.');
+  }
+  if (!/^(?:\d+)$/.test(timestamp)) {
+    throw unauthorized('Invalid Slack request timestamp.');
+  }
+
+  const signature = request.headers.get('x-slack-signature')?.trim();
+  if (!signature || !signature.startsWith('v0=')) {
+    throw unauthorized('Invalid Slack signature.');
+  }
+
+  return { teamId, timestamp, signature };
+}
+
+export async function buildSlackSignature(secret: string, timestamp: string, rawBody: string) {
+  const message = `v0:${timestamp}:${rawBody}`;
+  const key = await crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign']
+  );
+  const digest = await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(message));
+  return `v0=${toHex(new Uint8Array(digest))}`;
+}
+
+function sha256Hex(value: string) {
+  return crypto.subtle.digest('SHA-256', new TextEncoder().encode(value)).then((digest) => toHex(new Uint8Array(digest)));
+}
+
+async function resolveSigningSecret(env: Env, teamId: string | undefined) {
+  if (teamId) {
+    const tenantSecret = await env.SECRETS_KV.get(`${TEAM_SIGNING_SECRET_PREFIX}:${teamId}`);
+    if (tenantSecret && tenantSecret.trim()) {
+      return tenantSecret.trim();
+    }
+  }
+
+  const defaultSecret = await env.SECRETS_KV.get(DEFAULT_SIGNING_SECRET_KEY);
+  return defaultSecret?.trim() || undefined;
+}
+
+function validateTimestamp(timestamp: string) {
+  const parsed = Number(timestamp);
+  const nowMs = Date.now();
+  if (!Number.isFinite(parsed)) {
+    throw unauthorized('Invalid Slack request timestamp.');
+  }
+  const ageSeconds = Math.abs(nowMs / 1000 - parsed);
+  if (ageSeconds > REPLAY_WINDOW_SECONDS) {
+    throw unauthorized('Slack request timestamp is outside replay window.');
+  }
+}
+
+function buildReplayKey(teamId: string | undefined, timestamp: string, signature: string) {
+  const scope = teamId ? `team:${teamId}` : 'team:default';
+  const payload = `${scope}:${timestamp}:${signature}`;
+  return sha256Hex(payload).then((digest) => `slack:replay:${digest}`);
+}
+
+export async function verifySlackRequest(
+  env: Env,
+  request: Request,
+  rawBody: string
+): Promise<{ teamId: string | undefined; timestamp: string }> {
+  const headers = readSlackHeaders(request);
+  validateTimestamp(headers.timestamp);
+
+  const signingSecret = await resolveSigningSecret(env, headers.teamId);
+  if (!signingSecret) {
+    throw unauthorized('Missing Slack signing secret.');
+  }
+
+  const expectedSignature = await buildSlackSignature(signingSecret, headers.timestamp, rawBody);
+  if (!timingSafeEqual(expectedSignature, headers.signature)) {
+    throw unauthorized('Invalid Slack signature.');
+  }
+
+  const replayKey = await buildReplayKey(headers.teamId, headers.timestamp, headers.signature);
+  const alreadySeen = await env.SECRETS_KV.get(replayKey);
+  if (alreadySeen) {
+    throw unauthorized('Replay Slack request detected.');
+  }
+
+  await env.SECRETS_KV.put(replayKey, '1', { expirationTtl: REPLAY_CACHE_TTL_SECONDS });
+
+  return { teamId: headers.teamId, timestamp: headers.timestamp };
+}
+
+export function resolveThreadTenant(fallbackTenantId: string | undefined, teamId: string | undefined) {
+  if (!teamId && !fallbackTenantId) {
+    throw badRequest('Missing Slack tenant identifier.');
+  }
+  return teamId || fallbackTenantId!;
+}

--- a/src/server/router.ts
+++ b/src/server/router.ts
@@ -31,6 +31,11 @@ import { scheduleRunJob } from './run-orchestrator';
 import { getRunUsage, getTenantRunUsage, getTenantUsageSummary } from './usage-reporting';
 import { normalizeTenantId, normalizeTenantIdStrict } from '../shared/tenant';
 import * as tenantAuthDb from './tenant-auth-db';
+import {
+  handleSlackCommands as handleSlackCommandsHandler,
+  handleSlackEvents as handleSlackEventsHandler,
+  handleSlackInteractions as handleSlackInteractionsHandler
+} from './integrations/slack/handlers';
 
 const BOARD_OBJECT_NAME = 'agentboard';
 
@@ -62,6 +67,18 @@ async function resolveTenantContextFromRequest(env: Env, request: Request, optio
 
 function parsePathParam(value: string | undefined) {
   return decodeURIComponent(value ?? '');
+}
+
+export async function handleSlackCommands(request: Request, env: Env, ctx: ExecutionContext<unknown>): Promise<Response> {
+  return handleSlackCommandsHandler(request, env, ctx);
+}
+
+export async function handleSlackEvents(request: Request, env: Env): Promise<Response> {
+  return handleSlackEventsHandler(request, env);
+}
+
+export async function handleSlackInteractions(request: Request, env: Env): Promise<Response> {
+  return handleSlackInteractionsHandler(request, env);
 }
 
 export async function handleAuthSignup(request: Request, env: Env): Promise<Response> {

--- a/src/server/tenant-auth-db.ts
+++ b/src/server/tenant-auth-db.ts
@@ -1043,6 +1043,12 @@ export async function getTenant(env: Env, tenantId: string): Promise<Tenant> {
   return mapTenant(canonical, await getTenantConfigRow(db));
 }
 
+export async function getPrimaryTenantId(env: Env): Promise<string> {
+  const db = getDb(env);
+  await ensureSchema(db);
+  return getTenantId(db);
+}
+
 export async function getTenantMembership(env: Env, tenantId: string, userId: string): Promise<TenantMember | undefined> {
   const db = getDb(env);
   await ensureSchema(db);


### PR DESCRIPTION
Task: T2 - Slack Ingress, Fast Ack, and Conversation Binding

Add Slack command/events/interactions endpoints with signature validation, quick ack, and task-centric thread binding.
Source ref: main

Acceptance criteria:
- Valid slash command requests are acknowledged quickly and processed asynchronously.
- Invalid Slack signatures are rejected.
- Thread binding is task-centric and persists currentRunId/latestReviewRound.
- Interactions endpoint supports repo choice, approve rerun, pause, and close actions.

Run ID: run_repo_abuiles_agents_kanban_mmbdjum2bwn5