### PR TITLE
AR1 - Auto-Review Config, Types, and Validation

### DIFF
--- a/src/server/durable/board-index.ts
+++ b/src/server/durable/board-index.ts
@@ -756,9 +756,18 @@ export class BoardIndexDO extends DurableObject<Env> {
   async updateRepo(repoId: string, patch: UpdateRepoInput) {
     await this.ready;
     const existing = await this.getRepo(repoId);
+    const hasAutoReviewPatch = Object.prototype.hasOwnProperty.call(patch, 'autoReview');
+    const mergedAutoReview = hasAutoReviewPatch
+      ? {
+          ...(existing.autoReview ?? { enabled: false, provider: 'gitlab', postInline: false }),
+          ...patch.autoReview
+        }
+      : existing.autoReview;
+
     const updated = buildRepoRecord({
       ...existing,
       ...patch,
+      autoReview: mergedAutoReview,
       slug: patch.slug ?? patch.projectPath ?? existing.slug,
       projectPath: patch.projectPath ?? patch.slug ?? existing.projectPath,
       repoId: existing.repoId,
@@ -1163,12 +1172,20 @@ export class BoardIndexDO extends DurableObject<Env> {
 }
 
 function buildRepoRecord(input: CreateRepoInput | Repo): Repo {
+  const normalizedAutoReview = {
+    enabled: input.autoReview?.enabled ?? false,
+    provider: input.autoReview?.provider ?? 'gitlab',
+    postInline: input.autoReview?.postInline ?? false,
+    ...(input.autoReview?.prompt ? { prompt: input.autoReview.prompt.trim() } : {})
+  };
+
   const normalized = normalizeRepo({
     ...input,
     repoId: 'repoId' in input ? input.repoId : '',
     defaultBranch: input.defaultBranch ?? 'main',
     baselineUrl: input.baselineUrl,
     enabled: input.enabled ?? true,
+    autoReview: normalizedAutoReview,
     llmAdapter: input.llmAdapter,
     llmProfileId: input.llmProfileId,
     githubAuthMode: 'githubAuthMode' in input ? input.githubAuthMode : undefined,

--- a/src/server/durable/repo-board.ts
+++ b/src/server/durable/repo-board.ts
@@ -134,6 +134,8 @@ export class RepoBoardDO extends DurableObject<Env> {
       updatedAt: now,
       uiMeta: normalizeTaskUiMeta({
         simulationProfile: input.simulationProfile ?? 'happy_path',
+        autoReviewMode: input.autoReviewMode,
+        autoReviewPrompt: input.autoReviewPrompt,
         llmAdapter: input.llmAdapter,
         llmModel: input.llmModel,
         llmReasoningEffort: input.llmReasoningEffort,
@@ -188,6 +190,8 @@ export class RepoBoardDO extends DurableObject<Env> {
       acceptanceCriteria: patch.acceptanceCriteria ?? existing.acceptanceCriteria,
       uiMeta: normalizeTaskUiMeta({
         simulationProfile: patch.simulationProfile ?? existing.uiMeta?.simulationProfile ?? 'happy_path',
+        autoReviewMode: patch.autoReviewMode ?? existing.uiMeta?.autoReviewMode ?? 'inherit',
+        autoReviewPrompt: patch.autoReviewPrompt ?? existing.uiMeta?.autoReviewPrompt,
         llmAdapter: patch.llmAdapter ?? existing.uiMeta?.llmAdapter,
         llmModel: patch.llmModel ?? existing.uiMeta?.llmModel,
         llmReasoningEffort: patch.llmReasoningEffort ?? existing.uiMeta?.llmReasoningEffort,

--- a/src/server/http/validation.test.ts
+++ b/src/server/http/validation.test.ts
@@ -6,6 +6,7 @@ import {
   parseCreateRepoInput,
   parseCreateTaskInput,
   parseCreateUserApiTokenInput,
+  parseRequestRunChangesInput,
   parseUpdateRepoInput,
   parseUpdateTaskInput,
   parseUpsertScmCredentialInput
@@ -162,6 +163,37 @@ describe('task validation', () => {
       })
     ).toThrow('Invalid LLM payload: codex compatibility fields require llmAdapter "codex".');
   });
+
+  it('defaults task auto-review mode to inherit for create payloads', () => {
+    const parsed = parseCreateTaskInput(
+      createTaskPayload()
+    );
+
+    expect(parsed.autoReviewMode).toBe('inherit');
+    expect(parsed.autoReviewPrompt).toBeUndefined();
+  });
+
+  it('parses task auto-review overrides', () => {
+    const parsed = parseCreateTaskInput(
+      createTaskPayload({
+        autoReviewMode: 'on',
+        autoReviewPrompt: 'Keep reviews tight'
+      })
+    );
+
+    expect(parsed.autoReviewMode).toBe('on');
+    expect(parsed.autoReviewPrompt).toBe('Keep reviews tight');
+  });
+
+  it('rejects invalid task auto-review mode', () => {
+    expect(() =>
+      parseCreateTaskInput(
+        createTaskPayload({
+          autoReviewMode: 'sometimes'
+        })
+      )
+    ).toThrow('Invalid autoReviewMode.');
+  });
 });
 
 describe('repo validation', () => {
@@ -220,6 +252,50 @@ describe('repo validation', () => {
 
     expect(parsed.previewAdapter).toBe('cloudflare_checks');
     expect(parsed.previewConfig).toEqual({ checkName: 'Workers Builds: minions' });
+  });
+
+  it('defaults autoReview on payload omission', () => {
+    const parsed = parseCreateRepoInput({
+      slug: 'abuiles/minions',
+      baselineUrl: 'https://example.com'
+    });
+
+    expect(parsed.autoReview).toEqual({
+      enabled: false,
+      provider: 'gitlab',
+      postInline: false
+    });
+  });
+
+  it('defaults repo auto-review provider and includes prompt when enabled', () => {
+    const parsed = parseCreateRepoInput({
+      slug: 'abuiles/minions',
+      baselineUrl: 'https://example.com',
+      autoReview: {
+        enabled: true,
+        postInline: true,
+        prompt: 'Check all security findings first.'
+      }
+    });
+
+    expect(parsed.autoReview).toEqual({
+      enabled: true,
+      provider: 'gitlab',
+      postInline: true,
+      prompt: 'Check all security findings first.'
+    });
+  });
+
+  it('parses partial repo auto-review update patches without injecting create defaults', () => {
+    const parsed = parseUpdateRepoInput({
+      autoReview: {
+        postInline: true
+      }
+    });
+
+    expect(parsed.autoReview).toEqual({
+      postInline: true
+    });
   });
 
   it('rejects invalid repo execution policy values', () => {
@@ -338,6 +414,38 @@ describe('repo validation', () => {
     })).toMatchObject({
       llmAuthBundleR2Key: 'auth/llm.tgz',
       codexAuthBundleR2Key: 'auth/llm.tgz'
+    });
+  });
+});
+
+describe('request run validation', () => {
+  it('accepts legacy payloads containing only prompt', () => {
+    const parsed = parseRequestRunChangesInput({
+      prompt: 'Please rerun with extra test coverage.'
+    });
+
+    expect(parsed).toEqual({
+      prompt: 'Please rerun with extra test coverage.',
+      reviewSelection: undefined
+    });
+  });
+
+  it('parses request selection payloads with include mode', () => {
+    const parsed = parseRequestRunChangesInput({
+      prompt: 'Please rerun with extra test coverage.',
+      reviewSelection: {
+        mode: 'include',
+        findingIds: ['f1', 'f2'],
+        instruction: 'Focus on these failures.',
+        includeReplies: true
+      }
+    });
+
+    expect(parsed.reviewSelection).toEqual({
+      mode: 'include',
+      findingIds: ['f1', 'f2'],
+      instruction: 'Focus on these failures.',
+      includeReplies: true
     });
   });
 });

--- a/src/server/http/validation.ts
+++ b/src/server/http/validation.ts
@@ -1,10 +1,20 @@
-import type { CreateRepoInput, CreateTaskInput, UpdateRepoInput, UpdateTaskInput, UpsertScmCredentialInput } from '../../ui/domain/api';
+import type {
+  CreateRepoInput,
+  CreateTaskInput,
+  RequestRunChangesInput,
+  UpdateRepoInput,
+  UpdateTaskInput,
+  UpsertScmCredentialInput
+} from '../../ui/domain/api';
 import { badRequest } from './errors';
 import { SCM_PROVIDERS } from '../../shared/scm';
 
 const CODEX_MODELS = new Set(['gpt-5.1-codex-mini', 'gpt-5.3-codex', 'gpt-5.3-codex-spark'] as const);
 const CODEX_REASONING_EFFORTS = new Set(['low', 'medium', 'high'] as const);
 const LLM_ADAPTERS = new Set(['codex', 'cursor_cli'] as const);
+const AUTO_REVIEW_PROVIDERS = new Set(['gitlab', 'jira'] as const);
+const AUTO_REVIEW_MODES = new Set(['inherit', 'on', 'off'] as const);
+const AUTO_REVIEW_SELECTION_MODES = new Set(['all', 'include', 'exclude', 'freeform'] as const);
 const PREVIEW_ADAPTERS = new Set(['cloudflare_checks', 'prompt_recipe'] as const);
 const TENANT_MEMBER_ROLES = new Set(['owner', 'member'] as const);
 const TENANT_SEAT_STATES = new Set(['active', 'invited', 'revoked'] as const);
@@ -357,6 +367,52 @@ function readCommitConfig(value: unknown, field: string, required = true): Creat
   };
 }
 
+function readAutoReviewConfig(value: unknown, field: string, required = true): NonNullable<CreateRepoInput['autoReview']> | undefined {
+  if (!required && typeof value === 'undefined') {
+    return undefined;
+  }
+
+  if (!isRecord(value)) {
+    throw badRequest(`Invalid ${field}.`);
+  }
+
+  const enabled = readBoolean(value.enabled, `${field}.enabled`, false);
+  const prompt = readTrimmedString(value.prompt, `${field}.prompt`, false);
+  const provider = readEnumValue(value.provider, `${field}.provider`, AUTO_REVIEW_PROVIDERS, false);
+  const postInline = readBoolean(value.postInline, `${field}.postInline`, false);
+
+  return {
+    ...(typeof enabled === 'boolean' ? { enabled } : {}),
+    ...(provider ? { provider } : {}),
+    ...(typeof postInline === 'boolean' ? { postInline } : {}),
+    ...(prompt ? { prompt } : {}),
+  };
+}
+
+function readRequestRunChangesSelection(value: unknown, field = 'reviewSelection', required = false): RequestRunChangesInput['reviewSelection'] {
+  if (!required && typeof value === 'undefined') {
+    return undefined as unknown as RequestRunChangesInput['reviewSelection'];
+  }
+
+  if (!isRecord(value)) {
+    throw badRequest(`Invalid ${field}.`);
+  }
+
+  const mode = readEnumValue(value.mode, `${field}.mode`, AUTO_REVIEW_SELECTION_MODES, true);
+  const findingIds = readStringArray(value.findingIds, `${field}.findingIds`, false)
+    ?.map((findingId) => findingId.trim())
+    .filter(Boolean);
+  const instruction = readTrimmedString(value.instruction, `${field}.instruction`, false);
+  const includeReplies = readBoolean(value.includeReplies, `${field}.includeReplies`, false);
+
+  return {
+    mode,
+    ...(findingIds?.length ? { findingIds } : {}),
+    ...(instruction ? { instruction } : {}),
+    ...(typeof includeReplies === 'boolean' ? { includeReplies } : {})
+  };
+}
+
 function normalizeRepoPreviewFields<T extends {
   previewMode?: CreateRepoInput['previewMode'];
   previewAdapter?: CreateRepoInput['previewAdapter'];
@@ -429,6 +485,9 @@ export function parseCreateRepoInput(body: unknown): CreateRepoInput {
       ?? readTrimmedString(body.codexAuthBundleR2Key, 'codexAuthBundleR2Key', false),
     defaultBranch: readTrimmedString(body.defaultBranch, 'defaultBranch', false),
     baselineUrl: readTrimmedString(body.baselineUrl, 'baselineUrl')!,
+    autoReview: hasOwn(body, 'autoReview')
+      ? readAutoReviewConfig(body.autoReview, 'autoReview')
+      : { enabled: false, provider: 'gitlab', postInline: false },
     enabled: readBoolean(body.enabled, 'enabled', false),
     previewMode: readEnumValue(body.previewMode, 'previewMode', new Set(['auto', 'skip'] as const), false),
     evidenceMode: readEnumValue(body.evidenceMode, 'evidenceMode', new Set(['auto', 'skip'] as const), false),
@@ -472,6 +531,7 @@ export function parseUpdateRepoInput(body: unknown): UpdateRepoInput {
   if (hasOwn(body, 'commitConfig')) patch.commitConfig = readCommitConfig(body.commitConfig, 'commitConfig', false);
   if (hasOwn(body, 'previewProvider')) patch.previewProvider = readEnumValue(body.previewProvider, 'previewProvider', new Set(['cloudflare'] as const), false);
   if (hasOwn(body, 'previewCheckName')) patch.previewCheckName = readTrimmedString(body.previewCheckName, 'previewCheckName', false);
+  if (hasOwn(body, 'autoReview')) patch.autoReview = readAutoReviewConfig(body.autoReview, 'autoReview', false);
   if (hasOwn(body, 'codexAuthBundleR2Key')) patch.codexAuthBundleR2Key = readTrimmedString(body.codexAuthBundleR2Key, 'codexAuthBundleR2Key', false);
 
   if (hasOwn(body, 'previewAdapter') || hasOwn(body, 'previewConfig') || hasOwn(body, 'previewProvider') || hasOwn(body, 'previewCheckName')) {
@@ -526,6 +586,8 @@ export function parseCreateTaskInput(body: unknown): CreateTaskInput {
     context: readContext(body.context)!,
     baselineUrlOverride: readString(body.baselineUrlOverride, 'baselineUrlOverride', false),
     status: readString(body.status, 'status', false) as CreateTaskInput['status'],
+    autoReviewMode: readEnumValue(body.autoReviewMode, 'autoReviewMode', AUTO_REVIEW_MODES, false) ?? 'inherit',
+    autoReviewPrompt: readTrimmedString(body.autoReviewPrompt, 'autoReviewPrompt', false),
     simulationProfile: readString(body.simulationProfile, 'simulationProfile', false) as CreateTaskInput['simulationProfile'],
     ...llmFields
   };
@@ -551,6 +613,8 @@ export function parseUpdateTaskInput(body: unknown): UpdateTaskInput {
   if (hasOwn(body, 'context')) patch.context = readContext(body.context, false);
   if (hasOwn(body, 'baselineUrlOverride')) patch.baselineUrlOverride = readString(body.baselineUrlOverride, 'baselineUrlOverride', false);
   if (hasOwn(body, 'status')) patch.status = readString(body.status, 'status', false) as UpdateTaskInput['status'];
+  if (hasOwn(body, 'autoReviewMode')) patch.autoReviewMode = readEnumValue(body.autoReviewMode, 'autoReviewMode', AUTO_REVIEW_MODES, false);
+  if (hasOwn(body, 'autoReviewPrompt')) patch.autoReviewPrompt = readTrimmedString(body.autoReviewPrompt, 'autoReviewPrompt', false);
   if (hasOwn(body, 'simulationProfile')) patch.simulationProfile = readString(body.simulationProfile, 'simulationProfile', false) as UpdateTaskInput['simulationProfile'];
   if (hasOwn(body, 'llmAdapter') || hasOwn(body, 'codexModel') || hasOwn(body, 'codexReasoningEffort')) patch.llmAdapter = llmFields.llmAdapter;
   if (hasOwn(body, 'llmModel') || hasOwn(body, 'codexModel')) {
@@ -563,6 +627,22 @@ export function parseUpdateTaskInput(body: unknown): UpdateTaskInput {
   }
   if (hasOwn(body, 'runId')) patch.runId = readString(body.runId, 'runId', false);
   return patch;
+}
+
+export function parseRequestRunChangesInput(body: unknown): RequestRunChangesInput {
+  if (!isRecord(body)) {
+    throw badRequest('Invalid request changes payload.');
+  }
+
+  const prompt = readTrimmedString(body.prompt, 'prompt');
+  if (!prompt) {
+    throw badRequest('Invalid request changes payload.');
+  }
+
+  return {
+    prompt,
+    reviewSelection: readRequestRunChangesSelection(body.reviewSelection, 'reviewSelection')
+  };
 }
 
 export type CreateTenantInput = {

--- a/src/server/router.ts
+++ b/src/server/router.ts
@@ -19,6 +19,7 @@ import {
   parsePlatformAuthLoginInput,
   parsePlatformSupportAssumeTenantInput,
   parseSetActiveTenantInput,
+  parseRequestRunChangesInput,
   parseUpdateRepoInput,
   parseUpdateTaskInput,
   parseUpdateTenantMemberInput,
@@ -635,19 +636,10 @@ export async function handleRequestChanges(request: Request, env: Env, params: R
     const board = getBoard(env);
     const requestContext = await resolveRequestTenantContext(env, board, request, { requireSession: true });
     const runId = parsePathParam(params.runId);
-    const body = await readJson(request);
-    if (
-      typeof body !== 'object'
-      || !body
-      || !('prompt' in body)
-      || typeof body.prompt !== 'string'
-      || !body.prompt.trim()
-    ) {
-      throw badRequest('Invalid request changes payload.');
-    }
+    const body = parseRequestRunChangesInput(await readJson(request));
     const repoId = await resolveRepoIdForRun(board, runId);
     await assertRepoAccess(env, board, requestContext, repoId);
-    const run = await env.REPO_BOARD.getByName(repoId).requestRunChanges(runId, body.prompt.trim(), requestContext.activeTenantId);
+    const run = await env.REPO_BOARD.getByName(repoId).requestRunChanges(body.prompt, requestContext.activeTenantId);
     const workflow = await scheduleRunJob(env, ctx as unknown as ExecutionContext, {
       tenantId: requestContext.activeTenantId,
       repoId,

--- a/src/shared/llm.ts
+++ b/src/shared/llm.ts
@@ -1,8 +1,9 @@
-import type { AgentRun, CodexModel, CodexReasoningEffort, LlmAdapter, LlmReasoningEffort, OperatorSession, TaskUiMeta } from '../ui/domain/types';
+import type { AutoReviewMode, AgentRun, CodexModel, CodexReasoningEffort, LlmAdapter, LlmReasoningEffort, OperatorSession, TaskUiMeta } from '../ui/domain/types';
 
 export const DEFAULT_LLM_ADAPTER: LlmAdapter = 'codex';
 export const DEFAULT_CODEX_MODEL: CodexModel = 'gpt-5.1-codex-mini';
 export const DEFAULT_REASONING_EFFORT: CodexReasoningEffort = 'medium';
+export const DEFAULT_AUTO_REVIEW_MODE: AutoReviewMode = 'inherit';
 export const DEFAULT_SUPPORTS_RESUME_BY_ADAPTER: Record<LlmAdapter, boolean> = {
   codex: true,
   cursor_cli: false
@@ -18,12 +19,14 @@ export function normalizeTaskUiMeta(uiMeta?: TaskUiMeta): TaskUiMeta | undefined
   const llmReasoningEffort = uiMeta.llmReasoningEffort
     ?? uiMeta.codexReasoningEffort
     ?? (llmAdapter === 'codex' ? DEFAULT_REASONING_EFFORT : undefined);
+  const autoReviewMode = uiMeta.autoReviewMode ?? DEFAULT_AUTO_REVIEW_MODE;
 
   return {
     ...uiMeta,
     llmAdapter,
     llmModel,
     llmReasoningEffort,
+    autoReviewMode,
     codexModel: llmAdapter === 'codex' ? (uiMeta.codexModel ?? llmModel as CodexModel | undefined) : uiMeta.codexModel,
     codexReasoningEffort: llmAdapter === 'codex'
       ? (uiMeta.codexReasoningEffort ?? llmReasoningEffort as CodexReasoningEffort | undefined)

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -574,7 +574,8 @@ export default function App({ api: providedApi }: { api?: AgentBoardApi }) {
               llmAdapter: repoToEdit.llmAdapter,
               llmProfileId: repoToEdit.llmProfileId,
               llmAuthBundleR2Key: repoToEdit.llmAuthBundleR2Key,
-              codexAuthBundleR2Key: repoToEdit.codexAuthBundleR2Key
+              codexAuthBundleR2Key: repoToEdit.codexAuthBundleR2Key,
+              autoReview: repoToEdit.autoReview
             }}
             submitLabel="Save repo"
             onSubmit={async (input) => {
@@ -621,6 +622,8 @@ export default function App({ api: providedApi }: { api?: AgentBoardApi }) {
               context: taskToEdit.context,
               status: taskToEdit.status,
               baselineUrlOverride: taskToEdit.baselineUrlOverride,
+              autoReviewMode: taskToEdit.uiMeta?.autoReviewMode,
+              autoReviewPrompt: taskToEdit.uiMeta?.autoReviewPrompt,
               llmAdapter: taskToEdit.uiMeta?.llmAdapter,
               llmModel: taskToEdit.uiMeta?.llmModel,
               llmReasoningEffort: taskToEdit.uiMeta?.llmReasoningEffort,

--- a/src/ui/components/Forms.tsx
+++ b/src/ui/components/Forms.tsx
@@ -1,6 +1,18 @@
 import { useEffect, useState } from 'react';
 import type { CreateRepoInput, CreateTaskInput } from '../domain/api';
-import type { CodexModel, LlmAdapter, LlmReasoningEffort, PreviewAdapterKind, Repo, ScmProvider, TaskContextLink, TaskDependency, TaskStatus } from '../domain/types';
+import type {
+  AutoReviewMode,
+  AutoReviewProvider,
+  CodexModel,
+  LlmAdapter,
+  LlmReasoningEffort,
+  PreviewAdapterKind,
+  Repo,
+  ScmProvider,
+  TaskContextLink,
+  TaskDependency,
+  TaskStatus
+} from '../domain/types';
 import { normalizeRepoPreviewConfig } from '../../shared/preview';
 
 const DEFAULT_SCM_BASE_URLS: Record<ScmProvider, string> = {
@@ -72,6 +84,10 @@ export function RepoForm({
     previewProvider: initialValues?.previewProvider,
     previewCheckName: initialValues?.previewCheckName
   });
+  const initialAutoReviewEnabled = initialValues?.autoReview?.enabled ?? false;
+  const initialAutoReviewProvider = initialValues?.autoReview?.provider ?? 'gitlab';
+  const initialAutoReviewPostInline = initialValues?.autoReview?.postInline ?? false;
+  const initialAutoReviewPrompt = initialValues?.autoReview?.prompt ?? '';
   const initialPreviewMode = initialValues?.previewMode ?? 'auto';
   const initialEvidenceMode = initialValues?.evidenceMode ?? 'auto';
   const initialPreviewAdapter = normalizedPreview.previewAdapter ?? 'cloudflare_checks';
@@ -95,6 +111,10 @@ export function RepoForm({
   const [llmProfileId, setLlmProfileId] = useState(initialLlmProfileId);
   const [llmAuthBundleR2Key, setLlmAuthBundleR2Key] = useState(initialLlmAuthBundleR2Key);
   const [promptRecipe, setPromptRecipe] = useState(initialPromptRecipe);
+  const [autoReviewEnabled, setAutoReviewEnabled] = useState(initialAutoReviewEnabled);
+  const [autoReviewProvider, setAutoReviewProvider] = useState<AutoReviewProvider>(initialAutoReviewProvider);
+  const [autoReviewPostInline, setAutoReviewPostInline] = useState(initialAutoReviewPostInline);
+  const [autoReviewPrompt, setAutoReviewPrompt] = useState(initialAutoReviewPrompt);
   const [codexAuthBundleR2Key, setCodexAuthBundleR2Key] = useState(initialCodexAuthBundleR2Key);
   const [commitMessageTemplate, setCommitMessageTemplate] = useState(initialCommitMessageTemplate);
   const [commitMessageRegex, setCommitMessageRegex] = useState(initialCommitMessageRegex);
@@ -114,6 +134,10 @@ export function RepoForm({
     setLlmProfileId(initialLlmProfileId);
     setLlmAuthBundleR2Key(initialLlmAuthBundleR2Key);
     setPromptRecipe(initialPromptRecipe);
+    setAutoReviewEnabled(initialAutoReviewEnabled);
+    setAutoReviewProvider(initialAutoReviewProvider);
+    setAutoReviewPostInline(initialAutoReviewPostInline);
+    setAutoReviewPrompt(initialAutoReviewPrompt);
     setCodexAuthBundleR2Key(initialCodexAuthBundleR2Key);
     setCommitMessageTemplate(initialCommitMessageTemplate);
     setCommitMessageRegex(initialCommitMessageRegex);
@@ -124,6 +148,10 @@ export function RepoForm({
     initialProjectPath,
     initialDefaultBranch,
     initialBaselineUrl,
+    initialAutoReviewEnabled,
+    initialAutoReviewProvider,
+    initialAutoReviewPostInline,
+    initialAutoReviewPrompt,
     initialPreviewMode,
     initialEvidenceMode,
     initialPreviewAdapter,
@@ -180,6 +208,12 @@ export function RepoForm({
           defaultBranch,
           baselineUrl,
           enabled: true,
+          autoReview: {
+            enabled: autoReviewEnabled,
+            provider: autoReviewProvider,
+            postInline: autoReviewPostInline,
+            ...(autoReviewPrompt.trim() ? { prompt: autoReviewPrompt.trim() } : {})
+          },
           previewMode,
           evidenceMode,
           previewAdapter,
@@ -201,6 +235,10 @@ export function RepoForm({
         setLlmProfileId('');
         setLlmAuthBundleR2Key('');
         setPromptRecipe('');
+        setAutoReviewEnabled(false);
+        setAutoReviewProvider('gitlab');
+        setAutoReviewPostInline(false);
+        setAutoReviewPrompt('');
         setCodexAuthBundleR2Key('');
         setCommitMessageTemplate('');
         setCommitMessageRegex('');
@@ -295,6 +333,45 @@ export function RepoForm({
           />
         </FieldShell>
       ) : null}
+      <div className="grid gap-4 md:grid-cols-3">
+        <FieldShell label="Auto-review enabled" hint="Enable automatic review runs for this repo by default.">
+          <div className="flex h-11 items-center gap-3 rounded-xl border border-slate-700 bg-slate-900/90 px-3 text-sm text-slate-100">
+            <input
+              type="checkbox"
+              checked={autoReviewEnabled}
+              onChange={(event) => setAutoReviewEnabled(event.target.checked)}
+              className="h-4 w-4 rounded border-slate-600 bg-slate-950 text-cyan-400 focus:ring-cyan-400/30"
+            />
+            <span>{autoReviewEnabled ? 'Enabled' : 'Disabled'}</span>
+          </div>
+        </FieldShell>
+        <FieldShell label="Auto-review provider" hint="Which integration should handle review automation.">
+          <select className={inputClass()} value={autoReviewProvider} onChange={(event) => setAutoReviewProvider(event.target.value as AutoReviewProvider)}>
+            <option value="gitlab">GitLab</option>
+            <option value="jira">Jira</option>
+          </select>
+        </FieldShell>
+        <FieldShell label="Post inline comments" hint="Add findings directly in review comments when supported.">
+          <div className="flex h-11 items-center gap-3 rounded-xl border border-slate-700 bg-slate-900/90 px-3 text-sm text-slate-100">
+            <input
+              type="checkbox"
+              checked={autoReviewPostInline}
+              onChange={(event) => setAutoReviewPostInline(event.target.checked)}
+              className="h-4 w-4 rounded border-slate-600 bg-slate-950 text-cyan-400 focus:ring-cyan-400/30"
+            />
+            <span>{autoReviewPostInline ? 'Enabled' : 'Disabled'}</span>
+          </div>
+        </FieldShell>
+      </div>
+      <FieldShell label="Auto-review prompt" hint="Optional override prompt used when auto-review is enabled.">
+        <textarea
+          className={textareaClass()}
+          value={autoReviewPrompt}
+          onChange={(event) => setAutoReviewPrompt(event.target.value)}
+          rows={4}
+          placeholder="Prioritize API contract stability and security findings."
+        />
+      </FieldShell>
       <div className="grid gap-4 md:grid-cols-3">
         <FieldShell label="LLM adapter">
           <select className={inputClass()} value={llmAdapter} onChange={(event) => setLlmAdapter(event.target.value as LlmAdapter)}>
@@ -422,6 +499,8 @@ export function TaskForm({
   const initialLlmAdapter = initialValues?.llmAdapter ?? 'codex';
   const initialLlmModel = initialValues?.llmModel ?? initialValues?.codexModel ?? DEFAULT_LLM_MODELS[initialLlmAdapter];
   const initialLlmReasoningEffort = initialValues?.llmReasoningEffort ?? initialValues?.codexReasoningEffort ?? 'medium';
+  const initialAutoReviewMode = initialValues?.autoReviewMode ?? 'inherit';
+  const initialAutoReviewPrompt = initialValues?.autoReviewPrompt ?? '';
 
   const [repoId, setRepoId] = useState(initialRepoId);
   const [title, setTitle] = useState(initialTitle);
@@ -435,6 +514,8 @@ export function TaskForm({
   const [status, setStatus] = useState<TaskStatus>(initialTaskStatus);
   const [baselineUrlOverride, setBaselineUrlOverride] = useState(initialBaselineUrlOverride);
   const [autoStartEligible, setAutoStartEligible] = useState(initialAutoStartEligible);
+  const [autoReviewMode, setAutoReviewMode] = useState<NonNullable<AutoReviewMode>>(initialAutoReviewMode);
+  const [autoReviewPrompt, setAutoReviewPrompt] = useState(initialAutoReviewPrompt);
   const [llmAdapter, setLlmAdapter] = useState<LlmAdapter>(initialLlmAdapter);
   const [llmModel, setLlmModel] = useState(initialLlmModel);
   const [llmReasoningEffort, setLlmReasoningEffort] = useState<LlmReasoningEffort>(initialLlmReasoningEffort);
@@ -463,11 +544,15 @@ export function TaskForm({
     setStatus(initialTaskStatus);
     setBaselineUrlOverride(initialBaselineUrlOverride);
     setAutoStartEligible(initialAutoStartEligible);
+    setAutoReviewMode(initialAutoReviewMode);
+    setAutoReviewPrompt(initialAutoReviewPrompt);
     setLlmAdapter(initialLlmAdapter);
     setLlmModel(initialLlmModel);
     setLlmReasoningEffort(initialLlmReasoningEffort);
   }, [
     initialAutoStartEligible,
+    initialAutoReviewMode,
+    initialAutoReviewPrompt,
     initialBaselineUrlOverride,
     initialLlmAdapter,
     initialLlmModel,
@@ -507,6 +592,8 @@ export function TaskForm({
           context: { links: parseLinks(links), notes },
           status,
           baselineUrlOverride: baselineUrlOverride || undefined,
+          autoReviewMode,
+          autoReviewPrompt: autoReviewPrompt.trim() || undefined,
           simulationProfile: 'happy_path',
           llmAdapter,
           llmModel: llmModel || undefined,
@@ -525,6 +612,8 @@ export function TaskForm({
         setStatus(initialStatus);
         setBaselineUrlOverride('');
         setAutoStartEligible(false);
+        setAutoReviewMode('inherit');
+        setAutoReviewPrompt('');
         setLlmAdapter('codex');
         setLlmModel('gpt-5.1-codex-mini');
         setLlmReasoningEffort('medium');
@@ -611,6 +700,24 @@ export function TaskForm({
             />
             <span>{autoStartEligible ? 'Eligible' : 'Not eligible'}</span>
           </div>
+        </FieldShell>
+      </div>
+      <div className="grid gap-4 xl:grid-cols-2">
+        <FieldShell label="Auto-review mode" hint="inherit uses repo setting; on/off force behavior for this task.">
+          <select className={inputClass()} value={autoReviewMode} onChange={(event) => setAutoReviewMode(event.target.value as CreateTaskInput['autoReviewMode'])}>
+            <option value="inherit">Inherit</option>
+            <option value="on">On</option>
+            <option value="off">Off</option>
+          </select>
+        </FieldShell>
+        <FieldShell label="Auto-review prompt" hint="Optional override prompt for this task.">
+          <textarea
+            className={textareaClass()}
+            value={autoReviewPrompt}
+            onChange={(event) => setAutoReviewPrompt(event.target.value)}
+            rows={4}
+            placeholder="Inspect for security and performance regressions."
+          />
         </FieldShell>
       </div>
       <div className="grid gap-4 md:grid-cols-2">

--- a/src/ui/domain/api.ts
+++ b/src/ui/domain/api.ts
@@ -1,8 +1,10 @@
 import type {
   AgentRun,
   BoardSnapshotV1,
+  AutoReviewMode,
   CodexModel,
   CodexReasoningEffort,
+  AutoReviewProvider,
   LlmAdapter,
   LlmReasoningEffort,
   Repo,
@@ -20,6 +22,20 @@ import type {
   User
 } from './types';
 
+export type RepoAutoReviewInput = {
+  enabled?: boolean;
+  prompt?: string;
+  provider?: AutoReviewProvider;
+  postInline?: boolean;
+};
+
+export type RequestRunChangesSelection = {
+  mode: 'all' | 'include' | 'exclude' | 'freeform';
+  findingIds?: string[];
+  instruction?: string;
+  includeReplies?: boolean;
+};
+
 export type CreateRepoInput = {
   tenantId?: string;
   slug?: string;
@@ -32,6 +48,7 @@ export type CreateRepoInput = {
   defaultBranch?: string;
   baselineUrl: string;
   enabled?: boolean;
+  autoReview?: RepoAutoReviewInput;
   previewMode?: Repo['previewMode'];
   evidenceMode?: Repo['evidenceMode'];
   previewAdapter?: Repo['previewAdapter'];
@@ -66,6 +83,8 @@ export type CreateTaskInput = {
   context: Task['context'];
   baselineUrlOverride?: string;
   status?: TaskStatus;
+  autoReviewMode?: AutoReviewMode;
+  autoReviewPrompt?: string;
   simulationProfile?: SimulationProfile;
   llmAdapter?: LlmAdapter;
   llmModel?: string;
@@ -82,6 +101,7 @@ export type UpdateTaskInput = Partial<Omit<CreateTaskInput, 'repoId'>> & {
 
 export type RequestRunChangesInput = {
   prompt: string;
+  reviewSelection?: RequestRunChangesSelection;
 };
 
 export type AuthSession = {

--- a/src/ui/domain/types.ts
+++ b/src/ui/domain/types.ts
@@ -19,7 +19,9 @@ export type CodexReasoningEffort = 'low' | 'medium' | 'high';
 export type LlmAdapter = 'codex' | 'cursor_cli';
 export type LlmReasoningEffort = 'low' | 'medium' | 'high';
 export type ScmProvider = 'github' | 'gitlab';
+export type AutoReviewProvider = 'gitlab' | 'jira';
 export type ReviewProvider = ScmProvider;
+export type AutoReviewMode = 'inherit' | 'on' | 'off';
 export type PreviewAdapterKind = 'cloudflare_checks' | 'prompt_recipe';
 export type IntegrationScopeType = 'tenant' | 'repo' | 'channel';
 export type IntegrationPluginKind = 'slack' | 'jira' | 'gitlab';
@@ -66,6 +68,12 @@ export type RepoCommitConfig = {
   messageTemplate?: string;
   messageRegex?: string;
   messageExamples?: string[];
+};
+export type RepoAutoReview = {
+  enabled: boolean;
+  prompt?: string;
+  provider: AutoReviewProvider;
+  postInline: boolean;
 };
 export type PreviewResolutionStatus = 'ready' | 'pending' | 'failed' | 'timed_out';
 export type PreviewDiagnostic = {
@@ -169,6 +177,7 @@ export type Repo = {
   previewUrlPattern?: string;
   // Compatibility alias during migration to generic LLM executor fields.
   codexAuthBundleR2Key?: string;
+  autoReview?: RepoAutoReview;
   createdAt: string;
   updatedAt: string;
 };
@@ -238,6 +247,8 @@ export type TaskUiMeta = {
   llmReasoningEffort?: LlmReasoningEffort;
   codexModel?: CodexModel;
   codexReasoningEffort?: CodexReasoningEffort;
+  autoReviewMode?: AutoReviewMode;
+  autoReviewPrompt?: string;
 };
 
 export type Task = {

--- a/src/ui/mock/local-agent-board-api.ts
+++ b/src/ui/mock/local-agent-board-api.ts
@@ -209,6 +209,7 @@ export class LocalAgentBoardApi implements AgentBoardApi {
       slug: input.slug ?? input.projectPath ?? '',
       scmProvider: input.scmProvider,
       scmBaseUrl: input.scmBaseUrl,
+      autoReview: input.autoReview,
       projectPath: input.projectPath,
       llmAdapter: input.llmAdapter,
       llmProfileId: input.llmProfileId,
@@ -245,8 +246,17 @@ export class LocalAgentBoardApi implements AgentBoardApi {
           return repo;
         }
 
+        const hasAutoReviewPatch = Object.prototype.hasOwnProperty.call(patch, 'autoReview');
+        const mergedAutoReview = hasAutoReviewPatch
+          ? {
+              ...(repo.autoReview ?? { enabled: false, provider: 'gitlab', postInline: false }),
+              ...patch.autoReview
+            }
+          : repo.autoReview;
+
         updatedRepo = normalizeRepo({
           ...repo,
+          autoReview: mergedAutoReview,
           ...patch,
           slug: patch.slug ?? patch.projectPath ?? repo.slug,
           projectPath: patch.projectPath ?? patch.slug ?? repo.projectPath,
@@ -319,6 +329,8 @@ export class LocalAgentBoardApi implements AgentBoardApi {
       updatedAt: timestamp,
       uiMeta: normalizeTaskUiMeta({
         simulationProfile: input.simulationProfile ?? 'happy_path',
+        autoReviewMode: input.autoReviewMode,
+        autoReviewPrompt: input.autoReviewPrompt,
         llmAdapter: input.llmAdapter,
         llmModel: input.llmModel,
         llmReasoningEffort: input.llmReasoningEffort,
@@ -366,6 +378,8 @@ export class LocalAgentBoardApi implements AgentBoardApi {
           acceptanceCriteria: patch.acceptanceCriteria ?? task.acceptanceCriteria,
           uiMeta: normalizeTaskUiMeta({
             simulationProfile: patch.simulationProfile ?? task.uiMeta?.simulationProfile ?? 'happy_path',
+            autoReviewMode: patch.autoReviewMode ?? task.uiMeta?.autoReviewMode ?? 'inherit',
+            autoReviewPrompt: patch.autoReviewPrompt ?? task.uiMeta?.autoReviewPrompt,
             llmAdapter: patch.llmAdapter ?? task.uiMeta?.llmAdapter,
             llmModel: patch.llmModel ?? task.uiMeta?.llmModel,
             llmReasoningEffort: patch.llmReasoningEffort ?? task.uiMeta?.llmReasoningEffort,


### PR DESCRIPTION
Task: AR1 - Auto-Review Config, Types, and Validation

Add repo/task auto-review config surfaces with backward-compatible validation and defaults.
Source ref: main

Acceptance criteria:
- Repo/task auto-review fields are available in types, validation, and API surfaces.
- Legacy create/update payloads remain valid without new fields.
- Defaults are deterministic: repo disabled, task inherit.
- UI exposes repo/task auto-review settings.

Run ID: run_repo_abuiles_agents_kanban_mmbeecc5ezpj