### PR TITLE
AR3 - Provider Posting Adapters for GitLab and Jira

### DIFF
--- a/src/server/review-posting/adapter.test.ts
+++ b/src/server/review-posting/adapter.test.ts
@@ -1,0 +1,254 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { AgentRun, Repo, Task, ReviewFinding } from '../../ui/domain/types';
+import {
+  buildReviewFindingMarker,
+  buildReviewSummaryMarker
+} from './adapter';
+import { GitLabReviewPostingAdapter } from './gitlab';
+import { JiraReviewPostingAdapter } from './jira';
+
+function buildRepo(overrides: Partial<Repo> = {}): Repo {
+  return {
+    repoId: 'repo_demo',
+    slug: 'group/platform/demo',
+    scmProvider: 'gitlab',
+    scmBaseUrl: 'https://gitlab.example.com',
+    projectPath: 'group/platform/demo',
+    defaultBranch: 'main',
+    baselineUrl: 'https://example.com',
+    enabled: true,
+    createdAt: '2026-03-02T00:00:00.000Z',
+    updatedAt: '2026-03-02T00:00:00.000Z',
+    ...overrides
+  };
+}
+
+function buildTask(overrides: Partial<Task> = {}): Task {
+  return {
+    taskId: 'task_demo',
+    repoId: 'repo_demo',
+    title: 'Update demo flow',
+    taskPrompt: 'Do the thing',
+    acceptanceCriteria: ['it works'],
+    context: { links: [] },
+    status: 'ACTIVE',
+    createdAt: '2026-03-02T00:00:00.000Z',
+    updatedAt: '2026-03-02T00:00:00.000Z',
+    ...overrides
+  };
+}
+
+function buildRun(overrides: Partial<AgentRun> = {}): AgentRun {
+  return {
+    runId: 'run_demo',
+    taskId: 'task_demo',
+    repoId: 'repo_demo',
+    status: 'PR_OPEN',
+    branchName: 'agent/run-demo',
+    previewStatus: 'UNKNOWN',
+    evidenceStatus: 'NOT_STARTED',
+    errors: [],
+    startedAt: '2026-03-02T00:00:00.000Z',
+    simulationProfile: 'happy_path',
+    timeline: [],
+    pendingEvents: [],
+    ...overrides
+  };
+}
+
+function buildFinding(overrides: Partial<ReviewFinding> = {}): ReviewFinding {
+  return {
+    findingId: 'rf_1a2b3c4d',
+    severity: 'high',
+    title: 'Potential SQL injection',
+    description: 'Use prepared statements.',
+    status: 'open',
+    filePath: 'src/db.ts',
+    lineStart: 42,
+    lineEnd: 44,
+    ...overrides
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe('GitLab review posting adapter', () => {
+  it('posts inline findings when location is available and reuses existing notes by marker', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({
+          diff_refs: { base_sha: 'base', head_sha: 'head', start_sha: 'start' }
+        }), { status: 200 })
+      )
+      .mockResolvedValueOnce(new Response(JSON.stringify([{
+        id: 'd1',
+        notes: [{ id: '100', body: 'ignore me' }]
+      }]), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        id: 900,
+        notes: [{ id: '200', body: 'inline marker', url: 'https://gitlab.example.com/note/200' }]
+      }), { status: 201 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        id: 901,
+        notes: [{ id: '201', body: 'inline marker', url: 'https://gitlab.example.com/note/201' }]
+      }), { status: 201 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const adapter = new GitLabReviewPostingAdapter();
+    const result = await adapter.postFindings({
+      repo: buildRepo(),
+      task: buildTask(),
+      run: buildRun({ reviewNumber: 123 }),
+      findings: [
+        buildFinding({ findingId: 'rf_1', lineStart: 42, lineEnd: 44 }),
+        buildFinding({ findingId: 'rf_2', lineStart: 7 })
+      ],
+      credential: { token: 'glpat_test' },
+      postInline: true
+    });
+
+    expect(result.findings).toHaveLength(2);
+    expect(result.findings.every((entry) => entry.posted && entry.inline)).toBe(true);
+    expect(result.summary).toBeUndefined();
+    expect(result.findings[0].providerThreadId).toBe('200');
+  });
+
+  it('falls back to a summary note when inline posting is unavailable', async () => {
+    const finding = buildFinding({
+      findingId: 'rf_1',
+      filePath: 'src/main.ts',
+      lineStart: 12
+    });
+    const marker = buildReviewFindingMarker(finding.findingId, 'run_demo');
+    const summaryMarker = buildReviewSummaryMarker('run_demo');
+
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({
+          diff_refs: { base_sha: 'base', head_sha: 'head', start_sha: 'start' }
+        }), { status: 200 })
+      )
+      .mockResolvedValueOnce(new Response(JSON.stringify([]), { status: 200 }))
+      .mockResolvedValueOnce(new Response('bad request', { status: 400 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        id: 1000,
+        notes: [{ id: '3000', body: `summary body includes ${marker} and ${summaryMarker}`, url: 'https://gitlab.example.com/note/3000' }]
+      }), { status: 201 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const adapter = new GitLabReviewPostingAdapter();
+    const result = await adapter.postFindings({
+      repo: buildRepo(),
+      task: buildTask(),
+      run: buildRun({ reviewNumber: 123 }),
+      findings: [finding],
+      credential: { token: 'glpat_test' },
+      postInline: true
+    });
+
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0].inline).toBe(false);
+    expect(result.findings[0].summary).toBe(true);
+    expect(result.findings[0].posted).toBe(true);
+    expect(result.findings[0].providerThreadId).toBe('3000');
+    expect(result.summary?.providerThreadId).toBe('3000');
+    expect(result.summary?.posted).toBe(true);
+  });
+
+  it('maps GitLab discussion replies back to finding IDs', async () => {
+    const findingA = buildFinding({ findingId: 'rf_a1', filePath: 'src/a.ts', lineStart: 11 });
+    const findingB = buildFinding({ findingId: 'rf_b2', filePath: 'src/b.ts', lineStart: 3 });
+    const markerA = buildReviewFindingMarker(findingA.findingId, 'run_demo');
+    const markerB = buildReviewFindingMarker(findingB.findingId, 'run_demo');
+    const fetchMock = vi.fn().mockResolvedValueOnce(new Response(JSON.stringify([
+      {
+        id: 1,
+        notes: [
+          { id: 10, body: `Finding note ${markerA} with details` },
+          { id: 11, body: 'Please review this before merge.' }
+        ]
+      },
+      {
+        id: 2,
+        notes: [
+          { id: 20, body: `Finding note ${markerB} with details` },
+          { id: 21, body: `${markerB} additional note` },
+          { id: 22, body: 'No marker reply for finding b.' }
+        ]
+      }
+    ]), { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const adapter = new GitLabReviewPostingAdapter();
+    const context = await adapter.fetchReplyContext({
+      repo: buildRepo(),
+      task: buildTask(),
+      run: buildRun({ reviewNumber: 123 }),
+      findingIds: [findingA.findingId, findingB.findingId],
+      credential: { token: 'glpat_test' }
+    });
+
+    expect(context[findingA.findingId]).toEqual(['Please review this before merge.']);
+    expect(context[findingB.findingId]).toEqual([`${markerB} additional note`, 'No marker reply for finding b.']);
+  });
+});
+
+describe('Jira review posting adapter', () => {
+  it('posts Jira comments with stable finding markers and location references', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({ comments: [] }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ id: '9001' }), { status: 201 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ id: '9002' }), { status: 201 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const adapter = new JiraReviewPostingAdapter();
+    const result = await adapter.postFindings({
+      repo: buildRepo({ scmProvider: 'github', scmBaseUrl: 'https://github.com', projectPath: 'acme/demo', autoReview: undefined }),
+      task: buildTask(),
+      run: buildRun({ reviewUrl: 'https://jira.example.com/browse/ABC-123' }),
+      findings: [
+        buildFinding({ findingId: 'rf_1', filePath: 'src/main.ts', lineStart: 10 }),
+        buildFinding({ findingId: 'rf_2', filePath: 'src/lib.ts', lineStart: 30, lineEnd: 35 })
+      ],
+      credential: { token: 'jira_token' }
+    });
+
+    expect(result.findings).toHaveLength(2);
+    expect(result.findings.every((entry) => entry.posted)).toBe(true);
+    expect(result.findings[0].providerThreadId).toBe('9001');
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(fetchMock.mock.calls[1]?.[0]).toContain('/rest/api/2/issue/ABC-123/comment');
+    const secondBody = JSON.parse((fetchMock.mock.calls[1]?.[1] as RequestInit).body as string).body;
+    expect(secondBody).toContain('Location: src/main.ts:10');
+  });
+
+  it('maps Jira replies back to finding IDs from marker-bearing comments', async () => {
+    const markerA = buildReviewFindingMarker('rf_1', 'run_demo');
+    const markerB = buildReviewFindingMarker('rf_2', 'run_demo');
+    const fetchMock = vi.fn().mockResolvedValueOnce(new Response(JSON.stringify({
+      comments: [
+        { id: '1', body: `${markerA} Finding A` },
+        { id: '2', body: `${markerA} LGTM` },
+        { id: '3', body: `${markerB} needs follow up` }
+      ]
+    }), { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const adapter = new JiraReviewPostingAdapter();
+    const context = await adapter.fetchReplyContext({
+      repo: buildRepo({ scmProvider: 'github', scmBaseUrl: 'https://github.com', projectPath: 'acme/demo' }),
+      task: buildTask(),
+      run: buildRun({
+        reviewUrl: 'https://jira.example.com/browse/ABC-123'
+      }),
+      findingIds: ['rf_1', 'rf_2'],
+      credential: { token: 'jira_token' }
+    });
+
+    expect(context.rf_1).toEqual(['LGTM']);
+    expect(context.rf_2).toEqual(['needs follow up']);
+  });
+});

--- a/src/server/review-posting/adapter.ts
+++ b/src/server/review-posting/adapter.ts
@@ -1,0 +1,111 @@
+import type { AutoReviewProvider, AgentRun, Repo, ReviewFinding, Task } from '../../ui/domain/types';
+
+export type ReviewPostingCredential = {
+  token: string;
+};
+
+export type ReviewPostingInput = {
+  repo: Repo;
+  task: Task;
+  run: AgentRun;
+  findings: ReviewFinding[];
+  credential: ReviewPostingCredential;
+  postInline?: boolean;
+};
+
+export type ReviewPostingFindingRecord = {
+  findingId: string;
+  posted: boolean;
+  inline: boolean;
+  summary: boolean;
+  providerThreadId?: string;
+  providerThreadUrl?: string;
+  reason?: string;
+};
+
+export type ReviewPostingResult = {
+  provider: AutoReviewProvider;
+  findings: ReviewPostingFindingRecord[];
+  updatedFindings: ReviewFinding[];
+  summary?: {
+    posted: boolean;
+    providerThreadId?: string;
+    providerThreadUrl?: string;
+    reason?: string;
+  };
+  errors: string[];
+};
+
+export type ReviewReplyFetchInput = Omit<ReviewPostingInput, 'findings'> & {
+  findingIds?: string[];
+};
+
+export type ReviewReplyContext = Record<string, string[]>;
+
+export interface ReviewPostingAdapter {
+  readonly provider: AutoReviewProvider;
+  postFindings(input: ReviewPostingInput): Promise<ReviewPostingResult>;
+  fetchReplyContext(input: ReviewReplyFetchInput): Promise<ReviewReplyContext>;
+}
+
+export const REVIEW_MARKER_TAG = 'agentboard-review';
+const FINDING_MARKER_RE = /<!--\s*agentboard-review:finding:([^:\s>]+):([^>\s]+)\s*-->/g;
+const SUMMARY_MARKER_RE = /<!--\s*agentboard-review:summary:([^>\s]+)\s*-->/;
+
+export function buildReviewFindingMarker(findingId: string, runId: string) {
+  return `<!-- agentboard-review:finding:${findingId}:${runId} -->`;
+}
+
+export function buildReviewSummaryMarker(runId: string) {
+  return `<!-- agentboard-review:summary:${runId} -->`;
+}
+
+export function extractFindingIdsFromText(text: string) {
+  const ids = new Set<string>();
+  const matcher = new RegExp(FINDING_MARKER_RE.source, 'gi');
+  for (let match = matcher.exec(text); match; match = matcher.exec(text)) {
+    if (match[1]) {
+      ids.add(match[1]);
+    }
+  }
+  return [...ids];
+}
+
+export function extractRunIdFromSummaryMarker(text: string) {
+  const match = SUMMARY_MARKER_RE.exec(text);
+  return match?.[1];
+}
+
+export function buildReviewFindingBody(input: {
+  finding: ReviewFinding;
+  marker: string;
+  includeLocation: boolean;
+}) {
+  const location = input.includeLocation && input.finding.filePath
+    ? buildFindingLocationLine(input.finding.filePath, input.finding.lineStart, input.finding.lineEnd)
+    : undefined;
+
+  return [
+    input.marker,
+    `### ${input.finding.findingId}: ${input.finding.title}`,
+    '',
+    input.finding.description,
+    location ? `Location: ${location}` : undefined
+  ].filter(Boolean).join('\n');
+}
+
+function buildFindingLocationLine(filePath: string, lineStart?: number, lineEnd?: number) {
+  if (!lineStart && !lineEnd) {
+    return filePath;
+  }
+  if (lineStart && !lineEnd) {
+    return `${filePath}:${lineStart}`;
+  }
+  if (!lineStart && lineEnd) {
+    return `${filePath}:${lineEnd}`;
+  }
+  if (lineStart === lineEnd) {
+    return `${filePath}:${lineStart}`;
+  }
+  return `${filePath}:${lineStart}-${lineEnd}`;
+}

--- a/src/server/review-posting/gitlab.ts
+++ b/src/server/review-posting/gitlab.ts
@@ -1,0 +1,476 @@
+import { buildGitlabApiBaseUrl, getRepoProjectPath } from '../../shared/scm';
+import type { AutoReviewProvider, Repo, ReviewFinding } from '../../ui/domain/types';
+import {
+  ReviewPostingAdapter,
+  type ReviewPostingFindingRecord,
+  type ReviewPostingInput,
+  type ReviewPostingResult,
+  type ReviewReplyContext,
+  type ReviewReplyFetchInput,
+  buildReviewFindingBody,
+  buildReviewFindingMarker,
+  buildReviewSummaryMarker,
+  extractFindingIdsFromText,
+  extractRunIdFromSummaryMarker
+} from './adapter';
+
+type GitLabDiscussionNote = {
+  id?: string | number;
+  body?: string;
+  url?: string;
+};
+
+type GitLabDiscussion = {
+  notes?: GitLabDiscussionNote[];
+};
+
+type GitLabDiscussionResponse = {
+  id?: string | number;
+  notes?: GitLabDiscussionNote[];
+};
+
+type GitLabNoteResponse = {
+  id?: string | number;
+  url?: string;
+};
+
+type GitLabMergeRequestResponse = {
+  diff_refs?: {
+    base_sha?: string;
+    head_sha?: string;
+    start_sha?: string;
+  };
+};
+
+type ExistingFindingThread = {
+  noteId: string;
+  noteUrl?: string;
+  isSummary: boolean;
+};
+
+type ExistingThreadMap = Map<string, ExistingFindingThread>;
+
+type ExistingSummary = {
+  noteId: string;
+  noteUrl?: string;
+};
+
+type GitLabPostingInput = {
+  repo: Repo;
+  reviewNumber: number;
+  finding: ReviewFinding;
+  marker: string;
+  diffRefs: NonNullable<GitLabMergeRequestResponse['diff_refs']>;
+  token: string;
+};
+
+export class GitLabReviewPostingAdapter implements ReviewPostingAdapter {
+  readonly provider: AutoReviewProvider = 'gitlab';
+
+  async postFindings(input: ReviewPostingInput): Promise<ReviewPostingResult> {
+    const reviewNumber = input.run.reviewNumber ?? input.run.prNumber;
+    if (!reviewNumber) {
+      return {
+        provider: this.provider,
+        findings: input.findings.map((finding) => ({
+          findingId: finding.findingId,
+          posted: false,
+          inline: false,
+          summary: false,
+          reason: 'Review number is required for GitLab posting.'
+        })),
+        updatedFindings: [...input.findings],
+        errors: ['Review number is missing for GitLab provider.']
+      };
+    }
+
+    const results: ReviewPostingFindingRecord[] = [];
+    const updatedFindings = [...input.findings];
+    const needsSummary: ReviewFinding[] = [];
+    const errors: string[] = [];
+    const shouldInline = Boolean(input.postInline);
+
+    let existingSummary: ExistingSummary | undefined;
+    const findingsByMarker = new Map<string, ExistingFindingThread>();
+    try {
+      const discussions = await this.fetchDiscussions(input.repo, reviewNumber, input.credential.token);
+      existingSummary = this.fetchSummaryThread(discussions, input.run.runId);
+      const markerThreads = this.fetchExistingFindingThreads(discussions, existingSummary?.noteId);
+      markerThreads.forEach((value, key) => {
+        findingsByMarker.set(key, value);
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      errors.push(message);
+    }
+
+    const diffRefs = await this.fetchMergeRequestDiffRefs(input.repo, reviewNumber, input.credential.token).catch((error) => {
+      const message = error instanceof Error ? error.message : String(error);
+      errors.push(message);
+      return undefined;
+    });
+
+    for (const finding of input.findings) {
+      const result: ReviewPostingFindingRecord = {
+        findingId: finding.findingId,
+        posted: false,
+        inline: false,
+        summary: false
+      };
+      const marker = buildReviewFindingMarker(finding.findingId, input.run.runId);
+      const existingThread = findingsByMarker.get(finding.findingId);
+
+      if (existingThread) {
+        result.posted = true;
+        result.inline = !existingThread.isSummary;
+        result.summary = existingThread.isSummary;
+        result.providerThreadId = existingThread.noteId;
+        result.providerThreadUrl = existingThread.noteUrl;
+        this.updateFindingRecord(updatedFindings, finding.findingId, result.providerThreadId);
+        results.push(result);
+        continue;
+      }
+
+      if (!shouldInline || !finding.filePath || !finding.lineStart || !diffRefs) {
+        needsSummary.push(finding);
+        result.summary = true;
+        result.reason = !shouldInline || !finding.filePath || !finding.lineStart
+          ? 'Posting inline unavailable or disabled.'
+          : 'Missing MR diff metadata required for inline posting.';
+        results.push(result);
+        continue;
+      }
+
+      try {
+        const response = await this.postGitLabInlineFinding({
+          repo: input.repo,
+          reviewNumber,
+          finding,
+          marker,
+          diffRefs,
+          token: input.credential.token
+        });
+        result.posted = true;
+        result.inline = true;
+        result.summary = false;
+        result.providerThreadId = response.noteId;
+        result.providerThreadUrl = response.noteUrl;
+        this.updateFindingRecord(updatedFindings, finding.findingId, result.providerThreadId);
+      } catch (error) {
+        needsSummary.push(finding);
+        result.inline = false;
+        result.summary = true;
+        result.reason = `Inline posting failed: ${error instanceof Error ? error.message : String(error)}`;
+      }
+
+      results.push(result);
+    }
+
+    let summary: ReviewPostingResult['summary'];
+    if (needsSummary.length > 0) {
+      try {
+        const postedSummary = await this.postGitLabSummaryNote({
+          repo: input.repo,
+          reviewNumber,
+          runId: input.run.runId,
+          findings: needsSummary,
+          token: input.credential.token,
+          existingSummaryNoteId: existingSummary?.noteId
+        });
+        summary = {
+          posted: true,
+          providerThreadId: postedSummary.noteId,
+          providerThreadUrl: postedSummary.noteUrl
+        };
+        needsSummary.forEach((finding) => {
+          const record = results.find((entry) => entry.findingId === finding.findingId);
+          if (record) {
+            record.posted = true;
+            record.inline = false;
+            record.summary = true;
+            record.providerThreadId = postedSummary.noteId;
+            record.providerThreadUrl = postedSummary.noteUrl;
+            record.reason = undefined;
+          }
+          this.updateFindingRecord(updatedFindings, finding.findingId, postedSummary.noteId);
+        });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        summary = {
+          posted: false,
+          reason: message
+        };
+        errors.push(message);
+        needsSummary.forEach((finding) => {
+          const record = results.find((entry) => entry.findingId === finding.findingId);
+          if (record) {
+            record.summary = true;
+            record.reason = record.reason ?? message;
+          }
+        });
+      }
+    }
+
+    return {
+      provider: this.provider,
+      findings: results,
+      updatedFindings,
+      summary,
+      errors
+    };
+  }
+
+  async fetchReplyContext(input: ReviewReplyFetchInput): Promise<ReviewReplyContext> {
+    const reviewNumber = input.run.reviewNumber ?? input.run.prNumber;
+    if (!reviewNumber) {
+      return {};
+    }
+
+    const discussions = await this.fetchDiscussions(input.repo, reviewNumber, input.credential.token);
+    const targetIds = input.findingIds ? new Set(input.findingIds) : undefined;
+    const normalized: ReviewReplyContext = {};
+
+    for (const discussion of discussions) {
+      const root = discussion.notes?.[0];
+      const rootBody = root?.body;
+      if (!rootBody) {
+        continue;
+      }
+
+      const markerIds = extractFindingIdsFromText(rootBody);
+      const summaryRunId = extractRunIdFromSummaryMarker(rootBody);
+      const allowedIds = markerIds.length > 0
+        ? markerIds
+        : summaryRunId === input.run.runId
+          ? extractFindingIdsFromText(rootBody)
+          : [];
+
+      if (!allowedIds.length) {
+        continue;
+      }
+
+      for (const note of (discussion.notes ?? []).slice(1)) {
+        const body = note.body;
+        if (!body) {
+          continue;
+        }
+        const explicitIds = extractFindingIdsFromText(body);
+        const replyIds = explicitIds.length > 0 ? explicitIds : allowedIds;
+        for (const findingId of replyIds) {
+          if (targetIds && !targetIds.has(findingId)) {
+            continue;
+          }
+          if (!normalized[findingId]) {
+            normalized[findingId] = [];
+          }
+          normalized[findingId].push(body);
+        }
+      }
+    }
+
+    return normalized;
+  }
+
+  private async fetchMergeRequestDiffRefs(
+    repo: Repo,
+    reviewNumber: number,
+    token: string
+  ): Promise<NonNullable<GitLabMergeRequestResponse['diff_refs']>> {
+    const payload = await this.requestJson<GitLabMergeRequestResponse>(
+      repo,
+      `/merge_requests/${reviewNumber}`,
+      token
+    );
+    const diffRefs = payload.diff_refs;
+    if (!diffRefs?.head_sha || !diffRefs.base_sha || !diffRefs.start_sha) {
+      throw new Error('Merge request diff references are not available.');
+    }
+    return diffRefs;
+  }
+
+  private async postGitLabInlineFinding(input: GitLabPostingInput): Promise<{ noteId: string; noteUrl?: string }> {
+    const line = input.finding.lineStart ?? 1;
+    const response = await this.requestJson<GitLabDiscussionResponse>(
+      input.repo,
+      `/merge_requests/${input.reviewNumber}/discussions`,
+      input.token,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          body: buildReviewFindingBody({ finding: input.finding, marker: input.marker, includeLocation: true }),
+          position: {
+            position_type: 'text',
+            base_sha: input.diffRefs.base_sha,
+            start_sha: input.diffRefs.start_sha,
+            head_sha: input.diffRefs.head_sha,
+            old_path: input.finding.filePath,
+            new_path: input.finding.filePath,
+            new_line: line
+          }
+        })
+      }
+    );
+
+    const firstNote = response.notes?.[0];
+    if (!firstNote?.id) {
+      throw new Error('GitLab inline posting response did not contain a note id.');
+    }
+    return {
+      noteId: String(firstNote.id),
+      noteUrl: firstNote.url
+    };
+  }
+
+  private async postGitLabSummaryNote(input: {
+    repo: Repo;
+    reviewNumber: number;
+    runId: string;
+    findings: ReviewFinding[];
+    token: string;
+    existingSummaryNoteId?: string;
+  }): Promise<{ noteId: string; noteUrl?: string }> {
+    const marker = buildReviewSummaryMarker(input.runId);
+    const body = [
+      marker,
+      '# AgentsKanban Review Notes',
+      '',
+      'The following findings were posted in summary form because inline posting was not available:',
+      ...input.findings.map((finding, index) => {
+        const findingLine = buildReviewFindingBody({
+          finding,
+          marker: buildReviewFindingMarker(finding.findingId, input.runId),
+          includeLocation: true
+        });
+        return `${index + 1}. ${findingLine}`;
+      }),
+      ''
+    ].join('\n');
+
+    if (input.existingSummaryNoteId) {
+      const response = await this.requestJson<GitLabNoteResponse>(
+        input.repo,
+        `/merge_requests/${input.reviewNumber}/notes/${input.existingSummaryNoteId}`,
+        input.token,
+        {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ body })
+        }
+      );
+      return {
+        noteId: input.existingSummaryNoteId,
+        noteUrl: response.url
+      };
+    }
+
+    const response = await this.requestJson<GitLabDiscussionResponse>(
+      input.repo,
+      `/merge_requests/${input.reviewNumber}/discussions`,
+      input.token,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ body })
+      }
+    );
+    const firstNote = response.notes?.[0];
+    if (!firstNote?.id) {
+      throw new Error('GitLab summary posting response did not contain a note id.');
+    }
+    return {
+      noteId: String(firstNote.id),
+      noteUrl: firstNote.url
+    };
+  }
+
+  private fetchExistingFindingThreads(
+    discussions: GitLabDiscussion[],
+    summaryNoteId?: string
+  ): ExistingThreadMap {
+    const map: ExistingThreadMap = new Map();
+
+    for (const discussion of discussions) {
+      const rootBody = discussion.notes?.[0]?.body;
+      if (!rootBody) {
+        continue;
+      }
+      const note = discussion.notes?.[0];
+      if (!note?.id) {
+        continue;
+      }
+      const noteId = String(note.id);
+      const isSummary = summaryNoteId !== undefined && summaryNoteId === noteId;
+
+      for (const findingId of extractFindingIdsFromText(rootBody)) {
+        map.set(findingId, {
+          noteId,
+          noteUrl: note.url,
+          isSummary
+        });
+      }
+    }
+
+    return map;
+  }
+
+  private fetchSummaryThread(
+    discussions: GitLabDiscussion[],
+    runId: string
+  ): ExistingSummary | undefined {
+    const summaryMarker = buildReviewSummaryMarker(runId);
+    for (const discussion of discussions) {
+      const root = discussion.notes?.[0];
+      if (!root?.body?.includes(summaryMarker) || !root.id) {
+        continue;
+      }
+      return {
+        noteId: String(root.id),
+        noteUrl: root.url
+      };
+    }
+    return undefined;
+  }
+
+  private async fetchDiscussions(
+    repo: Repo,
+    reviewNumber: number,
+    token: string
+  ): Promise<GitLabDiscussion[]> {
+    const response = await this.requestJson<GitLabDiscussion[]>(
+      repo,
+      `/merge_requests/${reviewNumber}/discussions?per_page=100`,
+      token
+    );
+    return response;
+  }
+
+  private async requestJson<T>(repo: Repo, path: string, token: string, init: RequestInit = {}): Promise<T> {
+    const response = await fetch(this.buildApiUrl(repo, path), {
+      ...init,
+      headers: {
+        Accept: 'application/json',
+        'PRIVATE-TOKEN': token,
+        ...(init.headers ?? {})
+      }
+    });
+    if (!response.ok) {
+      throw new Error(`GitLab review-posting request failed with status ${response.status}.`);
+    }
+    return response.json() as Promise<T>;
+  }
+
+  private buildApiUrl(repo: Repo, path: string) {
+    return `${buildGitlabApiBaseUrl(repo)}/projects/${encodeURIComponent(getRepoProjectPath(repo))}${path}`;
+  }
+
+  private updateFindingRecord(updatedFindings: ReviewFinding[], findingId: string, providerThreadId?: string) {
+    const index = updatedFindings.findIndex((existing) => existing.findingId === findingId);
+    if (index >= 0) {
+      updatedFindings[index] = {
+        ...updatedFindings[index],
+        providerThreadId
+      };
+    }
+  }
+}

--- a/src/server/review-posting/jira.ts
+++ b/src/server/review-posting/jira.ts
@@ -1,0 +1,307 @@
+import type { AutoReviewProvider, AgentRun, ReviewFinding, Task } from '../../ui/domain/types';
+import {
+  ReviewPostingAdapter,
+  type ReviewPostingFindingRecord,
+  type ReviewPostingInput,
+  type ReviewPostingResult,
+  type ReviewReplyContext,
+  type ReviewReplyFetchInput,
+  buildReviewFindingBody,
+  buildReviewFindingMarker,
+  extractFindingIdsFromText
+} from './adapter';
+
+type JiraIssueComment = {
+  id?: string;
+  body?: unknown;
+};
+
+type JiraIssueCommentResponse = {
+  id: string;
+  comments?: JiraIssueComment[];
+};
+
+type JiraIssueLookup = {
+  issueKey: string;
+  host: string;
+};
+
+type JiraCommentRequestPayload = {
+  body: string;
+};
+
+type JiraCommentResponse = {
+  id: string;
+};
+
+const JIRA_ISSUE_KEY_RE = /^[A-Z][A-Z0-9]*-[0-9]+$/;
+
+export class JiraReviewPostingAdapter implements ReviewPostingAdapter {
+  readonly provider: AutoReviewProvider = 'jira';
+
+  async postFindings(input: ReviewPostingInput): Promise<ReviewPostingResult> {
+    const target = this.resolveJiraIssue(input.run, input.task);
+    if (!target) {
+      const message = 'Unable to resolve Jira issue key for this run.';
+      return {
+        provider: this.provider,
+        findings: input.findings.map((finding) => ({
+          findingId: finding.findingId,
+          posted: false,
+          inline: false,
+          summary: false,
+          reason: message
+        })),
+        updatedFindings: [...input.findings],
+        errors: [message]
+      };
+    }
+
+    const existingComments = await this.fetchExistingComments(target.host, target.issueKey, input.credential.token);
+    const existingMap = new Map<string, string>();
+    for (const comment of existingComments) {
+      const existingMarkerIds = extractFindingIdsFromText(this.toJiraBodyText(comment.body));
+      const commentId = comment.id;
+      if (!commentId) {
+        continue;
+      }
+      for (const findingId of existingMarkerIds) {
+        existingMap.set(findingId, commentId);
+      }
+    }
+
+    const results: ReviewPostingFindingRecord[] = [];
+    const updatedFindings = [...input.findings];
+    const errors: string[] = [];
+
+    for (const finding of input.findings) {
+      const record: ReviewPostingFindingRecord = {
+        findingId: finding.findingId,
+        posted: false,
+        inline: false,
+        summary: false
+      };
+      const marker = buildReviewFindingMarker(finding.findingId, input.run.runId);
+      const existingCommentId = existingMap.get(finding.findingId);
+      if (existingCommentId) {
+        record.posted = true;
+        record.providerThreadId = existingCommentId;
+        this.updateFindingRecord(updatedFindings, finding.findingId, existingCommentId);
+        results.push(record);
+        continue;
+      }
+
+      const body = this.buildJiraCommentBody({
+        finding,
+        marker,
+        includeLocation: Boolean(finding.filePath)
+      });
+      try {
+        const response = await this.requestJson<JiraCommentResponse>(
+          target.host,
+          `/rest/api/2/issue/${encodeURIComponent(target.issueKey)}/comment`,
+          input.credential.token,
+          {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ body } satisfies JiraCommentRequestPayload)
+          }
+        );
+        if (response.id) {
+          record.posted = true;
+          record.providerThreadId = response.id;
+          record.providerThreadUrl = `${target.host}/browse/${target.issueKey}?focusedCommentId=${response.id}&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-${response.id}`;
+          this.updateFindingRecord(updatedFindings, finding.findingId, record.providerThreadId);
+        }
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        record.reason = message;
+        errors.push(message);
+      }
+      results.push(record);
+    }
+
+    return {
+      provider: this.provider,
+      findings: results,
+      updatedFindings,
+      errors
+    };
+  }
+
+  async fetchReplyContext(input: ReviewReplyFetchInput): Promise<ReviewReplyContext> {
+    const target = this.resolveJiraIssue(input.run, input.task);
+    if (!target) {
+      return {};
+    }
+
+    const response = await this.requestJson<JiraIssueCommentResponse>(
+      target.host,
+      `/rest/api/2/issue/${encodeURIComponent(target.issueKey)}/comment`,
+      input.credential.token
+    );
+    const comments = response.comments ?? [];
+    const targetIds = input.findingIds ? new Set(input.findingIds) : undefined;
+
+    const firstByFinding = new Map<string, number>();
+    const replies: ReviewReplyContext = {};
+
+    comments.forEach((comment, index) => {
+      const commentBody = this.toJiraBodyText(comment.body);
+      const markerIds = extractFindingIdsFromText(commentBody);
+      if (!markerIds.length) {
+        return;
+      }
+      for (const findingId of markerIds) {
+        if (targetIds && !targetIds.has(findingId)) {
+          continue;
+        }
+        const firstIndex = firstByFinding.get(findingId);
+        if (firstIndex === undefined) {
+          firstByFinding.set(findingId, index);
+          continue;
+        }
+        if (firstIndex < index) {
+          if (!replies[findingId]) {
+            replies[findingId] = [];
+          }
+          if (commentBody) {
+            replies[findingId].push(commentBody);
+          }
+        }
+      }
+    });
+
+    return replies;
+  }
+
+  private buildJiraCommentBody({
+    finding,
+    marker,
+    includeLocation
+  }: {
+    finding: ReviewFinding;
+    marker: string;
+    includeLocation: boolean;
+  }) {
+    return `${marker}\n*${finding.title}*\n\n${finding.description}${includeLocation ? this.formatJiraFindingLocation(finding) : ''}`;
+  }
+
+  private formatJiraFindingLocation(finding: ReviewFinding) {
+    if (!finding.filePath) {
+      return '';
+    }
+
+    const lineStart = finding.lineStart;
+    const lineEnd = finding.lineEnd;
+    if (lineStart && lineEnd && lineStart !== lineEnd) {
+      return `\nLocation: ${finding.filePath}:${lineStart}-${lineEnd}`;
+    }
+    if (lineStart) {
+      return `\nLocation: ${finding.filePath}:${lineStart}`;
+    }
+    if (lineEnd) {
+      return `\nLocation: ${finding.filePath}:${lineEnd}`;
+    }
+    return `\nLocation: ${finding.filePath}`;
+  }
+
+  private async fetchExistingComments(
+    host: string,
+    issueKey: string,
+    token: string
+  ): Promise<JiraIssueComment[]> {
+    const response = await this.requestJson<JiraIssueCommentResponse>(
+      host,
+      `/rest/api/2/issue/${encodeURIComponent(issueKey)}/comment`,
+      token
+    );
+    return response.comments ?? [];
+  }
+
+  private async requestJson<T>(host: string, path: string, token: string, init: RequestInit = {}): Promise<T> {
+    const response = await fetch(`${host}${path}`, {
+      ...init,
+      headers: {
+        Accept: 'application/json',
+        Authorization: `Bearer ${token}`,
+        ...(init.headers ?? {})
+      }
+    });
+    if (!response.ok) {
+      throw new Error(`Jira review-posting request failed with status ${response.status}.`);
+    }
+    return response.json() as Promise<T>;
+  }
+
+  private updateFindingRecord(updatedFindings: ReviewFinding[], findingId: string, providerThreadId?: string) {
+    const index = updatedFindings.findIndex((existing) => existing.findingId === findingId);
+    if (index >= 0) {
+      updatedFindings[index] = {
+        ...updatedFindings[index],
+        providerThreadId
+      };
+    }
+  }
+
+  private toJiraBodyText(body: unknown): string {
+    if (typeof body === 'string') {
+      return body;
+    }
+
+    if (body && typeof body === 'object') {
+      if ('text' in body && typeof body.text === 'string') {
+        return body.text;
+      }
+      if ('body' in body && typeof body.body === 'string') {
+        return body.body;
+      }
+      if ('content' in body && typeof body.content === 'string') {
+        return body.content;
+      }
+    }
+    return '';
+  }
+
+  private resolveJiraIssue(run: AgentRun, task: Task): JiraIssueLookup | undefined {
+    for (const candidate of [run.reviewUrl, task.sourceRef]) {
+      if (!candidate) {
+        continue;
+      }
+      const parsed = this.parseJiraIssue(candidate);
+      if (parsed) {
+        return parsed;
+      }
+    }
+    return undefined;
+  }
+
+  private parseJiraIssue(candidate: string): JiraIssueLookup | undefined {
+    let url: URL;
+    try {
+      url = new URL(candidate);
+    } catch {
+      return undefined;
+    }
+
+    const pathKey = url.pathname
+      .split('/')
+      .map((segment) => segment.trim())
+      .find((segment) => JIRA_ISSUE_KEY_RE.test(segment.toUpperCase()));
+    if (pathKey) {
+      return {
+        issueKey: pathKey.toUpperCase(),
+        host: `${url.protocol}://${url.host}`
+      };
+    }
+
+    const queryKey = url.searchParams.get('id') ?? url.searchParams.get('issueKey') ?? url.searchParams.get('selectedIssue');
+    if (queryKey) {
+      const match = queryKey.trim().toUpperCase().match(JIRA_ISSUE_KEY_RE);
+      if (match) {
+        return { issueKey: match[0], host: `${url.protocol}://${url.host}` };
+      }
+    }
+    return undefined;
+  }
+}

--- a/src/server/review-posting/registry.ts
+++ b/src/server/review-posting/registry.ts
@@ -1,0 +1,13 @@
+import type { AutoReviewProvider } from '../../ui/domain/types';
+import type { ReviewPostingAdapter } from './adapter';
+import { GitLabReviewPostingAdapter } from './gitlab';
+import { JiraReviewPostingAdapter } from './jira';
+
+const adapters: Record<AutoReviewProvider, ReviewPostingAdapter> = {
+  gitlab: new GitLabReviewPostingAdapter(),
+  jira: new JiraReviewPostingAdapter()
+};
+
+export function getReviewPostingAdapter(provider: AutoReviewProvider): ReviewPostingAdapter {
+  return adapters[provider];
+}


### PR DESCRIPTION
Task: AR3 - Provider Posting Adapters for GitLab and Jira

Post normalized review findings to the configured provider and ingest replies for context.
Source ref: main

Acceptance criteria:
- GitLab and Jira review posting paths both work with provider-specific fallback behavior.
- Reply/readback context can be correlated to finding IDs.
- Provider failures are non-fatal and observable in run metadata/logs.
- Adapter tests cover posting, fallback, and reply ingestion.

Run ID: run_repo_abuiles_agents_kanban_mmbes94g4qga