### PR TITLE
T3 - Jira Read Adapter + Repo Resolution + Run Kickoff

### DIFF
--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -75,7 +75,7 @@ apiRouter.post('/api/integrations/slack/events', (c: Context) =>
   handleSlackEvents(c.req.raw, c.env as Env)
 );
 apiRouter.post('/api/integrations/slack/interactions', (c: Context) =>
-  handleSlackInteractions(c.req.raw, c.env as Env)
+  handleSlackInteractions(c.req.raw, c.env as Env, c.executionCtx as unknown as ExecutionContext<unknown>)
 );
 apiRouter.get('/api/board/ws', (c: Context) => handleBoardWs(c.req.raw, c.env as Env));
 apiRouter.get('/api/repos', (c: Context) => handleListRepos(c.req.raw, c.env as Env));

--- a/src/server/integrations/jira/client.test.ts
+++ b/src/server/integrations/jira/client.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from 'vitest';
+import { JiraMcpIssueSourceIntegration } from './client';
+
+function makeResponse(status: number, body: unknown) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' }
+  });
+}
+
+describe('jira issue source integration', () => {
+  it('normalizes Jira issue payload into task-ready fields', async () => {
+    const fetcher = vi.fn(async () => makeResponse(200, {
+      key: 'AB-1',
+      self: 'https://jira.example.com/rest/api/3/issue/AB-1',
+      fields: {
+        summary: 'Fix login bug',
+        description: {
+          type: 'doc',
+          content: [
+            {
+              type: 'paragraph',
+              content: [{ type: 'text', text: 'The login button fails.' }]
+            }
+          ]
+        }
+      }
+    }));
+    const integration = new JiraMcpIssueSourceIntegration({
+      baseUrl: 'https://jira.example.com',
+      authToken: 'token'
+    }, fetcher);
+
+    const issue = await integration.fetchIssue('ab-1', 'tenant_local');
+
+    expect(fetcher).toHaveBeenCalledTimes(1);
+    expect(issue.issueKey).toBe('AB-1');
+    expect(issue.title).toBe('Fix login bug');
+    expect(issue.body).toBe('The login button fails.');
+    expect(issue.url).toBe('https://jira.example.com/browse/AB-1');
+  });
+
+  it('retries retryable Jira failures and preserves explicit retry budget', async () => {
+    const fetcher = vi.fn(async () => makeResponse(503, { errorMessages: 'service unavailable' }));
+    const integration = new JiraMcpIssueSourceIntegration({
+      baseUrl: 'https://jira.example.com',
+      authToken: 'token',
+      maxAttempts: 3,
+      retryDelayMs: 1
+    }, fetcher);
+
+    await expect(integration.fetchIssue('ab-2', 'tenant_local')).rejects.toThrow(
+      'Failed to load Jira issue AB-2'
+    );
+    expect(fetcher).toHaveBeenCalledTimes(3);
+  });
+
+  it('maps 404 into an actionable operator-facing error', async () => {
+    const fetcher = vi.fn(async () => makeResponse(404, { message: 'not found' }));
+    const integration = new JiraMcpIssueSourceIntegration({
+      baseUrl: 'https://jira.example.com',
+      authToken: 'token'
+    }, fetcher);
+
+    await expect(integration.fetchIssue('AB-3', 'tenant_local')).rejects.toMatchObject({
+      message: 'Jira issue AB-3 not found: not found.'
+    });
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it('validates issue keys early before contacting Jira', async () => {
+    const fetcher = vi.fn();
+    const integration = new JiraMcpIssueSourceIntegration({
+      baseUrl: 'https://jira.example.com',
+      authToken: 'token'
+    }, fetcher);
+
+    await expect(integration.fetchIssue('bad-key', 'tenant_local')).rejects.toThrow('Invalid Jira issue key.');
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/integrations/jira/client.ts
+++ b/src/server/integrations/jira/client.ts
@@ -1,0 +1,313 @@
+import type { IntegrationIssueRef, IssueSourceIntegration } from '../interfaces';
+import { badRequest } from '../../http/errors';
+
+type HttpFetcher = (input: string, init?: RequestInit) => Promise<Response>;
+
+type JiraIssueSourceOptions = {
+  baseUrl: string;
+  authEmail?: string;
+  authToken?: string;
+  timeoutMs?: number;
+  maxAttempts?: number;
+  retryDelayMs?: number;
+};
+
+type NormalizedJiraIssueSourceOptions = {
+  baseUrl: string;
+  authEmail?: string;
+  authToken?: string;
+  timeoutMs: number;
+  maxAttempts: number;
+  retryDelayMs: number;
+  fetcher: HttpFetcher;
+};
+
+type JiraIssuePayload = {
+  key?: unknown;
+  self?: unknown;
+  fields?: {
+    description?: unknown;
+    summary?: unknown;
+    project?: { key?: unknown };
+  };
+};
+
+type TimeoutError = Error & { retryable?: boolean };
+
+const ISSUE_KEY_PATTERN = /^[A-Z][A-Z0-9_]*-\d+$/i;
+const DEFAULT_TIMEOUT_MS = 5_000;
+const DEFAULT_MAX_ATTEMPTS = 3;
+const DEFAULT_RETRY_DELAY_MS = 250;
+
+function readString(value: unknown): string | undefined {
+  if (typeof value === 'string' && value.trim()) {
+    return value.trim();
+  }
+  return undefined;
+}
+
+function readPositiveInt(value: unknown, fallback: number): number {
+  if (typeof value === 'number' && Number.isInteger(value) && value > 0) {
+    return value;
+  }
+  if (typeof value === 'string') {
+    const parsed = Number(value);
+    if (Number.isInteger(parsed) && parsed > 0) {
+      return parsed;
+    }
+  }
+  return fallback;
+}
+
+function encodeBasicAuthToken(username: string, token: string) {
+  const credentials = `${username}:${token}`;
+  if (typeof btoa === 'function') {
+    return btoa(credentials);
+  }
+  if (typeof Buffer !== 'undefined') {
+    return Buffer.from(credentials, 'utf-8').toString('base64');
+  }
+  return '';
+}
+
+function buildIssueEndpoint(baseUrl: string, issueKey: string) {
+  const normalizedBase = baseUrl.replace(/\/$/, '');
+  const lowerBase = normalizedBase.toLowerCase();
+  const separator = lowerBase.includes('/rest/api/3') ? '/issue/' : '/rest/api/3/issue/';
+  return `${normalizedBase}${separator}${issueKey}`;
+}
+
+function normalizeJiraText(value: unknown): string {
+  if (typeof value === 'string') {
+    return value.trim();
+  }
+  if (!value || typeof value !== 'object') {
+    return '';
+  }
+  if (Array.isArray(value)) {
+    return value
+      .map((item) => normalizeJiraText(item))
+      .filter((entry) => entry)
+      .join('\n');
+  }
+  const record = value as Record<string, unknown>;
+  if (typeof record.text === 'string') {
+    return record.text.trim();
+  }
+  if (typeof record.value === 'string') {
+    return record.value.trim();
+  }
+  if (Array.isArray(record.content)) {
+    return normalizeJiraText(record.content);
+  }
+  return '';
+}
+
+function toTimeoutError(message: string): TimeoutError {
+  const error = new Error(message) as TimeoutError;
+  error.retryable = true;
+  return error;
+}
+
+function isRetryableStatus(status: number) {
+  return status >= 500 || status === 429 || status === 408;
+}
+
+function buildIssueBrowseUrl(baseUrl: string, fallbackIssueKey: string, self?: string) {
+  if (self && self.includes('/browse/')) {
+    return self;
+  }
+
+  const normalizedSelf = readString(self);
+  if (normalizedSelf) {
+    const replacement = normalizedSelf.replace('/rest/api/3/issue/', '/browse/').replace('/rest/api/2/issue/', '/browse/');
+    if (replacement !== normalizedSelf && replacement.includes('/browse/')) {
+      return replacement;
+    }
+  }
+
+  const normalizedBase = readString(baseUrl)?.replace(/\/$/, '') ?? '';
+  if (!normalizedBase) {
+    return undefined;
+  }
+
+  const browserBase = normalizedBase.includes('/rest/api/')
+    ? normalizedBase.replace(/\/rest\/api\/.*/, '')
+    : normalizedBase;
+
+  return `${browserBase}/browse/${fallbackIssueKey}`;
+}
+
+function extractErrorMessage(payload: unknown): string | undefined {
+  if (!payload || typeof payload !== 'object') {
+    return undefined;
+  }
+  const record = payload as Record<string, unknown>;
+  return readString(record.message)
+    ?? readString(record.errorMessages)
+    ?? readString(record.error?.message);
+}
+
+function toIntegrationIssue(payload: unknown, fallbackIssueKey: string): IntegrationIssueRef {
+  const issue = payload as JiraIssuePayload;
+  const fields = issue.fields ?? {};
+  const title = readString(fields.summary) || fallbackIssueKey;
+  const body = normalizeJiraText(fields.description) || 'No description provided.';
+  return {
+    issueKey: readString(issue.key) || fallbackIssueKey,
+    title,
+    body,
+    url: buildIssueBrowseUrl(issue.self as string, readString(issue.key) || fallbackIssueKey)
+  };
+}
+
+function sleep(ms: number) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+export class RetryableRequestError extends Error {
+  readonly retryable = true;
+}
+
+export class JiraMcpIssueSourceIntegration implements IssueSourceIntegration {
+  readonly pluginKind: 'jira' = 'jira';
+  private readonly options: NormalizedJiraIssueSourceOptions;
+
+  constructor(input: JiraIssueSourceOptions, fetcher: HttpFetcher = fetch) {
+    const baseUrl = readString(input.baseUrl);
+    if (!baseUrl) {
+      throw badRequest('Jira integration requires a base URL.');
+    }
+
+    this.options = {
+      baseUrl,
+      authEmail: readString(input.authEmail),
+      authToken: readString(input.authToken),
+      timeoutMs: readPositiveInt(input.timeoutMs, DEFAULT_TIMEOUT_MS),
+      maxAttempts: readPositiveInt(input.maxAttempts, DEFAULT_MAX_ATTEMPTS),
+      retryDelayMs: readPositiveInt(input.retryDelayMs, DEFAULT_RETRY_DELAY_MS),
+      fetcher
+    };
+  }
+
+  async fetchIssue(issueRef: string, _tenantId: string): Promise<IntegrationIssueRef> {
+    const issueKey = readString(issueRef)?.toUpperCase();
+    if (!issueKey || !ISSUE_KEY_PATTERN.test(issueKey)) {
+      throw badRequest('Invalid Jira issue key.');
+    }
+
+    const response = await this.fetchWithRetry(buildIssueEndpoint(this.options.baseUrl, issueKey));
+    const payload = await response.json().catch(() => ({}));
+    if (!response.ok) {
+      const message = extractErrorMessage(payload);
+      const normalizedMessage = message ? `: ${message}` : '';
+
+      if (response.status === 404) {
+        throw badRequest(`Jira issue ${issueKey} not found${normalizedMessage}`);
+      }
+      if (response.status === 401 || response.status === 403) {
+        throw badRequest(`Jira authentication failed while loading ${issueKey}.`);
+      }
+      if (isRetryableStatus(response.status)) {
+        throw toTimeoutError(`Failed to load Jira issue ${issueKey} (${response.status}).`);
+      }
+      throw badRequest(`Failed to load Jira issue ${issueKey} (${response.status}).`);
+    }
+
+    return toIntegrationIssue(payload, issueKey);
+  }
+
+  private async fetchWithRetry(url: string): Promise<Response> {
+    let attempt = 0;
+    let lastRetryableError: Error | undefined;
+
+    while (attempt < this.options.maxAttempts) {
+      attempt += 1;
+      try {
+        const response = await this.fetchOnce(url);
+        if (response.ok) {
+          return response;
+        }
+
+        if (!isRetryableStatus(response.status)) {
+          return response;
+        }
+
+        if (attempt < this.options.maxAttempts) {
+          await sleep(this.options.retryDelayMs);
+          continue;
+        }
+
+        return response;
+      } catch (error) {
+        const typedError = error instanceof Error ? error : new Error('Unknown Jira request error.');
+        if ((typedError instanceof RetryableRequestError) || (typedError instanceof DOMException) || typedError.retryable) {
+          lastRetryableError = typedError;
+          if (attempt < this.options.maxAttempts) {
+            await sleep(this.options.retryDelayMs);
+            continue;
+          }
+        }
+
+        throw typedError;
+      }
+    }
+
+    throw lastRetryableError ?? new Error('Failed to fetch Jira issue.');
+  }
+
+  private async fetchOnce(url: string): Promise<Response> {
+    const headers: HeadersInit = {
+      Accept: 'application/json'
+    };
+    if (this.options.authToken && this.options.authEmail) {
+      headers.Authorization = `Basic ${encodeBasicAuthToken(this.options.authEmail, this.options.authToken)}`;
+    } else if (this.options.authToken) {
+      headers.Authorization = `Bearer ${this.options.authToken}`;
+    }
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => {
+      controller.abort();
+    }, this.options.timeoutMs);
+
+    try {
+      const response = await this.options.fetcher(url, { headers, signal: controller.signal }).catch((error) => {
+        throw error instanceof Error ? error : new Error('Unknown fetch error.');
+      });
+
+      if (!response.ok && (response.status >= 500 || response.status === 429 || response.status === 408)) {
+        throw new RetryableRequestError(`Retryable Jira response: ${response.status}`);
+      }
+
+      return response;
+    } catch (error) {
+      if (error instanceof DOMException && error.name === 'AbortError') {
+        throw toTimeoutError('Jira read request timed out.');
+      }
+      if (error instanceof RetryableRequestError) {
+        throw error;
+      }
+      if (error instanceof Error && error.message.includes('timed out')) {
+        throw error;
+      }
+      throw new Error('Unable to reach Jira issue endpoint.');
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+}
+
+export function createJiraIssueSourceIntegrationFromEnv(env: Env, tenantId: string) {
+  const envValues = env as Record<string, string | undefined>;
+  return new JiraMcpIssueSourceIntegration({
+    baseUrl: envValues.JIRA_API_BASE_URL ?? envValues.JIRA_API_URL ?? ``,
+    authEmail: envValues.JIRA_EMAIL ?? envValues.JIRA_USER_EMAIL,
+    authToken: envValues.JIRA_API_TOKEN,
+    timeoutMs: readPositiveInt(envValues.JIRA_TIMEOUT_MS, DEFAULT_TIMEOUT_MS),
+    maxAttempts: readPositiveInt(envValues.JIRA_MAX_ATTEMPTS, DEFAULT_MAX_ATTEMPTS),
+    retryDelayMs: readPositiveInt(envValues.JIRA_RETRY_DELAY_MS, DEFAULT_RETRY_DELAY_MS)
+  });
+}

--- a/src/server/integrations/slack/handlers.test.ts
+++ b/src/server/integrations/slack/handlers.test.ts
@@ -1,14 +1,26 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { buildSlackSignature } from './verification';
-import { handleSlackCommands, handleSlackEvents, handleSlackInteractions } from './handlers';
+import { handleSlackCommands, handleSlackInteractions } from './handlers';
 
 const tenantAuthDbMocks = vi.hoisted(() => ({
   deleteSlackThreadBinding: vi.fn(),
   getPrimaryTenantId: vi.fn(),
+  listJiraProjectRepoMappingsByProject: vi.fn(),
   upsertSlackThreadBinding: vi.fn()
 }));
 
-vi.mock('../tenant-auth-db', () => tenantAuthDbMocks);
+const jiraClientMocks = vi.hoisted(() => ({
+  createJiraIssueSourceIntegrationFromEnv: vi.fn()
+}));
+
+const runOrchestratorMocks = vi.hoisted(() => ({
+  scheduleRunJob: vi.fn()
+}));
+const fetchSpy = vi.spyOn(globalThis, 'fetch');
+
+vi.mock('../../tenant-auth-db', () => tenantAuthDbMocks);
+vi.mock('../jira/client', () => jiraClientMocks);
+vi.mock('../run-orchestrator', () => runOrchestratorMocks);
 
 function createKv(secret: string) {
   const values = new Map<string, string>([['slack/signing-secret', secret]]);
@@ -30,12 +42,6 @@ function slackHeaders(timestamp: string, signature: string, teamId = 'T1') {
   };
 }
 
-function makeEnv(secret = 'secret') {
-  return {
-    SECRETS_KV: createKv(secret)
-  };
-}
-
 function taskBinding(taskId: string, channelId: string, threadTs: string) {
   return {
     id: `binding_${taskId}`,
@@ -49,9 +55,50 @@ function taskBinding(taskId: string, channelId: string, threadTs: string) {
   };
 }
 
+function makeRepoBoard(stub: { taskId: string; runId: string }) {
+  return {
+    createTask: vi.fn().mockResolvedValue({
+      taskId: stub.taskId,
+      repoId: 'repo_alpha'
+    }),
+    startRun: vi.fn().mockResolvedValue({
+      runId: stub.runId,
+      taskId: stub.taskId
+    }),
+    transitionRun: vi.fn()
+  };
+};
+
+function makeBoardIndex(repos: Array<{ repoId: string; slug: string }>) {
+  return {
+    getByName: vi.fn(() => ({
+      listRepos: vi.fn(async () => repos)
+    }))
+  };
+}
+
+function makeEnv(secret = 'secret', repoBoard = makeRepoBoard({ taskId: 'task_1', runId: 'run_1' }), boardIndex = makeBoardIndex([])) {
+  return {
+    SECRETS_KV: createKv(secret),
+    REPO_BOARD: { getByName: vi.fn(() => repoBoard) },
+    BOARD_INDEX: boardIndex
+  };
+}
+
 describe('slack handlers', () => {
+  const nowTs = Math.floor(Date.now() / 1000).toString();
+  const issue = {
+    issueKey: 'ABC-100',
+    title: 'Cannot login',
+    body: 'Button fails',
+    url: 'https://jira.test.com/browse/ABC-100'
+  };
+  const fetchIssue = vi.fn().mockResolvedValue(issue);
+
   beforeEach(() => {
     vi.clearAllMocks();
+    fetchSpy.mockReset();
+    fetchSpy.mockResolvedValue(new Response('{}', { status: 200 }));
     tenantAuthDbMocks.getPrimaryTenantId.mockResolvedValue('tenant_local');
     tenantAuthDbMocks.upsertSlackThreadBinding.mockImplementation(async (input: {
       taskId: string;
@@ -59,18 +106,28 @@ describe('slack handlers', () => {
       threadTs: string;
     }) => taskBinding(input.taskId, input.channelId, input.threadTs));
     tenantAuthDbMocks.deleteSlackThreadBinding.mockResolvedValue({ ok: true });
+    tenantAuthDbMocks.listJiraProjectRepoMappingsByProject.mockResolvedValue([]);
+    jiraClientMocks.createJiraIssueSourceIntegrationFromEnv.mockReturnValue({
+      fetchIssue
+    });
+    runOrchestratorMocks.scheduleRunJob.mockResolvedValue({ id: 'workflow_1' });
   });
 
-  it('acknowledges slash commands quickly and processes async via waitUntil', async () => {
+  it('acknowledges slash commands and auto-starts task/run for single Jira repo mapping', async () => {
+    const repoBoard = makeRepoBoard({ taskId: 'task_single', runId: 'run_single' });
+    tenantAuthDbMocks.listJiraProjectRepoMappingsByProject.mockResolvedValue([
+      { jiraProjectKey: 'ABC', repoId: 'repo_alpha', priority: 0, active: true, id: 'm1', tenantId: 'tenant_local', createdAt: '', updatedAt: '' }
+    ]);
     const rawBody = new URLSearchParams({
       command: '/kanvy',
       text: 'fix ABC-100',
       channel_id: 'C123',
       thread_ts: '1672531200.1234',
       team_id: 'team_one',
-      user_id: 'U1'
+      user_id: 'U1',
+      response_url: 'https://hooks.slack.com/commands/response'
     }).toString();
-    const timestamp = Math.floor(Date.now() / 1000).toString();
+    const timestamp = nowTs;
     const signature = await buildSlackSignature('secret', timestamp, rawBody);
     const request = new Request('https://example.test/api/integrations/slack/commands', {
       method: 'POST',
@@ -81,19 +138,224 @@ describe('slack handlers', () => {
     const waitUntil = vi.fn((task: Promise<unknown>) => {
       waitUntilTasks.push(task);
     });
-    const response = await handleSlackCommands(request, makeEnv('secret') as Env, { waitUntil } as ExecutionContext<unknown>);
+    const response = await handleSlackCommands(request, makeEnv('secret', repoBoard), { waitUntil } as ExecutionContext<unknown>);
     const body = await response.json() as { ok: boolean; text: string };
 
     expect(response.status).toBe(200);
     expect(body.ok).toBe(true);
     expect(waitUntil).toHaveBeenCalledTimes(1);
-    expect(waitUntilTasks).toHaveLength(1);
     await waitUntilTasks[0];
+    expect(repoBoard.createTask).toHaveBeenCalledWith(expect.objectContaining({
+      repoId: 'repo_alpha',
+      sourceRef: 'main',
+      llmAdapter: 'codex',
+      codexModel: 'gpt-5.3-codex-spark',
+      codexReasoningEffort: 'high'
+    }));
+    expect(repoBoard.startRun).toHaveBeenCalledWith('task_single', { tenantId: 'tenant_local' });
+    expect(repoBoard.transitionRun).toHaveBeenCalledWith('run_single', {
+      workflowInstanceId: 'workflow_1',
+      orchestrationMode: 'workflow'
+    });
+    expect(runOrchestratorMocks.scheduleRunJob).toHaveBeenCalledWith(
+      expect.anything(),
+      {
+        tenantId: 'tenant_local',
+        repoId: 'repo_alpha',
+        taskId: 'task_single',
+        runId: 'run_single',
+        mode: 'full_run'
+      },
+      expect.anything()
+    );
+    expect(tenantAuthDbMocks.deleteSlackThreadBinding).toHaveBeenCalledWith('tenant_local', 'issue:ABC-100', 'C123');
     expect(tenantAuthDbMocks.upsertSlackThreadBinding).toHaveBeenCalledWith({
       tenantId: 'tenant_local',
-      taskId: 'issue:ABC-100',
+      taskId: 'task_single',
       channelId: 'C123',
       threadTs: '1672531200.1234',
+      currentRunId: 'run_single',
+      latestReviewRound: 0
+    });
+  });
+
+  it('asks for repo disambiguation when multiple mappings exist', async () => {
+    tenantAuthDbMocks.listJiraProjectRepoMappingsByProject.mockResolvedValue([
+      { jiraProjectKey: 'ABC', repoId: 'repo_alpha', priority: 0, active: true, id: 'm1', tenantId: 'tenant_local', createdAt: '', updatedAt: '' },
+      { jiraProjectKey: 'ABC', repoId: 'repo_beta', priority: 1, active: true, id: 'm2', tenantId: 'tenant_local', createdAt: '', updatedAt: '' }
+    ]);
+
+    const rawBody = new URLSearchParams({
+      command: '/kanvy',
+      text: 'fix ABC-100',
+      channel_id: 'C123',
+      thread_ts: '1672531200.1234',
+      team_id: 'team_one',
+      user_id: 'U1',
+      response_url: 'https://hooks.slack.com/commands/response'
+    }).toString();
+    const timestamp = nowTs;
+    const signature = await buildSlackSignature('secret', timestamp, rawBody);
+    const request = new Request('https://example.test/api/integrations/slack/commands', {
+      method: 'POST',
+      headers: slackHeaders(timestamp, signature),
+      body: rawBody
+    });
+    const waitUntilTasks: Array<Promise<unknown>> = [];
+    const waitUntil = vi.fn((task: Promise<unknown>) => {
+      waitUntilTasks.push(task);
+    });
+    const response = await handleSlackCommands(request, makeEnv('secret'), { waitUntil } as ExecutionContext<unknown>);
+    const body = await response.json() as { ok: boolean; text: string };
+
+    expect(body.ok).toBe(true);
+    expect(waitUntil).toHaveBeenCalledTimes(1);
+    await waitUntilTasks[0];
+    const calledPayload = JSON.parse(((vi.mocked(global.fetch).mock.calls[0] as [string, RequestInit])[1].body as string));
+    expect(calledPayload.response_type).toBe('ephemeral');
+    expect(calledPayload.blocks[1].elements).toHaveLength(2);
+    expect(calledPayload.blocks[1].elements[0].action_id).toBe('repo_disambiguation');
+  });
+
+  it('returns a clear message when no mappings are resolvable and does not start a run', async () => {
+    const boardIndex = makeBoardIndex([
+      { repoId: 'repo_alpha', slug: 'alpha' },
+      { repoId: 'repo_beta', slug: 'beta' }
+    ]);
+    const repoBoard = makeRepoBoard({ taskId: 'task_none', runId: 'run_none' });
+    const rawBody = new URLSearchParams({
+      command: '/kanvy',
+      text: 'fix ABC-100',
+      channel_id: 'C123',
+      thread_ts: '1672531200.1234',
+      team_id: 'team_one',
+      user_id: 'U1',
+      response_url: 'https://hooks.slack.com/commands/response'
+    }).toString();
+    const timestamp = nowTs;
+    const signature = await buildSlackSignature('secret', timestamp, rawBody);
+    const request = new Request('https://example.test/api/integrations/slack/commands', {
+      method: 'POST',
+      headers: slackHeaders(timestamp, signature),
+      body: rawBody
+    });
+    const waitUntilTasks: Array<Promise<unknown>> = [];
+    const waitUntil = vi.fn((task: Promise<unknown>) => {
+      waitUntilTasks.push(task);
+    });
+    const response = await handleSlackCommands(request, makeEnv('secret', repoBoard, boardIndex), { waitUntil } as ExecutionContext<unknown>);
+    const body = await response.json() as { ok: boolean; text: string };
+
+    expect(body.ok).toBe(true);
+    expect(waitUntil).toHaveBeenCalledTimes(1);
+    await waitUntilTasks[0];
+    const calledPayload = JSON.parse(((vi.mocked(global.fetch).mock.calls[0] as [string, RequestInit])[1].body as string));
+    expect(calledPayload.text).toContain('No active mapping exists for project ABC.');
+    expect(calledPayload.blocks[1].elements).toHaveLength(2);
+    expect(repoBoard.createTask).not.toHaveBeenCalled();
+    expect(repoBoard.startRun).not.toHaveBeenCalled();
+  });
+
+  it('returns clear Jira read failure responses and does not create tasks', async () => {
+    const failingBoard = makeRepoBoard({ taskId: 'task_fail', runId: 'run_fail' });
+    jiraClientMocks.createJiraIssueSourceIntegrationFromEnv.mockReturnValue({
+      fetchIssue: vi.fn().mockRejectedValue(new Error('temporary outage'))
+    });
+
+    const rawBody = new URLSearchParams({
+      command: '/kanvy',
+      text: 'fix ABC-100',
+      channel_id: 'C123',
+      thread_ts: '1672531200.1234',
+      team_id: 'team_one',
+      user_id: 'U1',
+      response_url: 'https://hooks.slack.com/commands/response'
+    }).toString();
+    const timestamp = nowTs;
+    const signature = await buildSlackSignature('secret', timestamp, rawBody);
+    const request = new Request('https://example.test/api/integrations/slack/commands', {
+      method: 'POST',
+      headers: slackHeaders(timestamp, signature),
+      body: rawBody
+    });
+    const waitUntilTasks: Array<Promise<unknown>> = [];
+    const waitUntil = vi.fn((task: Promise<unknown>) => {
+      waitUntilTasks.push(task);
+    });
+    const response = await handleSlackCommands(request, makeEnv('secret', failingBoard), { waitUntil } as ExecutionContext<unknown>);
+    const body = await response.json() as { ok: boolean; text: string };
+
+    expect(body.ok).toBe(true);
+    expect(waitUntil).toHaveBeenCalledTimes(1);
+    await waitUntilTasks[0];
+    const calledPayload = JSON.parse(((vi.mocked(global.fetch).mock.calls[0] as [string, RequestInit])[1].body as string));
+    expect(calledPayload.text).toContain('Failed to process /kanvy command for ABC-100');
+    expect(calledPayload.text).toContain('temporary outage');
+    expect(failingBoard.createTask).not.toHaveBeenCalled();
+  });
+
+  it('starts task/run from repo_disambiguation interaction', async () => {
+    const repoBoard = makeRepoBoard({ taskId: 'task_interaction', runId: 'run_interaction' });
+    const payload = {
+      type: 'block_actions',
+      container: { channel_id: 'C123', thread_ts: '1672531200.1234' },
+      actions: [
+        {
+          action_id: 'repo_disambiguation',
+          value: JSON.stringify({
+            tenantId: 'tenant_local',
+            taskId: 'issue:ABC-100',
+            channelId: 'C123',
+            threadTs: '1672531200.1234',
+            issueKey: 'ABC-100',
+            issueTitle: 'Cannot login',
+            issueBody: 'Button fails',
+            issueUrl: 'https://jira.test.com/browse/ABC-100',
+            repoId: 'repo_alpha'
+          })
+        }
+      ]
+    };
+    const rawBody = new URLSearchParams({ payload: JSON.stringify(payload) }).toString();
+    const timestamp = nowTs;
+    const signature = await buildSlackSignature('secret', timestamp, rawBody);
+    const request = new Request('https://example.test/api/integrations/slack/interactions', {
+      method: 'POST',
+      headers: slackHeaders(timestamp, signature),
+      body: rawBody
+    });
+    const response = await handleSlackInteractions(request, makeEnv('secret', repoBoard), {} as ExecutionContext<unknown>);
+    const responseBody = await response.json() as { ok: true; action: string; taskId: string; runId: string; repoId: string };
+
+    expect(responseBody).toMatchObject({
+      ok: true,
+      action: 'repo_disambiguation',
+      taskId: 'task_interaction',
+      runId: 'run_interaction',
+      repoId: 'repo_alpha'
+    });
+    expect(repoBoard.createTask).toHaveBeenCalledWith(expect.objectContaining({
+      repoId: 'repo_alpha',
+      sourceRef: 'main'
+    }));
+    expect(repoBoard.startRun).toHaveBeenCalledWith('task_interaction', { tenantId: 'tenant_local' });
+    expect(runOrchestratorMocks.scheduleRunJob).toHaveBeenCalledWith(
+      expect.anything(),
+      {
+        tenantId: 'tenant_local',
+        repoId: 'repo_alpha',
+        taskId: 'task_interaction',
+        runId: 'run_interaction',
+        mode: 'full_run'
+      },
+      expect.anything()
+    );
+    expect(tenantAuthDbMocks.upsertSlackThreadBinding).toHaveBeenCalledWith({
+      tenantId: 'tenant_local',
+      taskId: 'task_interaction',
+      channelId: 'C123',
+      threadTs: '1672531200.1234',
+      currentRunId: 'run_interaction',
       latestReviewRound: 0
     });
   });
@@ -108,9 +370,13 @@ describe('slack handlers', () => {
           action_id: 'repo_disambiguation',
           value: JSON.stringify({
             tenantId: 'tenant_local',
-            taskId: 'task_1',
+            taskId: 'issue:ABC-100',
             channelId: 'C123',
             threadTs: '1672531200.1234',
+            issueKey: 'ABC-100',
+            issueTitle: 'Cannot login',
+            issueBody: 'Button fails',
+            issueUrl: 'https://jira.test.com/browse/ABC-100',
             latestReviewRound: 1,
             repoId: 'repo_alpha'
           })
@@ -148,32 +414,24 @@ describe('slack handlers', () => {
     };
 
     const repoBody = new URLSearchParams({ payload: JSON.stringify(repoDisambiguationPayload) }).toString();
-    const timestamp = Math.floor(Date.now() / 1000).toString();
-    const repoSig = await buildSlackSignature('secret', timestamp, repoBody);
+    const repoSig = await buildSlackSignature('secret', nowTs, repoBody);
 
     const repoRequest = new Request('https://example.test/api/integrations/slack/interactions', {
       method: 'POST',
-      headers: slackHeaders(timestamp, repoSig),
+      headers: slackHeaders(nowTs, repoSig),
       body: repoBody
     });
-    const repoResponse = await handleSlackInteractions(repoRequest, makeEnv('secret') as Env);
+    const repoResponse = await handleSlackInteractions(repoRequest, makeEnv('secret'), {} as ExecutionContext<unknown>);
     expect(await repoResponse.json()).toMatchObject({ ok: true, action: 'repo_disambiguation' });
-    expect(tenantAuthDbMocks.upsertSlackThreadBinding).toHaveBeenCalledWith({
-      tenantId: 'tenant_local',
-      taskId: 'task_1',
-      channelId: 'C123',
-      threadTs: '1672531200.1234',
-      latestReviewRound: 1
-    });
 
     const approveBody = new URLSearchParams({ payload: JSON.stringify(approvePayload) }).toString();
-    const approveSig = await buildSlackSignature('secret', timestamp, approveBody);
+    const approveSig = await buildSlackSignature('secret', nowTs, approveBody);
     const approveRequest = new Request('https://example.test/api/integrations/slack/interactions', {
       method: 'POST',
-      headers: slackHeaders(timestamp, approveSig),
+      headers: slackHeaders(nowTs, approveSig),
       body: approveBody
     });
-    const approveResponse = await handleSlackInteractions(approveRequest, makeEnv('secret') as Env);
+    const approveResponse = await handleSlackInteractions(approveRequest, makeEnv('secret'), {} as ExecutionContext<unknown>);
     expect(await approveResponse.json()).toMatchObject({ ok: true, action: 'approve_rerun' });
     expect(tenantAuthDbMocks.upsertSlackThreadBinding).toHaveBeenCalledWith({
       tenantId: 'tenant_local',
@@ -185,13 +443,13 @@ describe('slack handlers', () => {
     });
 
     const pauseBody = new URLSearchParams({ payload: JSON.stringify(pausePayload) }).toString();
-    const pauseSig = await buildSlackSignature('secret', timestamp, pauseBody);
+    const pauseSig = await buildSlackSignature('secret', nowTs, pauseBody);
     const pauseRequest = new Request('https://example.test/api/integrations/slack/interactions', {
       method: 'POST',
-      headers: slackHeaders(timestamp, pauseSig),
+      headers: slackHeaders(nowTs, pauseSig),
       body: pauseBody
     });
-    const pauseResponse = await handleSlackInteractions(pauseRequest, makeEnv('secret') as Env);
+    const pauseResponse = await handleSlackInteractions(pauseRequest, makeEnv('secret'), {} as ExecutionContext<unknown>);
     expect(await pauseResponse.json()).toMatchObject({ ok: true, action: 'pause' });
     expect(tenantAuthDbMocks.upsertSlackThreadBinding).toHaveBeenCalledWith({
       tenantId: 'tenant_local',
@@ -219,7 +477,7 @@ describe('slack handlers', () => {
     };
 
     const rawBody = new URLSearchParams({ payload: JSON.stringify(payload) }).toString();
-    const timestamp = Math.floor(Date.now() / 1000).toString();
+    const timestamp = nowTs;
     const signature = await buildSlackSignature('secret', timestamp, rawBody);
     const request = new Request('https://example.test/api/integrations/slack/interactions', {
       method: 'POST',
@@ -227,7 +485,7 @@ describe('slack handlers', () => {
       body: rawBody
     });
 
-    const response = await handleSlackInteractions(request, makeEnv('secret') as Env);
+    const response = await handleSlackInteractions(request, makeEnv('secret'), {} as ExecutionContext<unknown>);
     expect(await response.json()).toMatchObject({ ok: true, action: 'close' });
     expect(tenantAuthDbMocks.deleteSlackThreadBinding).toHaveBeenCalledWith('tenant_local', 'task_1', 'C123');
   });
@@ -235,14 +493,14 @@ describe('slack handlers', () => {
   it('acknowledges event verification challenge', async () => {
     const event = { type: 'url_verification', challenge: 'challenge-123' };
     const rawBody = JSON.stringify(event);
-    const timestamp = Math.floor(Date.now() / 1000).toString();
+    const timestamp = nowTs;
     const signature = await buildSlackSignature('secret', timestamp, rawBody);
     const request = new Request('https://example.test/api/integrations/slack/events', {
       method: 'POST',
       headers: slackHeaders(timestamp, signature),
       body: rawBody
     });
-    const response = await handleSlackEvents(request, makeEnv('secret') as Env);
+    const response = await handleSlackEvents(request, makeEnv('secret'));
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual({ challenge: 'challenge-123' });
   });

--- a/src/server/integrations/slack/handlers.ts
+++ b/src/server/integrations/slack/handlers.ts
@@ -1,6 +1,9 @@
+import type { IntegrationIssueRef } from '../interfaces';
 import { badRequest } from '../../http/errors';
 import { handleError, json } from '../../http/response';
 import * as tenantAuthDb from '../../tenant-auth-db';
+import { createJiraIssueSourceIntegrationFromEnv } from '../jira/client';
+import { scheduleRunJob } from '../run-orchestrator';
 import {
   parseSlackEventBody,
   parseSlackInteractionBody,
@@ -11,13 +14,260 @@ import { resolveThreadTenant, verifySlackRequest } from './verification';
 
 const DEFAULT_TASK_ID_PREFIX = 'issue';
 const DEFAULT_REVIEW_ROUND = 0;
+const BOARD_OBJECT_NAME = 'agentboard';
+const SOURCE_REF = 'main';
+const JIRA_LLM_ADAPTER = 'codex';
+const JIRA_LLM_MODEL = 'gpt-5.3-codex-spark';
+const JIRA_LLM_REASONING_EFFORT = 'high';
+const FALLBACK_DISAMBIGUATION_WARNING = 'No matching repository was auto-selected for this issue.';
+const DISAMBIGUATION_MULTIPLE_MAPPINGS_MESSAGE = 'Multiple repositories are mapped for Jira project';
+const DISAMBIGUATION_NO_MAPPING_MESSAGE = 'No active mapping exists for project';
+
+type RepoDisambiguationChoice = {
+  repoId: string;
+  label: string;
+};
+
+type RunKickoff = {
+  taskId: string;
+  runId: string;
+};
 
 function buildTaskIdFromIssue(issueKey: string) {
   return `${DEFAULT_TASK_ID_PREFIX}:${issueKey}`;
 }
 
+function issueProjectKeyFromIssue(issueKey: string) {
+  const match = issueKey.match(/^[A-Z][A-Z0-9_]*-/i);
+  if (!match) {
+    return issueKey;
+  }
+  return match[0].slice(0, -1).toUpperCase();
+}
+
+function executionContextOrNoop(ctx?: ExecutionContext<unknown>): ExecutionContext<unknown> {
+  return ctx ?? ({ waitUntil: () => {} } as ExecutionContext<unknown>);
+}
+
+function toReadableErrorMessage(error: unknown) {
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+  return 'Unknown error.';
+}
+
+function buildTaskPromptFromIssue(issue: IntegrationIssueRef) {
+  return `Fix Jira issue ${issue.issueKey}: ${issue.title}\n\n${issue.body}`.trim();
+}
+
+function buildTaskPayloadFromIssue(issue: IntegrationIssueRef, repoId: string) {
+  return {
+    repoId,
+    title: `[${issue.issueKey}] ${issue.title}`.trim(),
+    description: issue.body,
+    sourceRef: SOURCE_REF,
+    taskPrompt: buildTaskPromptFromIssue(issue),
+    acceptanceCriteria: [
+      `Fix ${issue.issueKey} in the mapped repository.`
+    ],
+    context: {
+      links: issue.url
+        ? [{ id: `jira:${issue.issueKey}`, label: `Jira issue ${issue.issueKey}`, url: issue.url }]
+        : [],
+      notes: `Imported from Jira issue ${issue.issueKey}: ${issue.title}`
+    },
+    llmAdapter: JIRA_LLM_ADAPTER,
+    codexModel: JIRA_LLM_MODEL,
+    codexReasoningEffort: JIRA_LLM_REASONING_EFFORT
+  };
+}
+
+function buildRepoCandidateValue(value: {
+  tenantId: string;
+  taskId: string;
+  channelId: string;
+  threadTs: string;
+  issueKey: string;
+  issueTitle?: string;
+  issueBody?: string;
+  issueUrl?: string;
+  repoId: string;
+}) {
+  return JSON.stringify({
+    tenantId: value.tenantId,
+    taskId: value.taskId,
+    channelId: value.channelId,
+    threadTs: value.threadTs,
+    issueKey: value.issueKey,
+    issueTitle: value.issueTitle,
+    issueBody: value.issueBody,
+    issueUrl: value.issueUrl,
+    repoId: value.repoId
+  });
+}
+
+async function postSlackResponse(responseUrl: string | undefined, payload: unknown) {
+  if (!responseUrl) {
+    return;
+  }
+  try {
+    await fetch(responseUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    });
+  } catch {
+    // Slack responses are best-effort from the platform side.
+  }
+}
+
+function buildDisambiguationResponse(
+  issue: IntegrationIssueRef,
+  issueProjectKey: string,
+  options: RepoDisambiguationChoice[],
+  tenantId: string,
+  isNoMapping: boolean,
+  taskBindingContext: {
+    taskId: string;
+    channelId: string;
+    threadTs: string;
+  }
+) {
+  const actions = options.map((option) => ({
+    type: 'button' as const,
+    text: { type: 'plain_text' as const, text: option.label },
+    action_id: 'repo_disambiguation',
+    value: buildRepoCandidateValue({
+      tenantId,
+      taskId: taskBindingContext.taskId,
+      channelId: taskBindingContext.channelId,
+      threadTs: taskBindingContext.threadTs,
+      issueKey: issue.issueKey,
+      issueTitle: issue.title,
+      issueBody: issue.body,
+      issueUrl: issue.url,
+      repoId: option.repoId
+    })
+  }));
+
+  const warning = isNoMapping
+    ? issueProjectKey
+      ? `${DISAMBIGUATION_NO_MAPPING_MESSAGE} ${issueProjectKey}.`
+      : FALLBACK_DISAMBIGUATION_WARNING
+    : issueProjectKey
+      ? `${DISAMBIGUATION_MULTIPLE_MAPPINGS_MESSAGE} ${issueProjectKey}.`
+      : 'Multiple repository candidates were found.';
+
+  return {
+    response_type: 'ephemeral' as const,
+    replace_original: false,
+    text: `${warning} Pick a repository to continue for ${issue.issueKey}.`,
+    blocks: [
+      {
+        type: 'section' as const,
+        text: { type: 'mrkdwn' as const, text: `${warning} Pick a repository to continue for ${issue.issueKey}.` }
+      },
+      ...(options.length > 0 ? [{
+        type: 'actions' as const,
+        elements: actions
+      }] : [])
+    ]
+  };
+}
+
+function buildNoMappingResponse(issue: IntegrationIssueRef, issueProjectKey: string) {
+  return {
+    response_type: 'ephemeral' as const,
+    text: `${FALLBACK_DISAMBIGUATION_WARNING} ${issueProjectKey ? `No active mapping exists for project ${issueProjectKey}.` : ''} ${issue.issueKey} will not start automatically.`
+  };
+}
+
 function normalizeLatestReviewRound(value: number | undefined) {
   return Number.isFinite(value) ? Number(value) : DEFAULT_REVIEW_ROUND;
+}
+
+function normalizeJiraIssueFromInteraction(values: {
+  issueKey: string;
+  issueTitle?: string;
+  issueBody?: string;
+  issueUrl?: string;
+}) {
+  return {
+    issueKey: values.issueKey,
+    title: values.issueTitle || values.issueKey,
+    body: values.issueBody || 'No description provided.',
+    url: values.issueUrl
+  };
+}
+
+async function resolveRepoCandidates(
+  env: Env,
+  tenantId: string,
+  issueProjectKey: string,
+  mappings: Array<{ repoId: string }>
+): Promise<RepoDisambiguationChoice[]> {
+  if (mappings.length > 0) {
+    return mappings.map((entry) => ({ repoId: entry.repoId, label: entry.repoId }));
+  }
+  const boardIndex = env.BOARD_INDEX?.getByName(BOARD_OBJECT_NAME);
+  if (!boardIndex) {
+    return [];
+  }
+  try {
+    const repos = await boardIndex.listRepos(tenantId);
+    return repos
+      .filter((repo) => repo.repoId)
+      .map((repo) => ({ repoId: repo.repoId, label: `${repo.slug} (${repo.repoId})` }));
+  } catch {
+    return [];
+  }
+}
+
+async function startRunForTask(
+  env: Env,
+  ctx: ExecutionContext<unknown> | undefined,
+  tenantId: string,
+  repoId: string,
+  taskPayload: ReturnType<typeof buildTaskPayloadFromIssue>
+): Promise<RunKickoff> {
+  const repoBoard = env.REPO_BOARD.getByName(repoId);
+  const task = await repoBoard.createTask(taskPayload);
+  const run = await repoBoard.startRun(task.taskId, { tenantId });
+  const workflow = await scheduleRunJob(env, executionContextOrNoop(ctx), {
+    tenantId,
+    repoId,
+    taskId: task.taskId,
+    runId: run.runId,
+    mode: 'full_run'
+  });
+  await repoBoard.transitionRun(run.runId, {
+    workflowInstanceId: workflow.id,
+    orchestrationMode: workflow.id.startsWith('local-alarm-') ? 'local_alarm' : 'workflow'
+  });
+  return { taskId: task.taskId, runId: run.runId };
+}
+
+async function syncSlackBindingAfterRunStart(
+  env: Env,
+  tenantId: string,
+  existingTaskId: string,
+  binding: {
+    taskId: string;
+    channelId: string;
+    threadTs: string;
+    runId: string;
+    latestReviewRound: number;
+  }
+) {
+  await tenantAuthDb.deleteSlackThreadBinding(env, tenantId, existingTaskId, binding.channelId).catch(() => {});
+  await tenantAuthDb.upsertSlackThreadBinding(env, {
+    tenantId,
+    taskId: binding.taskId,
+    channelId: binding.channelId,
+    threadTs: binding.threadTs,
+    currentRunId: binding.runId,
+    latestReviewRound: binding.latestReviewRound
+  });
 }
 
 async function createThreadBindingForSlashCommand(
@@ -28,13 +278,99 @@ async function createThreadBindingForSlashCommand(
   threadTs: string
 ) {
   const taskId = buildTaskIdFromIssue(commandIssueKey);
-  return tenantAuthDb.upsertSlackThreadBinding(env, {
+  await tenantAuthDb.upsertSlackThreadBinding(env, {
     tenantId,
     taskId,
     channelId,
     threadTs,
     latestReviewRound: DEFAULT_REVIEW_ROUND
   });
+  return taskId;
+}
+
+async function resolveTenantAndJiraIssue(env: Env, tenantId: string, issueKey: string): Promise<IntegrationIssueRef> {
+  const jira = createJiraIssueSourceIntegrationFromEnv(env, tenantId);
+  return jira.fetchIssue(issueKey, tenantId);
+}
+
+async function processJiraIssueFlow(
+  env: Env,
+  ctx: ExecutionContext<unknown> | undefined,
+  tenantId: string,
+  issue: IntegrationIssueRef,
+  bindings: {
+    taskId: string;
+    channelId: string;
+    threadTs?: string;
+    latestReviewRound?: number;
+  },
+  responseUrl: string | undefined
+) {
+  const issueProjectKey = issueProjectKeyFromIssue(issue.issueKey);
+  const mappings = await tenantAuthDb.listJiraProjectRepoMappingsByProject(env, tenantId, issueProjectKey, true);
+  if (mappings.length === 0) {
+    const candidates = await resolveRepoCandidates(env, tenantId, issueProjectKey, []);
+    if (candidates.length === 0) {
+      await postSlackResponse(responseUrl, buildNoMappingResponse(issue, issueProjectKey));
+      return;
+    }
+    await postSlackResponse(responseUrl, buildDisambiguationResponse(
+      issue,
+      issueProjectKey,
+      candidates,
+      tenantId,
+      true,
+      { taskId: bindings.taskId, channelId: bindings.channelId, threadTs: bindings.threadTs ?? '' }
+    ));
+    return;
+  }
+
+  const candidates = await resolveRepoCandidates(env, tenantId, issueProjectKey, mappings);
+  if (mappings.length > 1) {
+    if (candidates.length === 0) {
+      await postSlackResponse(responseUrl, buildNoMappingResponse(issue, issueProjectKey));
+      return;
+    }
+    await postSlackResponse(responseUrl, buildDisambiguationResponse(
+      issue,
+      issueProjectKey,
+      candidates,
+      tenantId,
+      false,
+      { taskId: bindings.taskId, channelId: bindings.channelId, threadTs: bindings.threadTs ?? '' }
+    ));
+    return;
+  }
+
+  if (candidates.length !== 1) {
+    await postSlackResponse(responseUrl, buildNoMappingResponse(issue, issueProjectKey));
+    return;
+  }
+
+  const repoId = candidates[0]!.repoId;
+  const payload = buildTaskPayloadFromIssue(issue, repoId);
+  try {
+    const started = await startRunForTask(env, ctx, tenantId, repoId, payload);
+    if (bindings.threadTs) {
+      await syncSlackBindingAfterRunStart(env, tenantId, bindings.taskId, {
+        taskId: started.taskId,
+        channelId: bindings.channelId,
+        threadTs: bindings.threadTs,
+        runId: started.runId,
+        latestReviewRound: normalizeLatestReviewRound(bindings.latestReviewRound)
+      });
+    }
+    await postSlackResponse(responseUrl, {
+      response_type: 'ephemeral',
+      text: `Started ${issue.issueKey} in repo ${repoId} (task ${started.taskId}, run ${started.runId}).`
+    });
+  } catch (error) {
+    await postSlackResponse(responseUrl, {
+      response_type: 'ephemeral',
+      text: `Failed to start a run for ${issue.issueKey}: ${toReadableErrorMessage(error)}`
+    });
+    throw error;
+  }
 }
 
 async function resolveThreadTenantId(env: Env, teamId: string | undefined) {
@@ -47,6 +383,9 @@ async function updateBindingForAction(
   tenantId: string,
   interaction: ParsedSlackInteraction
 ) {
+  if (interaction.actionId === 'repo_disambiguation') {
+    return;
+  }
   if (!interaction.taskId) {
     throw badRequest('Missing task identifier.');
   }
@@ -78,12 +417,74 @@ async function updateBindingForAction(
   });
 }
 
-async function runSlackCommandAsync(env: Env, payload: ReturnType<typeof parseSlackSlashCommandBody>) {
+async function runSlackCommandAsync(
+  env: Env,
+  payload: ReturnType<typeof parseSlackSlashCommandBody>,
+  ctx?: ExecutionContext<unknown>
+) {
   const tenantId = await resolveThreadTenantId(env, payload.teamId);
-  if (!payload.threadTs) {
-    return;
+  const bindingTaskId = payload.threadTs
+    ? await createThreadBindingForSlashCommand(env, tenantId, payload.issueKey, payload.channelId, payload.threadTs)
+    : buildTaskIdFromIssue(payload.issueKey);
+
+  try {
+    const issue = await resolveTenantAndJiraIssue(env, tenantId, payload.issueKey);
+    await processJiraIssueFlow(env, ctx, tenantId, issue, {
+      taskId: bindingTaskId,
+      channelId: payload.channelId,
+      threadTs: payload.threadTs,
+      latestReviewRound: DEFAULT_REVIEW_ROUND
+    }, payload.responseUrl);
+  } catch (error) {
+    await postSlackResponse(payload.responseUrl, {
+      response_type: 'ephemeral',
+      text: `Failed to process /kanvy command for ${payload.issueKey}: ${toReadableErrorMessage(error)}`
+    });
   }
-  await createThreadBindingForSlashCommand(env, tenantId, payload.issueKey, payload.channelId, payload.threadTs);
+}
+
+async function handleRepoDisambiguationAction(
+  env: Env,
+  ctx: ExecutionContext<unknown> | undefined,
+  tenantId: string,
+  interaction: ParsedSlackInteraction
+): Promise<Response> {
+  const repoId = interaction.repoId?.trim();
+  const issueKey = interaction.issueKey?.trim();
+  if (!repoId || !issueKey) {
+    throw badRequest('Missing repository or issue context in repo disambiguation action.');
+  }
+
+  const issue = normalizeJiraIssueFromInteraction({
+    issueKey,
+    issueTitle: interaction.issueTitle,
+    issueBody: interaction.issueBody,
+    issueUrl: interaction.issueUrl
+  });
+
+  const resolvedIssue = issue.title === issueKey && issue.body === 'No description provided.'
+    ? await resolveTenantAndJiraIssue(env, tenantId, issueKey)
+    : issue;
+
+  const payload = buildTaskPayloadFromIssue(resolvedIssue, repoId);
+  const started = await startRunForTask(env, ctx, tenantId, repoId, payload);
+  if (interaction.threadTs) {
+    await syncSlackBindingAfterRunStart(env, tenantId, interaction.taskId, {
+      taskId: started.taskId,
+      channelId: interaction.channelId,
+      threadTs: interaction.threadTs,
+      runId: started.runId,
+      latestReviewRound: normalizeLatestReviewRound(interaction.latestReviewRound)
+    });
+  }
+
+  return json({
+    ok: true,
+    action: interaction.actionId,
+    taskId: started.taskId,
+    runId: started.runId,
+    repoId
+  });
 }
 
 export async function handleSlackCommands(
@@ -95,9 +496,8 @@ export async function handleSlackCommands(
     const rawBody = await request.text();
     await verifySlackRequest(env, request, rawBody);
     const payload = parseSlackSlashCommandBody(rawBody);
-    const job = runSlackCommandAsync(env, payload);
+    const job = runSlackCommandAsync(env, payload, ctx);
     if (ctx?.waitUntil) {
-      // Keep ack path fast and defer persistence to platform context.
       ctx.waitUntil(job);
     } else {
       await job;
@@ -125,12 +525,19 @@ export async function handleSlackEvents(request: Request, env: Env): Promise<Res
   }
 }
 
-export async function handleSlackInteractions(request: Request, env: Env): Promise<Response> {
+export async function handleSlackInteractions(
+  request: Request,
+  env: Env,
+  ctx: ExecutionContext<unknown>
+): Promise<Response> {
   try {
     const rawBody = await request.text();
     await verifySlackRequest(env, request, rawBody);
     const interaction = parseSlackInteractionBody(rawBody);
     const tenantId = await resolveThreadTenantId(env, interaction.tenantId || interaction.teamId);
+    if (interaction.actionId === 'repo_disambiguation') {
+      return handleRepoDisambiguationAction(env, ctx, tenantId, interaction);
+    }
     await updateBindingForAction(env, tenantId, interaction);
     return json({
       ok: true,

--- a/src/server/integrations/slack/payload.ts
+++ b/src/server/integrations/slack/payload.ts
@@ -21,6 +21,10 @@ export type SlackInteractionValue = {
   currentRunId?: string;
   latestReviewRound?: number;
   repoId?: string;
+  issueKey?: string;
+  issueTitle?: string;
+  issueBody?: string;
+  issueUrl?: string;
 };
 
 export type ParsedSlackInteraction = {
@@ -33,6 +37,10 @@ export type ParsedSlackInteraction = {
   currentRunId?: string;
   latestReviewRound?: number;
   repoId?: string;
+  issueKey?: string;
+  issueTitle?: string;
+  issueBody?: string;
+  issueUrl?: string;
 };
 
 type SlackEventPayload = {
@@ -74,6 +82,17 @@ function parseInteractionValue(raw: string | undefined): SlackInteractionValue {
     throw badRequest('Invalid Slack interaction action value.');
   }
   throw badRequest('Invalid Slack interaction action value.');
+}
+
+function readOptionalString(value: unknown, field: string): string | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    return trimmed ? trimmed : undefined;
+  }
+  throw badRequest(`Invalid Slack interaction value ${field}.`);
 }
 
 function readOptionalNumber(value: unknown, field: string): number | undefined {
@@ -173,10 +192,14 @@ export function parseSlackInteractionBody(rawBody: string): ParsedSlackInteracti
       ? value.threadTs.trim()
       : typeof (container?.thread_ts) === 'string' && container?.thread_ts.trim()
         ? String(container.thread_ts).trim()
-        : (() => { throw badRequest('Missing Slack interaction thread.'); })(),
+        : '',
     currentRunId: typeof value.currentRunId === 'string' && value.currentRunId.trim() ? value.currentRunId.trim() : undefined,
     latestReviewRound: readOptionalNumber(value.latestReviewRound, 'latestReviewRound'),
-    repoId: typeof value.repoId === 'string' && value.repoId.trim() ? value.repoId.trim() : undefined
+    repoId: readOptionalString(value.repoId, 'repoId'),
+    issueKey: readOptionalString(value.issueKey, 'issueKey'),
+    issueTitle: readOptionalString(value.issueTitle, 'issueTitle'),
+    issueBody: readOptionalString(value.issueBody, 'issueBody'),
+    issueUrl: readOptionalString(value.issueUrl, 'issueUrl')
   };
 }
 

--- a/src/server/router.ts
+++ b/src/server/router.ts
@@ -77,8 +77,8 @@ export async function handleSlackEvents(request: Request, env: Env): Promise<Res
   return handleSlackEventsHandler(request, env);
 }
 
-export async function handleSlackInteractions(request: Request, env: Env): Promise<Response> {
-  return handleSlackInteractionsHandler(request, env);
+export async function handleSlackInteractions(request: Request, env: Env, ctx: ExecutionContext<unknown>): Promise<Response> {
+  return handleSlackInteractionsHandler(request, env, ctx);
 }
 
 export async function handleAuthSignup(request: Request, env: Env): Promise<Response> {


### PR DESCRIPTION
Task: T3 - Jira Read Adapter + Repo Resolution + Run Kickoff

Implement platform-side Jira read flow, repo resolution, and Slack-triggered task/run creation from main.
Source ref: main

Acceptance criteria:
- Slack command with a mapped Jira project creates a task and starts a run without dashboard interaction.
- Ambiguous or missing mapping is resolved through Slack interaction.
- Jira read failures are surfaced clearly and do not leave orphan runs.
- Run starts from main with codex spark high profile.

Run ID: run_repo_abuiles_agents_kanban_mmbem5teyvmg