### PR TITLE
S1 - Sentinel Domain and Persistence Foundation

### DIFF
--- a/migrations/0002_sentinel_foundation.sql
+++ b/migrations/0002_sentinel_foundation.sql
@@ -1,0 +1,51 @@
+CREATE TABLE IF NOT EXISTS repo_sentinel_configs (
+  id INTEGER PRIMARY KEY,
+  external_id TEXT NOT NULL UNIQUE,
+  tenant_id TEXT NOT NULL,
+  repo_id TEXT NOT NULL,
+  config_json TEXT NOT NULL DEFAULT '{}',
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  UNIQUE (tenant_id, repo_id)
+);
+
+CREATE TABLE IF NOT EXISTS sentinel_runs (
+  id INTEGER PRIMARY KEY,
+  external_id TEXT NOT NULL UNIQUE,
+  tenant_id TEXT NOT NULL,
+  repo_id TEXT NOT NULL,
+  scope_type TEXT NOT NULL CHECK (scope_type IN ('group', 'global')),
+  scope_value TEXT,
+  status TEXT NOT NULL CHECK (status IN ('running', 'paused', 'stopped', 'failed', 'completed')),
+  current_task_id TEXT,
+  current_run_id TEXT,
+  attempt_count INTEGER NOT NULL DEFAULT 0,
+  started_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS sentinel_events (
+  id INTEGER PRIMARY KEY,
+  external_id TEXT NOT NULL UNIQUE,
+  sentinel_run_id TEXT NOT NULL,
+  tenant_id TEXT NOT NULL,
+  repo_id TEXT NOT NULL,
+  at TEXT NOT NULL,
+  level TEXT NOT NULL CHECK (level IN ('info', 'warn', 'error')),
+  type TEXT NOT NULL,
+  message TEXT NOT NULL,
+  metadata_json TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_repo_sentinel_configs_tenant_repo
+  ON repo_sentinel_configs (tenant_id, repo_id);
+
+CREATE INDEX IF NOT EXISTS idx_sentinel_runs_tenant_repo_status
+  ON sentinel_runs (tenant_id, repo_id, status, started_at DESC);
+CREATE INDEX IF NOT EXISTS idx_sentinel_runs_scope
+  ON sentinel_runs (tenant_id, scope_type, scope_value, started_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_sentinel_events_tenant_repo_at
+  ON sentinel_events (tenant_id, repo_id, at DESC);
+CREATE INDEX IF NOT EXISTS idx_sentinel_events_run_at
+  ON sentinel_events (sentinel_run_id, at DESC);

--- a/src/server/durable/board-index.ts
+++ b/src/server/durable/board-index.ts
@@ -7,6 +7,7 @@ import type { BoardEvent } from '../shared/events';
 import { stringifyBoardEvent } from '../shared/events';
 import { buildBoardSnapshot, type BoardSyncResponse } from '../shared/state';
 import { buildRepoScmKey, getRepoHost, getRepoProjectPath, normalizeCredentialHost, normalizeRepo } from '../../shared/scm';
+import { DEFAULT_REPO_SENTINEL_CONFIG, normalizeRepoSentinelConfig } from '../../shared/sentinel';
 import { DEFAULT_TENANT_ID, normalizeTenantId } from '../../shared/tenant';
 
 const REPOS_STORAGE_KEY = 'board-index-repos';
@@ -757,17 +758,37 @@ export class BoardIndexDO extends DurableObject<Env> {
     await this.ready;
     const existing = await this.getRepo(repoId);
     const hasAutoReviewPatch = Object.prototype.hasOwnProperty.call(patch, 'autoReview');
+    const hasSentinelConfigPatch = Object.prototype.hasOwnProperty.call(patch, 'sentinelConfig');
     const mergedAutoReview = hasAutoReviewPatch
       ? {
           ...(existing.autoReview ?? { enabled: false, provider: 'gitlab', postInline: false }),
           ...patch.autoReview
         }
       : existing.autoReview;
+    const mergedSentinelConfig = hasSentinelConfigPatch
+      ? {
+          ...(existing.sentinelConfig ?? {}),
+          ...patch.sentinelConfig,
+          reviewGate: {
+            ...(existing.sentinelConfig?.reviewGate ?? {}),
+            ...(patch.sentinelConfig?.reviewGate ?? {})
+          },
+          mergePolicy: {
+            ...(existing.sentinelConfig?.mergePolicy ?? {}),
+            ...(patch.sentinelConfig?.mergePolicy ?? {})
+          },
+          conflictPolicy: {
+            ...(existing.sentinelConfig?.conflictPolicy ?? {}),
+            ...(patch.sentinelConfig?.conflictPolicy ?? {})
+          }
+        }
+      : existing.sentinelConfig;
 
     const updated = buildRepoRecord({
       ...existing,
       ...patch,
       autoReview: mergedAutoReview,
+      sentinelConfig: mergedSentinelConfig,
       slug: patch.slug ?? patch.projectPath ?? existing.slug,
       projectPath: patch.projectPath ?? patch.slug ?? existing.projectPath,
       repoId: existing.repoId,
@@ -1178,6 +1199,24 @@ function buildRepoRecord(input: CreateRepoInput | Repo): Repo {
     postInline: input.autoReview?.postInline ?? false,
     ...(input.autoReview?.prompt ? { prompt: input.autoReview.prompt.trim() } : {})
   };
+  const normalizedSentinelConfig = normalizeRepoSentinelConfig({
+    sentinelConfig: {
+      ...DEFAULT_REPO_SENTINEL_CONFIG,
+      ...input.sentinelConfig,
+      reviewGate: {
+        ...DEFAULT_REPO_SENTINEL_CONFIG.reviewGate,
+        ...(input.sentinelConfig?.reviewGate ?? {})
+      },
+      mergePolicy: {
+        ...DEFAULT_REPO_SENTINEL_CONFIG.mergePolicy,
+        ...(input.sentinelConfig?.mergePolicy ?? {})
+      },
+      conflictPolicy: {
+        ...DEFAULT_REPO_SENTINEL_CONFIG.conflictPolicy,
+        ...(input.sentinelConfig?.conflictPolicy ?? {})
+      }
+    }
+  }).sentinelConfig;
 
   const normalized = normalizeRepo({
     ...input,
@@ -1186,6 +1225,7 @@ function buildRepoRecord(input: CreateRepoInput | Repo): Repo {
     baselineUrl: input.baselineUrl,
     enabled: input.enabled ?? true,
     autoReview: normalizedAutoReview,
+    sentinelConfig: normalizedSentinelConfig,
     llmAdapter: input.llmAdapter,
     llmProfileId: input.llmProfileId,
     githubAuthMode: 'githubAuthMode' in input ? input.githubAuthMode : undefined,

--- a/src/server/durable/repo-board.ts
+++ b/src/server/durable/repo-board.ts
@@ -84,11 +84,13 @@ export class RepoBoardDO extends DurableObject<Env> {
     return this.state.runs.some((run) => run.runId === runId);
   }
 
-  async listTasks(tenantId?: string) {
+  async listTasks(tenantId?: string, options?: { tags?: string[] }) {
     await this.ready;
     const normalizedTenantId = tenantId ? normalizeTenantId(tenantId) : undefined;
+    const tags = normalizeTaskTags(options?.tags);
     return [...this.state.tasks]
       .filter((task) => !normalizedTenantId || normalizeTenantId(task.tenantId) === normalizedTenantId)
+      .filter((task) => !tags || tags.every((tag) => task.tags?.includes(tag)))
       .sort((left, right) => right.updatedAt.localeCompare(left.updatedAt));
   }
 
@@ -128,6 +130,7 @@ export class RepoBoardDO extends DurableObject<Env> {
       taskPrompt: input.taskPrompt,
       acceptanceCriteria: input.acceptanceCriteria,
       context: input.context,
+      tags: normalizeTaskTags(input.tags),
       baselineUrlOverride: input.baselineUrlOverride,
       status: input.status ?? 'INBOX',
       createdAt: now,
@@ -187,6 +190,7 @@ export class RepoBoardDO extends DurableObject<Env> {
       branchSource: hasPatchField('branchSource') ? cloneTaskBranchSource(patch.branchSource) : cloneTaskBranchSource(existing.branchSource),
       sourceRef: patch.sourceRef ?? existing.sourceRef,
       context: patch.context ?? existing.context,
+      tags: hasPatchField('tags') ? normalizeTaskTags(patch.tags) : normalizeTaskTags(existing.tags),
       acceptanceCriteria: patch.acceptanceCriteria ?? existing.acceptanceCriteria,
       uiMeta: normalizeTaskUiMeta({
         simulationProfile: patch.simulationProfile ?? existing.uiMeta?.simulationProfile ?? 'happy_path',
@@ -1120,6 +1124,7 @@ function cloneRepoBoardState(state: RepoBoardState): RepoBoardState {
       dependencyState: cloneTaskDependencyState(task.dependencyState),
       automationState: cloneTaskAutomationState(task.automationState),
       branchSource: cloneTaskBranchSource(task.branchSource),
+      tags: normalizeTaskTags(task.tags),
       context: { ...task.context, links: task.context.links.map((link) => ({ ...link })) },
       uiMeta: normalizeTaskUiMeta(task.uiMeta ? { ...task.uiMeta } : undefined)
     })),
@@ -1176,6 +1181,7 @@ function normalizeRepoBoardState(state?: Partial<RepoBoardState> | null): RepoBo
     ...task,
     tenantId: normalizeTenantId(task.tenantId),
     branchSource: cloneTaskBranchSource(task.branchSource),
+    tags: normalizeTaskTags(task.tags),
     uiMeta: normalizeTaskUiMeta(task.uiMeta)
   }));
   const taskTenantIds = new Map(normalizedTasks.map((task) => [task.taskId, task.tenantId]));
@@ -1277,4 +1283,24 @@ function cloneTaskAutomationState(automationState: Task['automationState']) {
 
 function cloneTaskBranchSource(branchSource: Task['branchSource']) {
   return branchSource ? normalizeTaskBranchSourceReviewMetadata({ ...branchSource }) : undefined;
+}
+
+function normalizeTaskTags(tags: Task['tags']) {
+  if (!Array.isArray(tags)) {
+    return undefined;
+  }
+  const seen = new Set<string>();
+  const normalized: string[] = [];
+  for (const tag of tags) {
+    if (typeof tag !== 'string') {
+      continue;
+    }
+    const trimmed = tag.trim();
+    if (!trimmed || seen.has(trimmed)) {
+      continue;
+    }
+    seen.add(trimmed);
+    normalized.push(trimmed);
+  }
+  return normalized.length ? normalized : undefined;
 }

--- a/src/server/http/validation.test.ts
+++ b/src/server/http/validation.test.ts
@@ -63,6 +63,20 @@ describe('task validation', () => {
     expect(parsed.branchSource?.upstreamReviewProvider).toBe('gitlab');
   });
 
+  it('parses and normalizes task tags for create and update payloads', () => {
+    const created = parseCreateTaskInput(
+      createTaskPayload({
+        tags: [' p1 ', 'backend', 'p1', '']
+      })
+    );
+    expect(created.tags).toEqual(['p1', 'backend']);
+
+    const updated = parseUpdateTaskInput({
+      tags: ['ops', ' ops ', 'infra']
+    });
+    expect(updated.tags).toEqual(['ops', 'infra']);
+  });
+
   it('parses generic llm task fields and mirrors codex aliases', () => {
     const parsed = parseCreateTaskInput(
       createTaskPayload({
@@ -171,6 +185,7 @@ describe('task validation', () => {
 
     expect(parsed.autoReviewMode).toBe('inherit');
     expect(parsed.autoReviewPrompt).toBeUndefined();
+    expect(parsed.tags).toBeUndefined();
   });
 
   it('parses task auto-review overrides', () => {
@@ -265,6 +280,51 @@ describe('repo validation', () => {
       provider: 'gitlab',
       postInline: false
     });
+    expect(parsed.sentinelConfig).toEqual({});
+  });
+
+  it('parses nested sentinel config updates', () => {
+    const parsed = parseUpdateRepoInput({
+      sentinelConfig: {
+        enabled: true,
+        globalMode: true,
+        defaultGroupTag: 'p1',
+        reviewGate: {
+          requireChecksGreen: false
+        },
+        mergePolicy: {
+          autoMergeEnabled: true,
+          method: 'rebase',
+          deleteBranch: false
+        },
+        conflictPolicy: {
+          remediationEnabled: true,
+          rebaseBeforeMerge: true,
+          maxAttempts: 3
+        }
+      }
+    });
+
+    expect(parsed.sentinelConfig).toEqual({
+      enabled: true,
+      globalMode: true,
+      defaultGroupTag: 'p1',
+      reviewGate: { requireChecksGreen: false },
+      mergePolicy: { autoMergeEnabled: true, method: 'rebase', deleteBranch: false },
+      conflictPolicy: { remediationEnabled: true, rebaseBeforeMerge: true, maxAttempts: 3 }
+    });
+  });
+
+  it('rejects invalid sentinel merge policy methods', () => {
+    expect(() =>
+      parseUpdateRepoInput({
+        sentinelConfig: {
+          mergePolicy: {
+            method: 'fast-forward'
+          }
+        }
+      })
+    ).toThrow('Invalid sentinelConfig.mergePolicy.method.');
   });
 
   it('defaults repo auto-review provider and includes prompt when enabled', () => {

--- a/src/server/http/validation.ts
+++ b/src/server/http/validation.ts
@@ -16,6 +16,7 @@ const AUTO_REVIEW_PROVIDERS = new Set(['gitlab', 'jira'] as const);
 const AUTO_REVIEW_MODES = new Set(['inherit', 'on', 'off'] as const);
 const AUTO_REVIEW_SELECTION_MODES = new Set(['all', 'include', 'exclude', 'freeform'] as const);
 const PREVIEW_ADAPTERS = new Set(['cloudflare_checks', 'prompt_recipe'] as const);
+const SENTINEL_MERGE_METHODS = new Set(['merge', 'squash', 'rebase'] as const);
 const TENANT_MEMBER_ROLES = new Set(['owner', 'member'] as const);
 const TENANT_SEAT_STATES = new Set(['active', 'invited', 'revoked'] as const);
 
@@ -398,7 +399,7 @@ function readRequestRunChangesSelection(value: unknown, field = 'reviewSelection
     throw badRequest(`Invalid ${field}.`);
   }
 
-  const mode = readEnumValue(value.mode, `${field}.mode`, AUTO_REVIEW_SELECTION_MODES, true);
+  const mode = readEnumValue(value.mode, `${field}.mode`, AUTO_REVIEW_SELECTION_MODES, true)!;
   const findingIds = readStringArray(value.findingIds, `${field}.findingIds`, false)
     ?.map((findingId) => findingId.trim())
     .filter(Boolean);
@@ -410,6 +411,98 @@ function readRequestRunChangesSelection(value: unknown, field = 'reviewSelection
     ...(findingIds?.length ? { findingIds } : {}),
     ...(instruction ? { instruction } : {}),
     ...(typeof includeReplies === 'boolean' ? { includeReplies } : {})
+  };
+}
+
+function readTaskTags(value: unknown, field: string, required = false): string[] | undefined {
+  const tags = readStringArray(value, field, required);
+  if (typeof tags === 'undefined') {
+    return undefined;
+  }
+  const seen = new Set<string>();
+  const normalized: string[] = [];
+  for (const tag of tags) {
+    const trimmed = tag.trim();
+    if (!trimmed || seen.has(trimmed)) {
+      continue;
+    }
+    seen.add(trimmed);
+    normalized.push(trimmed);
+  }
+  return normalized;
+}
+
+function readSentinelConfig(
+  value: unknown,
+  field: string,
+  required = true
+): NonNullable<CreateRepoInput['sentinelConfig']> | undefined {
+  if (!required && typeof value === 'undefined') {
+    return undefined;
+  }
+  if (!isRecord(value)) {
+    throw badRequest(`Invalid ${field}.`);
+  }
+
+  const reviewGate = hasOwn(value, 'reviewGate')
+    ? (() => {
+        if (!isRecord(value.reviewGate)) {
+          throw badRequest(`Invalid ${field}.reviewGate.`);
+        }
+        return {
+          ...(hasOwn(value.reviewGate, 'requireChecksGreen')
+            ? { requireChecksGreen: readBoolean(value.reviewGate.requireChecksGreen, `${field}.reviewGate.requireChecksGreen`, false) }
+            : {}),
+          ...(hasOwn(value.reviewGate, 'requireAutoReviewPass')
+            ? { requireAutoReviewPass: readBoolean(value.reviewGate.requireAutoReviewPass, `${field}.reviewGate.requireAutoReviewPass`, false) }
+            : {})
+        };
+      })()
+    : undefined;
+  const mergePolicy = hasOwn(value, 'mergePolicy')
+    ? (() => {
+        if (!isRecord(value.mergePolicy)) {
+          throw badRequest(`Invalid ${field}.mergePolicy.`);
+        }
+        return {
+          ...(hasOwn(value.mergePolicy, 'autoMergeEnabled')
+            ? { autoMergeEnabled: readBoolean(value.mergePolicy.autoMergeEnabled, `${field}.mergePolicy.autoMergeEnabled`, false) }
+            : {}),
+          ...(hasOwn(value.mergePolicy, 'method')
+            ? { method: readEnumValue(value.mergePolicy.method, `${field}.mergePolicy.method`, SENTINEL_MERGE_METHODS, false) }
+            : {}),
+          ...(hasOwn(value.mergePolicy, 'deleteBranch')
+            ? { deleteBranch: readBoolean(value.mergePolicy.deleteBranch, `${field}.mergePolicy.deleteBranch`, false) }
+            : {})
+        };
+      })()
+    : undefined;
+  const conflictPolicy = hasOwn(value, 'conflictPolicy')
+    ? (() => {
+        if (!isRecord(value.conflictPolicy)) {
+          throw badRequest(`Invalid ${field}.conflictPolicy.`);
+        }
+        return {
+          ...(hasOwn(value.conflictPolicy, 'rebaseBeforeMerge')
+            ? { rebaseBeforeMerge: readBoolean(value.conflictPolicy.rebaseBeforeMerge, `${field}.conflictPolicy.rebaseBeforeMerge`, false) }
+            : {}),
+          ...(hasOwn(value.conflictPolicy, 'remediationEnabled')
+            ? { remediationEnabled: readBoolean(value.conflictPolicy.remediationEnabled, `${field}.conflictPolicy.remediationEnabled`, false) }
+            : {}),
+          ...(hasOwn(value.conflictPolicy, 'maxAttempts')
+            ? { maxAttempts: readPositiveInteger(value.conflictPolicy.maxAttempts, `${field}.conflictPolicy.maxAttempts`, false) }
+            : {})
+        };
+      })()
+    : undefined;
+
+  return {
+    ...(hasOwn(value, 'enabled') ? { enabled: readBoolean(value.enabled, `${field}.enabled`, false) } : {}),
+    ...(hasOwn(value, 'globalMode') ? { globalMode: readBoolean(value.globalMode, `${field}.globalMode`, false) } : {}),
+    ...(hasOwn(value, 'defaultGroupTag') ? { defaultGroupTag: readTrimmedString(value.defaultGroupTag, `${field}.defaultGroupTag`, false) } : {}),
+    ...(reviewGate ? { reviewGate } : {}),
+    ...(mergePolicy ? { mergePolicy } : {}),
+    ...(conflictPolicy ? { conflictPolicy } : {})
   };
 }
 
@@ -486,8 +579,16 @@ export function parseCreateRepoInput(body: unknown): CreateRepoInput {
     defaultBranch: readTrimmedString(body.defaultBranch, 'defaultBranch', false),
     baselineUrl: readTrimmedString(body.baselineUrl, 'baselineUrl')!,
     autoReview: hasOwn(body, 'autoReview')
-      ? readAutoReviewConfig(body.autoReview, 'autoReview')
+      ? {
+          enabled: false,
+          provider: 'gitlab',
+          postInline: false,
+          ...readAutoReviewConfig(body.autoReview, 'autoReview')
+        }
       : { enabled: false, provider: 'gitlab', postInline: false },
+    sentinelConfig: hasOwn(body, 'sentinelConfig')
+      ? readSentinelConfig(body.sentinelConfig, 'sentinelConfig')
+      : {},
     enabled: readBoolean(body.enabled, 'enabled', false),
     previewMode: readEnumValue(body.previewMode, 'previewMode', new Set(['auto', 'skip'] as const), false),
     evidenceMode: readEnumValue(body.evidenceMode, 'evidenceMode', new Set(['auto', 'skip'] as const), false),
@@ -532,6 +633,7 @@ export function parseUpdateRepoInput(body: unknown): UpdateRepoInput {
   if (hasOwn(body, 'previewProvider')) patch.previewProvider = readEnumValue(body.previewProvider, 'previewProvider', new Set(['cloudflare'] as const), false);
   if (hasOwn(body, 'previewCheckName')) patch.previewCheckName = readTrimmedString(body.previewCheckName, 'previewCheckName', false);
   if (hasOwn(body, 'autoReview')) patch.autoReview = readAutoReviewConfig(body.autoReview, 'autoReview', false);
+  if (hasOwn(body, 'sentinelConfig')) patch.sentinelConfig = readSentinelConfig(body.sentinelConfig, 'sentinelConfig', false);
   if (hasOwn(body, 'codexAuthBundleR2Key')) patch.codexAuthBundleR2Key = readTrimmedString(body.codexAuthBundleR2Key, 'codexAuthBundleR2Key', false);
 
   if (hasOwn(body, 'previewAdapter') || hasOwn(body, 'previewConfig') || hasOwn(body, 'previewProvider') || hasOwn(body, 'previewCheckName')) {
@@ -585,6 +687,7 @@ export function parseCreateTaskInput(body: unknown): CreateTaskInput {
     acceptanceCriteria: readStringArray(body.acceptanceCriteria, 'acceptanceCriteria')!,
     context: readContext(body.context)!,
     baselineUrlOverride: readString(body.baselineUrlOverride, 'baselineUrlOverride', false),
+    tags: readTaskTags(body.tags, 'tags', false),
     status: readString(body.status, 'status', false) as CreateTaskInput['status'],
     autoReviewMode: readEnumValue(body.autoReviewMode, 'autoReviewMode', AUTO_REVIEW_MODES, false) ?? 'inherit',
     autoReviewPrompt: readTrimmedString(body.autoReviewPrompt, 'autoReviewPrompt', false),
@@ -612,6 +715,7 @@ export function parseUpdateTaskInput(body: unknown): UpdateTaskInput {
   if (hasOwn(body, 'acceptanceCriteria')) patch.acceptanceCriteria = readStringArray(body.acceptanceCriteria, 'acceptanceCriteria', false);
   if (hasOwn(body, 'context')) patch.context = readContext(body.context, false);
   if (hasOwn(body, 'baselineUrlOverride')) patch.baselineUrlOverride = readString(body.baselineUrlOverride, 'baselineUrlOverride', false);
+  if (hasOwn(body, 'tags')) patch.tags = readTaskTags(body.tags, 'tags', false);
   if (hasOwn(body, 'status')) patch.status = readString(body.status, 'status', false) as UpdateTaskInput['status'];
   if (hasOwn(body, 'autoReviewMode')) patch.autoReviewMode = readEnumValue(body.autoReviewMode, 'autoReviewMode', AUTO_REVIEW_MODES, false);
   if (hasOwn(body, 'autoReviewPrompt')) patch.autoReviewPrompt = readTrimmedString(body.autoReviewPrompt, 'autoReviewPrompt', false);

--- a/src/server/router.ts
+++ b/src/server/router.ts
@@ -70,6 +70,24 @@ function parsePathParam(value: string | undefined) {
   return decodeURIComponent(value ?? '');
 }
 
+function normalizeTagFilters(searchParams: URLSearchParams) {
+  const values = [
+    ...searchParams.getAll('tag'),
+    ...searchParams.getAll('tags').flatMap((value) => value.split(','))
+  ];
+  const seen = new Set<string>();
+  const tags: string[] = [];
+  for (const value of values) {
+    const trimmed = value.trim();
+    if (!trimmed || seen.has(trimmed)) {
+      continue;
+    }
+    seen.add(trimmed);
+    tags.push(trimmed);
+  }
+  return tags;
+}
+
 export async function handleSlackCommands(request: Request, env: Env, ctx: ExecutionContext<unknown>): Promise<Response> {
   return handleSlackCommandsHandler(request, env, ctx);
 }
@@ -480,11 +498,16 @@ export async function handleListTasks(request: Request, env: Env): Promise<Respo
     const requestContext = await resolveRequestTenantContext(env, board, request, { requireSession: true });
     await requireActiveTenantAccess(env, board, requestContext);
     const repoId = url.searchParams.get('repoId');
+    const tags = normalizeTagFilters(url.searchParams);
     if (!repoId || repoId === 'all') {
-      return json((await board.getBoardSync('all', requestContext.activeTenantId)).tasks);
+      const tasks = (await board.getBoardSync('all', requestContext.activeTenantId)).tasks;
+      if (!tags.length) {
+        return json(tasks);
+      }
+      return json(tasks.filter((task) => tags.every((tag) => task.tags?.includes(tag))));
     }
     await assertRepoAccess(env, board, requestContext, repoId);
-    return json(await env.REPO_BOARD.getByName(repoId).listTasks(requestContext.activeTenantId));
+    return json(await env.REPO_BOARD.getByName(repoId).listTasks(requestContext.activeTenantId, { tags }));
   });
 }
 

--- a/src/server/sentinel-config.test.ts
+++ b/src/server/sentinel-config.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { DEFAULT_REPO_SENTINEL_CONFIG, normalizeRepoSentinelConfig } from '../shared/sentinel';
+
+describe('sentinel config normalization', () => {
+  it('resolves deterministic defaults when sentinel config is omitted', () => {
+    const normalized = normalizeRepoSentinelConfig({});
+    expect(normalized.sentinelConfig).toEqual(DEFAULT_REPO_SENTINEL_CONFIG);
+  });
+
+  it('merges partial sentinel config while preserving defaults', () => {
+    const normalized = normalizeRepoSentinelConfig({
+      sentinelConfig: {
+        enabled: true,
+        mergePolicy: { method: 'merge', autoMergeEnabled: false, deleteBranch: false }
+      }
+    });
+
+    expect(normalized.sentinelConfig).toEqual({
+      ...DEFAULT_REPO_SENTINEL_CONFIG,
+      enabled: true,
+      mergePolicy: {
+        method: 'merge',
+        autoMergeEnabled: false,
+        deleteBranch: false
+      }
+    });
+  });
+});

--- a/src/server/tenant-auth-db.test.ts
+++ b/src/server/tenant-auth-db.test.ts
@@ -1,19 +1,27 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 import {
+  appendSentinelEvent,
   acceptTenantInvite,
+  createSentinelRun,
   deleteIntegrationConfig,
   deleteJiraProjectRepoMapping,
   deleteSlackThreadBinding,
   createTenantInvite,
+  getRepoSentinelConfig,
+  getSentinelRun,
   getIntegrationConfig,
   getSlackThreadBinding,
   createUserApiToken,
   listIntegrationConfigs,
   listJiraProjectRepoMappings,
   listJiraProjectRepoMappingsByProject,
+  listSentinelEvents,
+  listSentinelRuns,
   upsertIntegrationConfig,
   upsertJiraProjectRepoMapping,
+  upsertRepoSentinelConfig,
   upsertSlackThreadBinding,
+  updateSentinelRun,
   listTenantInvites,
   listUserApiTokens,
   login,
@@ -75,6 +83,9 @@ class FakeTenantAuthDb {
   integrationConfigs: Row[] = [];
   jiraProjectRepoMappings: Row[] = [];
   slackThreadBindings: Row[] = [];
+  repoSentinelConfigs: Row[] = [];
+  sentinelRuns: Row[] = [];
+  sentinelEvents: Row[] = [];
 
   prepare(sql: string) {
     return new FakeD1Statement(sql, (statement, bindings) => this.execute(statement, bindings));
@@ -99,7 +110,10 @@ class FakeTenantAuthDb {
           { name: 'security_audit_log' },
           { name: 'integration_configs' },
           { name: 'jira_project_repo_mappings' },
-          { name: 'slack_thread_bindings' }
+          { name: 'slack_thread_bindings' },
+          { name: 'repo_sentinel_configs' },
+          { name: 'sentinel_runs' },
+          { name: 'sentinel_events' }
         ]
       };
     }
@@ -276,6 +290,147 @@ class FakeTenantAuthDb {
       }
       if (sql.includes('LIMIT 1')) {
         rows = rows.slice(0, 1);
+      }
+      return { results: rows };
+    }
+
+    if (sql.includes('INSERT INTO repo_sentinel_configs')) {
+      const row = {
+        external_id: String(bindings[0]),
+        tenant_id: String(bindings[1]),
+        repo_id: String(bindings[2]),
+        config_json: String(bindings[3]),
+        created_at: String(bindings[4]),
+        updated_at: String(bindings[5])
+      };
+      const existingIndex = this.repoSentinelConfigs.findIndex((entry) => (
+        entry.tenant_id === row.tenant_id
+        && entry.repo_id === row.repo_id
+      ));
+      if (existingIndex >= 0) {
+        this.repoSentinelConfigs[existingIndex] = {
+          ...this.repoSentinelConfigs[existingIndex],
+          config_json: row.config_json,
+          updated_at: row.updated_at
+        };
+      } else {
+        this.repoSentinelConfigs.push(row);
+      }
+      return {};
+    }
+
+    if (sql.includes('SELECT * FROM repo_sentinel_configs')) {
+      const tenantId = String(bindings[0]);
+      const repoId = String(bindings[1]);
+      return {
+        results: this.repoSentinelConfigs.filter((row) => row.tenant_id === tenantId && row.repo_id === repoId).slice(0, 1)
+      };
+    }
+
+    if (sql.includes('INSERT INTO sentinel_runs')) {
+      this.sentinelRuns.push({
+        external_id: String(bindings[0]),
+        tenant_id: String(bindings[1]),
+        repo_id: String(bindings[2]),
+        scope_type: String(bindings[3]),
+        scope_value: bindings[4] ? String(bindings[4]) : null,
+        status: String(bindings[5]),
+        current_task_id: bindings[6] ? String(bindings[6]) : null,
+        current_run_id: bindings[7] ? String(bindings[7]) : null,
+        attempt_count: Number(bindings[8]),
+        started_at: String(bindings[9]),
+        updated_at: String(bindings[10])
+      });
+      return {};
+    }
+
+    if (sql.includes('UPDATE sentinel_runs')) {
+      const status = String(bindings[0]);
+      const currentTaskId = bindings[1] ? String(bindings[1]) : null;
+      const currentRunId = bindings[2] ? String(bindings[2]) : null;
+      const attemptCount = Number(bindings[3]);
+      const updatedAt = String(bindings[4]);
+      const tenantId = String(bindings[5]);
+      const runId = String(bindings[6]);
+      this.sentinelRuns = this.sentinelRuns.map((row) => (
+        row.tenant_id === tenantId && row.external_id === runId
+          ? {
+              ...row,
+              status,
+              current_task_id: currentTaskId,
+              current_run_id: currentRunId,
+              attempt_count: attemptCount,
+              updated_at: updatedAt
+            }
+          : row
+      ));
+      return {};
+    }
+
+    if (sql.includes('SELECT * FROM sentinel_runs')) {
+      const tenantId = String(bindings[0]);
+      let index = 1;
+      let rows = this.sentinelRuns.filter((row) => row.tenant_id === tenantId);
+      if (sql.includes('external_id = ?')) {
+        const runId = String(bindings[index]);
+        rows = rows.filter((row) => row.external_id === runId);
+      }
+      if (sql.includes('repo_id = ?')) {
+        const repoId = String(bindings[index++]);
+        rows = rows.filter((row) => row.repo_id === repoId);
+      }
+      if (sql.includes('status = ?')) {
+        const status = String(bindings[index++]);
+        rows = rows.filter((row) => row.status === status);
+      }
+      if (sql.includes('LIMIT 1')) {
+        rows = rows.slice(0, 1);
+      }
+      if (sql.includes('ORDER BY started_at DESC')) {
+        rows = [...rows].sort((a, b) => String(b.started_at).localeCompare(String(a.started_at)));
+      }
+      return { results: rows };
+    }
+
+    if (sql.includes('INSERT INTO sentinel_events')) {
+      this.sentinelEvents.push({
+        external_id: String(bindings[0]),
+        sentinel_run_id: String(bindings[1]),
+        tenant_id: String(bindings[2]),
+        repo_id: String(bindings[3]),
+        at: String(bindings[4]),
+        level: String(bindings[5]),
+        type: String(bindings[6]),
+        message: String(bindings[7]),
+        metadata_json: bindings[8] ? String(bindings[8]) : null
+      });
+      return {};
+    }
+
+    if (sql.includes('SELECT * FROM sentinel_events')) {
+      const tenantId = String(bindings[0]);
+      let rows = this.sentinelEvents.filter((row) => row.tenant_id === tenantId);
+      let index = 1;
+      if (sql.includes('external_id = ?')) {
+        const eventId = String(bindings[index++]);
+        rows = rows.filter((row) => row.external_id === eventId);
+      }
+      if (sql.includes('repo_id = ?')) {
+        const repoId = String(bindings[index++]);
+        rows = rows.filter((row) => row.repo_id === repoId);
+      }
+      if (sql.includes('sentinel_run_id = ?')) {
+        const runId = String(bindings[index++]);
+        rows = rows.filter((row) => row.sentinel_run_id === runId);
+      }
+      if (sql.includes('ORDER BY at DESC')) {
+        rows = [...rows].sort((a, b) => String(b.at).localeCompare(String(a.at)));
+      }
+      if (sql.includes('LIMIT ')) {
+        const limitMatch = sql.match(/LIMIT\s+(\d+)/i);
+        if (limitMatch) {
+          rows = rows.slice(0, Number(limitMatch[1]));
+        }
       }
       return { results: rows };
     }
@@ -795,5 +950,86 @@ describe('tenant-auth-db single-tenant auth store', () => {
     await deleteSlackThreadBinding(env, tenantId, 'task_1', 'C123');
     const afterDelete = await getSlackThreadBinding(env, tenantId, 'task_1', 'C123');
     expect(afterDelete).toBeUndefined();
+  });
+
+  it('persists repo sentinel config and returns deterministic defaults when missing', async () => {
+    const tenantId = 'tenant_local';
+    const repoId = 'repo_alpha';
+
+    const defaultConfig = await getRepoSentinelConfig(env, tenantId, repoId);
+    expect(defaultConfig).toMatchObject({
+      enabled: false,
+      globalMode: false,
+      reviewGate: { requireChecksGreen: true, requireAutoReviewPass: true },
+      mergePolicy: { autoMergeEnabled: true, method: 'squash', deleteBranch: true },
+      conflictPolicy: { rebaseBeforeMerge: true, remediationEnabled: true, maxAttempts: 2 }
+    });
+
+    const updated = await upsertRepoSentinelConfig(env, {
+      tenantId,
+      repoId,
+      config: {
+        enabled: true,
+        globalMode: true,
+        defaultGroupTag: 'p1',
+        mergePolicy: { method: 'merge', autoMergeEnabled: false, deleteBranch: false },
+        conflictPolicy: { maxAttempts: 5, remediationEnabled: false, rebaseBeforeMerge: false }
+      }
+    });
+
+    expect(updated.enabled).toBe(true);
+    expect(updated.globalMode).toBe(true);
+    expect(updated.defaultGroupTag).toBe('p1');
+    expect(updated.mergePolicy.method).toBe('merge');
+    expect(updated.conflictPolicy.maxAttempts).toBe(5);
+  });
+
+  it('persists sentinel runs and events with roundtrip reads', async () => {
+    const tenantId = 'tenant_local';
+    const repoId = 'repo_alpha';
+
+    const run = await createSentinelRun(env, {
+      tenantId,
+      repoId,
+      scopeType: 'group',
+      scopeValue: 'p1',
+      status: 'running'
+    });
+    expect(run.repoId).toBe(repoId);
+    expect(run.scopeType).toBe('group');
+    expect(run.scopeValue).toBe('p1');
+
+    const updatedRun = await updateSentinelRun(env, tenantId, run.id, {
+      status: 'paused',
+      currentTaskId: 'task_1',
+      currentRunId: 'run_1',
+      attemptCount: 2
+    });
+    expect(updatedRun.status).toBe('paused');
+    expect(updatedRun.currentTaskId).toBe('task_1');
+    expect(updatedRun.currentRunId).toBe('run_1');
+    expect(updatedRun.attemptCount).toBe(2);
+
+    const fetchedRun = await getSentinelRun(env, tenantId, run.id);
+    expect(fetchedRun.status).toBe('paused');
+
+    const event = await appendSentinelEvent(env, {
+      tenantId,
+      repoId,
+      sentinelRunId: run.id,
+      level: 'info',
+      type: 'sentinel.started',
+      message: 'Sentinel started',
+      metadata: { source: 'test', attempt: 1 }
+    });
+    expect(event.sentinelRunId).toBe(run.id);
+    expect(event.metadata?.source).toBe('test');
+
+    const runEvents = await listSentinelEvents(env, tenantId, { sentinelRunId: run.id });
+    expect(runEvents).toHaveLength(1);
+    expect(runEvents[0].id).toBe(event.id);
+
+    const repoRuns = await listSentinelRuns(env, tenantId, { repoId });
+    expect(repoRuns.map((entry) => entry.id)).toContain(run.id);
   });
 });

--- a/src/server/tenant-auth-db.ts
+++ b/src/server/tenant-auth-db.ts
@@ -4,6 +4,9 @@ import type {
   IntegrationPluginKind,
   IntegrationScopeType,
   JiraProjectRepoMapping,
+  RepoSentinelConfig,
+  SentinelEvent,
+  SentinelRun,
   SlackThreadBinding,
   Tenant,
   TenantMember,
@@ -12,6 +15,7 @@ import type {
   UserSession
 } from '../ui/domain/types';
 import { badRequest, conflict, forbidden, notFound, unauthorized } from './http/errors';
+import { DEFAULT_REPO_SENTINEL_CONFIG, normalizeRepoSentinelConfig } from '../shared/sentinel';
 
 type TenantRecordInput = {
   name: string;
@@ -102,6 +106,36 @@ type SlackThreadBindingInput = {
   currentRunId?: string;
   latestReviewRound?: number;
 };
+type RepoSentinelConfigInput = {
+  tenantId: string;
+  repoId: string;
+  config?: Partial<RepoSentinelConfig>;
+};
+type SentinelRunInput = {
+  id?: string;
+  tenantId: string;
+  repoId: string;
+  scopeType: SentinelRun['scopeType'];
+  scopeValue?: string;
+  status?: SentinelRun['status'];
+  currentTaskId?: string;
+  currentRunId?: string;
+  attemptCount?: number;
+  startedAt?: string;
+  updatedAt?: string;
+};
+type SentinelRunPatch = Partial<Pick<SentinelRun, 'status' | 'currentTaskId' | 'currentRunId' | 'attemptCount' | 'updatedAt'>>;
+type SentinelEventInput = {
+  id?: string;
+  sentinelRunId: string;
+  tenantId: string;
+  repoId: string;
+  at?: string;
+  level: SentinelEvent['level'];
+  type: SentinelEvent['type'];
+  message: string;
+  metadata?: SentinelEvent['metadata'];
+};
 
 const DEFAULT_SEAT_LIMIT = 100;
 const SESSION_TTL_MS = 1000 * 60 * 60 * 24 * 30;
@@ -115,6 +149,24 @@ const PASSWORD_SALT_BYTES = 16;
 
 const VALID_INTEGRATION_SCOPE_TYPES = new Set<IntegrationScopeType>(['tenant', 'repo', 'channel']);
 const VALID_INTEGRATION_PLUGIN_KINDS = new Set<IntegrationPluginKind>(['slack', 'jira', 'gitlab']);
+const VALID_SENTINEL_SCOPE_TYPES = new Set<SentinelRun['scopeType']>(['group', 'global']);
+const VALID_SENTINEL_RUN_STATUSES = new Set<SentinelRun['status']>(['running', 'paused', 'stopped', 'failed', 'completed']);
+const VALID_SENTINEL_EVENT_LEVELS = new Set<SentinelEvent['level']>(['info', 'warn', 'error']);
+const VALID_SENTINEL_EVENT_TYPES = new Set<SentinelEvent['type']>([
+  'sentinel.started',
+  'sentinel.paused',
+  'sentinel.resumed',
+  'sentinel.stopped',
+  'task.activated',
+  'run.started',
+  'review.gate.waiting',
+  'merge.attempted',
+  'merge.succeeded',
+  'merge.failed',
+  'remediation.started',
+  'remediation.succeeded',
+  'remediation.failed'
+]);
 
 let schemaReady: Promise<void> | undefined;
 
@@ -141,7 +193,10 @@ async function ensureSchema(db: D1Database): Promise<void> {
         'user_api_tokens',
         'integration_configs',
         'jira_project_repo_mappings',
-        'slack_thread_bindings'
+        'slack_thread_bindings',
+        'repo_sentinel_configs',
+        'sentinel_runs',
+        'sentinel_events'
       ] as const;
       const quoted = requiredTables.map((table) => `'${table}'`).join(', ');
       const result = await db.prepare(`SELECT name FROM sqlite_master WHERE type = 'table' AND name IN (${quoted})`).all<{ name: string }>();
@@ -408,6 +463,181 @@ function normalizeSlackBindingInput(input: SlackThreadBindingInput): SlackThread
     threadTs,
     currentRunId: input.currentRunId?.trim(),
     latestReviewRound: Number.isFinite(input.latestReviewRound) ? input.latestReviewRound : 0
+  };
+}
+
+function parseSentinelScopeType(value: unknown): SentinelRun['scopeType'] {
+  const candidate = String(value ?? '').trim();
+  if (VALID_SENTINEL_SCOPE_TYPES.has(candidate as SentinelRun['scopeType'])) {
+    return candidate as SentinelRun['scopeType'];
+  }
+  throw badRequest('Invalid sentinel scope type.');
+}
+
+function parseSentinelRunStatus(value: unknown): SentinelRun['status'] {
+  const candidate = String(value ?? '').trim();
+  if (VALID_SENTINEL_RUN_STATUSES.has(candidate as SentinelRun['status'])) {
+    return candidate as SentinelRun['status'];
+  }
+  throw badRequest('Invalid sentinel run status.');
+}
+
+function parseSentinelEventLevel(value: unknown): SentinelEvent['level'] {
+  const candidate = String(value ?? '').trim();
+  if (VALID_SENTINEL_EVENT_LEVELS.has(candidate as SentinelEvent['level'])) {
+    return candidate as SentinelEvent['level'];
+  }
+  throw badRequest('Invalid sentinel event level.');
+}
+
+function parseSentinelEventType(value: unknown): SentinelEvent['type'] {
+  const candidate = String(value ?? '').trim();
+  if (VALID_SENTINEL_EVENT_TYPES.has(candidate as SentinelEvent['type'])) {
+    return candidate as SentinelEvent['type'];
+  }
+  throw badRequest('Invalid sentinel event type.');
+}
+
+function parseSentinelConfigJson(value: unknown): Partial<RepoSentinelConfig> {
+  if (typeof value !== 'string' || !value.trim()) {
+    return {};
+  }
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return parsed as Partial<RepoSentinelConfig>;
+    }
+  } catch {
+    // Ignore invalid JSON and fall through to defaults.
+  }
+  return {};
+}
+
+function parseEventMetadataJson(value: unknown): SentinelEvent['metadata'] {
+  if (typeof value !== 'string' || !value.trim()) {
+    return undefined;
+  }
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return undefined;
+    }
+    const metadata: Record<string, string | number | boolean> = {};
+    for (const [key, entry] of Object.entries(parsed as Record<string, unknown>)) {
+      if (typeof entry === 'string' || typeof entry === 'number' || typeof entry === 'boolean') {
+        metadata[key] = entry;
+      }
+    }
+    return Object.keys(metadata).length ? metadata : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function normalizeRepoSentinelConfigInput(input: RepoSentinelConfigInput): RepoSentinelConfigInput {
+  const repoId = input.repoId.trim();
+  if (!repoId) {
+    throw badRequest('repoId is required.');
+  }
+  const normalized = normalizeRepoSentinelConfig({
+    sentinelConfig: {
+      ...DEFAULT_REPO_SENTINEL_CONFIG,
+      ...input.config,
+      reviewGate: {
+        ...DEFAULT_REPO_SENTINEL_CONFIG.reviewGate,
+        ...(input.config?.reviewGate ?? {})
+      },
+      mergePolicy: {
+        ...DEFAULT_REPO_SENTINEL_CONFIG.mergePolicy,
+        ...(input.config?.mergePolicy ?? {})
+      },
+      conflictPolicy: {
+        ...DEFAULT_REPO_SENTINEL_CONFIG.conflictPolicy,
+        ...(input.config?.conflictPolicy ?? {})
+      }
+    }
+  }).sentinelConfig;
+  return {
+    tenantId: input.tenantId,
+    repoId,
+    config: normalized
+  };
+}
+
+function mapRepoSentinelConfig(row: Record<string, unknown>): RepoSentinelConfig {
+  return normalizeRepoSentinelConfig({
+    sentinelConfig: parseSentinelConfigJson(row.config_json)
+  }).sentinelConfig;
+}
+
+function normalizeSentinelRunInput(input: SentinelRunInput): Required<Omit<SentinelRun, 'scopeValue' | 'currentTaskId' | 'currentRunId'>> & Pick<SentinelRun, 'scopeValue' | 'currentTaskId' | 'currentRunId'> {
+  const scopeValue = input.scopeValue?.trim();
+  const currentTaskId = input.currentTaskId?.trim();
+  const currentRunId = input.currentRunId?.trim();
+  const startedAt = input.startedAt ?? new Date().toISOString();
+  const updatedAt = input.updatedAt ?? startedAt;
+  const attemptCount = Number.isInteger(input.attemptCount) && Number(input.attemptCount) >= 0 ? Number(input.attemptCount) : 0;
+  return {
+    id: input.id?.trim() || `sentinel_run_${crypto.randomUUID ? crypto.randomUUID() : Math.random().toString(36).slice(2, 10)}`,
+    tenantId: input.tenantId,
+    repoId: input.repoId.trim(),
+    scopeType: parseSentinelScopeType(input.scopeType),
+    scopeValue: scopeValue || undefined,
+    status: input.status ? parseSentinelRunStatus(input.status) : 'running',
+    currentTaskId: currentTaskId || undefined,
+    currentRunId: currentRunId || undefined,
+    attemptCount,
+    startedAt,
+    updatedAt
+  };
+}
+
+function mapSentinelRun(row: Record<string, unknown>): SentinelRun {
+  return {
+    id: externalId(row),
+    tenantId: String(row.tenant_id),
+    repoId: String(row.repo_id),
+    scopeType: parseSentinelScopeType(row.scope_type),
+    scopeValue: row.scope_value ? String(row.scope_value) : undefined,
+    status: parseSentinelRunStatus(row.status),
+    currentTaskId: row.current_task_id ? String(row.current_task_id) : undefined,
+    currentRunId: row.current_run_id ? String(row.current_run_id) : undefined,
+    attemptCount: Number(row.attempt_count ?? 0),
+    startedAt: String(row.started_at),
+    updatedAt: String(row.updated_at)
+  };
+}
+
+function normalizeSentinelEventInput(input: SentinelEventInput): Required<Omit<SentinelEvent, 'metadata'>> & Pick<SentinelEvent, 'metadata'> {
+  const at = input.at ?? new Date().toISOString();
+  const message = input.message.trim();
+  if (!message) {
+    throw badRequest('Sentinel event message is required.');
+  }
+  return {
+    id: input.id?.trim() || `sentinel_event_${crypto.randomUUID ? crypto.randomUUID() : Math.random().toString(36).slice(2, 10)}`,
+    sentinelRunId: input.sentinelRunId.trim(),
+    tenantId: input.tenantId,
+    repoId: input.repoId.trim(),
+    at,
+    level: parseSentinelEventLevel(input.level),
+    type: parseSentinelEventType(input.type),
+    message,
+    metadata: input.metadata && Object.keys(input.metadata).length ? input.metadata : undefined
+  };
+}
+
+function mapSentinelEvent(row: Record<string, unknown>): SentinelEvent {
+  return {
+    id: externalId(row),
+    sentinelRunId: String(row.sentinel_run_id),
+    tenantId: String(row.tenant_id),
+    repoId: String(row.repo_id),
+    at: String(row.at),
+    level: parseSentinelEventLevel(row.level),
+    type: parseSentinelEventType(row.type),
+    message: String(row.message),
+    metadata: parseEventMetadataJson(row.metadata_json)
   };
 }
 
@@ -882,6 +1112,185 @@ export async function deleteSlackThreadBinding(
     'DELETE FROM slack_thread_bindings WHERE tenant_id = ? AND task_id = ? AND channel_id = ?'
   ).bind(tenantId, taskId.trim(), channelId.trim()).run();
   return { ok: true };
+}
+
+export async function upsertRepoSentinelConfig(env: Env, input: RepoSentinelConfigInput): Promise<RepoSentinelConfig> {
+  const db = getDb(env);
+  await ensureSchema(db);
+  const normalized = normalizeRepoSentinelConfigInput(input);
+  const now = new Date().toISOString();
+  const id = `repo_sentinel_config_${crypto.randomUUID ? crypto.randomUUID() : Math.random().toString(36).slice(2, 10)}`;
+  await db.prepare(
+    `INSERT INTO repo_sentinel_configs
+     (external_id, tenant_id, repo_id, config_json, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?)
+     ON CONFLICT (tenant_id, repo_id) DO UPDATE SET
+       config_json = excluded.config_json,
+       updated_at = excluded.updated_at`
+  ).bind(
+    id,
+    normalized.tenantId,
+    normalized.repoId,
+    JSON.stringify(normalized.config ?? DEFAULT_REPO_SENTINEL_CONFIG),
+    now,
+    now
+  ).run();
+  return getRepoSentinelConfig(env, normalized.tenantId, normalized.repoId);
+}
+
+export async function getRepoSentinelConfig(env: Env, tenantId: string, repoId: string): Promise<RepoSentinelConfig> {
+  const db = getDb(env);
+  await ensureSchema(db);
+  const row = await db.prepare(
+    'SELECT * FROM repo_sentinel_configs WHERE tenant_id = ? AND repo_id = ? LIMIT 1'
+  ).bind(tenantId, repoId.trim()).first<Record<string, unknown>>();
+  if (!row) {
+    return normalizeRepoSentinelConfig({ sentinelConfig: DEFAULT_REPO_SENTINEL_CONFIG }).sentinelConfig;
+  }
+  return mapRepoSentinelConfig(row);
+}
+
+export async function createSentinelRun(env: Env, input: SentinelRunInput): Promise<SentinelRun> {
+  const db = getDb(env);
+  await ensureSchema(db);
+  const normalized = normalizeSentinelRunInput(input);
+  await db.prepare(
+    `INSERT INTO sentinel_runs
+     (external_id, tenant_id, repo_id, scope_type, scope_value, status, current_task_id, current_run_id, attempt_count, started_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+  ).bind(
+    normalized.id,
+    normalized.tenantId,
+    normalized.repoId,
+    normalized.scopeType,
+    normalized.scopeValue ?? null,
+    normalized.status,
+    normalized.currentTaskId ?? null,
+    normalized.currentRunId ?? null,
+    normalized.attemptCount,
+    normalized.startedAt,
+    normalized.updatedAt
+  ).run();
+  return getSentinelRun(env, normalized.tenantId, normalized.id);
+}
+
+export async function getSentinelRun(env: Env, tenantId: string, runId: string): Promise<SentinelRun> {
+  const db = getDb(env);
+  await ensureSchema(db);
+  const row = await db.prepare(
+    'SELECT * FROM sentinel_runs WHERE tenant_id = ? AND external_id = ? LIMIT 1'
+  ).bind(tenantId, runId.trim()).first<Record<string, unknown>>();
+  if (!row) {
+    throw notFound(`Sentinel run ${runId} not found.`);
+  }
+  return mapSentinelRun(row);
+}
+
+export async function updateSentinelRun(env: Env, tenantId: string, runId: string, patch: SentinelRunPatch): Promise<SentinelRun> {
+  const db = getDb(env);
+  await ensureSchema(db);
+  const existing = await getSentinelRun(env, tenantId, runId);
+  const updated: SentinelRun = {
+    ...existing,
+    status: patch.status ? parseSentinelRunStatus(patch.status) : existing.status,
+    currentTaskId: patch.currentTaskId?.trim() || (Object.prototype.hasOwnProperty.call(patch, 'currentTaskId') ? undefined : existing.currentTaskId),
+    currentRunId: patch.currentRunId?.trim() || (Object.prototype.hasOwnProperty.call(patch, 'currentRunId') ? undefined : existing.currentRunId),
+    attemptCount: Number.isInteger(patch.attemptCount) && Number(patch.attemptCount) >= 0
+      ? Number(patch.attemptCount)
+      : existing.attemptCount,
+    updatedAt: patch.updatedAt ?? new Date().toISOString()
+  };
+  await db.prepare(
+    `UPDATE sentinel_runs
+     SET status = ?, current_task_id = ?, current_run_id = ?, attempt_count = ?, updated_at = ?
+     WHERE tenant_id = ? AND external_id = ?`
+  ).bind(
+    updated.status,
+    updated.currentTaskId ?? null,
+    updated.currentRunId ?? null,
+    updated.attemptCount,
+    updated.updatedAt,
+    tenantId,
+    runId
+  ).run();
+  return getSentinelRun(env, tenantId, runId);
+}
+
+export async function listSentinelRuns(env: Env, tenantId: string, filters?: { repoId?: string; status?: SentinelRun['status'] }): Promise<SentinelRun[]> {
+  const db = getDb(env);
+  await ensureSchema(db);
+  const clauses = ['tenant_id = ?'];
+  const values: unknown[] = [tenantId];
+  if (filters?.repoId) {
+    clauses.push('repo_id = ?');
+    values.push(filters.repoId.trim());
+  }
+  if (filters?.status) {
+    clauses.push('status = ?');
+    values.push(parseSentinelRunStatus(filters.status));
+  }
+  const query = `SELECT * FROM sentinel_runs WHERE ${clauses.join(' AND ')} ORDER BY started_at DESC`;
+  const result = await db.prepare(query).bind(...values).all<Record<string, unknown>>();
+  return (result.results ?? []).map(mapSentinelRun);
+}
+
+export async function appendSentinelEvent(env: Env, input: SentinelEventInput): Promise<SentinelEvent> {
+  const db = getDb(env);
+  await ensureSchema(db);
+  const normalized = normalizeSentinelEventInput(input);
+  await db.prepare(
+    `INSERT INTO sentinel_events
+     (external_id, sentinel_run_id, tenant_id, repo_id, at, level, type, message, metadata_json)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+  ).bind(
+    normalized.id,
+    normalized.sentinelRunId,
+    normalized.tenantId,
+    normalized.repoId,
+    normalized.at,
+    normalized.level,
+    normalized.type,
+    normalized.message,
+    normalized.metadata ? JSON.stringify(normalized.metadata) : null
+  ).run();
+  return getSentinelEvent(env, normalized.tenantId, normalized.id);
+}
+
+export async function getSentinelEvent(env: Env, tenantId: string, eventId: string): Promise<SentinelEvent> {
+  const db = getDb(env);
+  await ensureSchema(db);
+  const row = await db.prepare(
+    'SELECT * FROM sentinel_events WHERE tenant_id = ? AND external_id = ? LIMIT 1'
+  ).bind(tenantId, eventId.trim()).first<Record<string, unknown>>();
+  if (!row) {
+    throw notFound(`Sentinel event ${eventId} not found.`);
+  }
+  return mapSentinelEvent(row);
+}
+
+export async function listSentinelEvents(
+  env: Env,
+  tenantId: string,
+  filters?: { repoId?: string; sentinelRunId?: string; limit?: number }
+): Promise<SentinelEvent[]> {
+  const db = getDb(env);
+  await ensureSchema(db);
+  const clauses = ['tenant_id = ?'];
+  const values: unknown[] = [tenantId];
+  if (filters?.repoId) {
+    clauses.push('repo_id = ?');
+    values.push(filters.repoId.trim());
+  }
+  if (filters?.sentinelRunId) {
+    clauses.push('sentinel_run_id = ?');
+    values.push(filters.sentinelRunId.trim());
+  }
+  const limit = Number.isInteger(filters?.limit) && Number(filters?.limit) > 0
+    ? Math.min(Number(filters?.limit), 500)
+    : 200;
+  const query = `SELECT * FROM sentinel_events WHERE ${clauses.join(' AND ')} ORDER BY at DESC LIMIT ${limit}`;
+  const result = await db.prepare(query).bind(...values).all<Record<string, unknown>>();
+  return (result.results ?? []).map(mapSentinelEvent);
 }
 
 export async function signup(env: Env, input: {

--- a/src/shared/scm.ts
+++ b/src/shared/scm.ts
@@ -1,5 +1,6 @@
 import type { AgentRun, Repo, ScmProvider, TaskBranchSource } from '../ui/domain/types';
 import { normalizeRepoPreviewConfig } from './preview';
+import { normalizeRepoSentinelConfig } from './sentinel';
 import { normalizeTenantId } from './tenant';
 
 export const SCM_PROVIDERS = new Set(['github', 'gitlab'] as const);
@@ -63,17 +64,19 @@ export function normalizeRepo(repo: RepoScmLike & Omit<Repo, 'slug' | 'scmProvid
     messageExamples: messageExamples.length ? messageExamples : undefined
   };
 
-  return normalizeRepoPreviewConfig({
-    ...repo,
-    tenantId: normalizeTenantId(repo.tenantId),
-    slug: projectPath,
-    scmProvider,
-    scmBaseUrl: normalizeScmBaseUrl(scmProvider, repo.scmBaseUrl),
-    projectPath,
-    commitConfig: (commitConfig.messageTemplate || commitConfig.messageRegex || commitConfig.messageExamples)
-      ? commitConfig
-      : undefined
-  });
+  return normalizeRepoSentinelConfig(
+    normalizeRepoPreviewConfig({
+      ...repo,
+      tenantId: normalizeTenantId(repo.tenantId),
+      slug: projectPath,
+      scmProvider,
+      scmBaseUrl: normalizeScmBaseUrl(scmProvider, repo.scmBaseUrl),
+      projectPath,
+      commitConfig: (commitConfig.messageTemplate || commitConfig.messageRegex || commitConfig.messageExamples)
+        ? commitConfig
+        : undefined
+    })
+  );
 }
 
 export function getRepoScmProvider(repo: RepoScmLike): ScmProvider {

--- a/src/shared/sentinel.ts
+++ b/src/shared/sentinel.ts
@@ -1,0 +1,60 @@
+import type { RepoSentinelConfig } from '../ui/domain/types';
+
+export const DEFAULT_REPO_SENTINEL_CONFIG: RepoSentinelConfig = {
+  enabled: false,
+  globalMode: false,
+  reviewGate: {
+    requireChecksGreen: true,
+    requireAutoReviewPass: true
+  },
+  mergePolicy: {
+    autoMergeEnabled: true,
+    method: 'squash',
+    deleteBranch: true
+  },
+  conflictPolicy: {
+    rebaseBeforeMerge: true,
+    remediationEnabled: true,
+    maxAttempts: 2
+  }
+};
+
+type RepoSentinelLike = {
+  sentinelConfig?: Partial<RepoSentinelConfig>;
+};
+
+export function normalizeRepoSentinelConfig<T extends RepoSentinelLike>(repo: T): T & { sentinelConfig: RepoSentinelConfig } {
+  const maxAttempts = Number(repo.sentinelConfig?.conflictPolicy?.maxAttempts);
+  return {
+    ...repo,
+    sentinelConfig: {
+      enabled: repo.sentinelConfig?.enabled ?? DEFAULT_REPO_SENTINEL_CONFIG.enabled,
+      globalMode: repo.sentinelConfig?.globalMode ?? DEFAULT_REPO_SENTINEL_CONFIG.globalMode,
+      defaultGroupTag: normalizeGroupTag(repo.sentinelConfig?.defaultGroupTag),
+      reviewGate: {
+        requireChecksGreen: repo.sentinelConfig?.reviewGate?.requireChecksGreen ?? DEFAULT_REPO_SENTINEL_CONFIG.reviewGate.requireChecksGreen,
+        requireAutoReviewPass: repo.sentinelConfig?.reviewGate?.requireAutoReviewPass ?? DEFAULT_REPO_SENTINEL_CONFIG.reviewGate.requireAutoReviewPass
+      },
+      mergePolicy: {
+        autoMergeEnabled: repo.sentinelConfig?.mergePolicy?.autoMergeEnabled ?? DEFAULT_REPO_SENTINEL_CONFIG.mergePolicy.autoMergeEnabled,
+        method: repo.sentinelConfig?.mergePolicy?.method ?? DEFAULT_REPO_SENTINEL_CONFIG.mergePolicy.method,
+        deleteBranch: repo.sentinelConfig?.mergePolicy?.deleteBranch ?? DEFAULT_REPO_SENTINEL_CONFIG.mergePolicy.deleteBranch
+      },
+      conflictPolicy: {
+        rebaseBeforeMerge: repo.sentinelConfig?.conflictPolicy?.rebaseBeforeMerge ?? DEFAULT_REPO_SENTINEL_CONFIG.conflictPolicy.rebaseBeforeMerge,
+        remediationEnabled: repo.sentinelConfig?.conflictPolicy?.remediationEnabled ?? DEFAULT_REPO_SENTINEL_CONFIG.conflictPolicy.remediationEnabled,
+        maxAttempts: Number.isInteger(maxAttempts) && maxAttempts > 0
+          ? maxAttempts
+          : DEFAULT_REPO_SENTINEL_CONFIG.conflictPolicy.maxAttempts
+      }
+    }
+  };
+}
+
+function normalizeGroupTag(value: string | undefined): string | undefined {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+  const normalized = value.trim();
+  return normalized || undefined;
+}

--- a/src/ui/api/http-agent-board-api.ts
+++ b/src/ui/api/http-agent-board-api.ts
@@ -184,11 +184,15 @@ export class HttpAgentBoardApi implements AgentBoardApi {
     return task;
   }
 
-  async listTasks(filter?: { repoId?: string }) {
-    if (!filter?.repoId || filter.repoId === 'all') {
-      return this.snapshot.tasks;
+  async listTasks(filter?: { repoId?: string; tags?: string[] }) {
+    const normalizedTags = (filter?.tags ?? []).map((tag) => tag.trim()).filter(Boolean);
+    const filteredByRepo = (!filter?.repoId || filter.repoId === 'all')
+      ? this.snapshot.tasks
+      : this.snapshot.tasks.filter((task) => task.repoId === filter.repoId);
+    if (!normalizedTags.length) {
+      return filteredByRepo;
     }
-    return this.snapshot.tasks.filter((task) => task.repoId === filter.repoId);
+    return filteredByRepo.filter((task) => normalizedTags.every((tag) => task.tags?.includes(tag)));
   }
 
   async getTask(taskId: string) {

--- a/src/ui/domain/api.ts
+++ b/src/ui/domain/api.ts
@@ -8,6 +8,7 @@ import type {
   LlmAdapter,
   LlmReasoningEffort,
   Repo,
+  RepoSentinelConfig,
   RunCommand,
   RunEvent,
   RunLogEntry,
@@ -27,6 +28,14 @@ export type RepoAutoReviewInput = {
   prompt?: string;
   provider?: AutoReviewProvider;
   postInline?: boolean;
+};
+export type RepoSentinelConfigInput = {
+  enabled?: boolean;
+  globalMode?: boolean;
+  defaultGroupTag?: string;
+  reviewGate?: Partial<RepoSentinelConfig['reviewGate']>;
+  mergePolicy?: Partial<RepoSentinelConfig['mergePolicy']>;
+  conflictPolicy?: Partial<RepoSentinelConfig['conflictPolicy']>;
 };
 
 export type RequestRunChangesSelection = {
@@ -49,6 +58,7 @@ export type CreateRepoInput = {
   baselineUrl: string;
   enabled?: boolean;
   autoReview?: RepoAutoReviewInput;
+  sentinelConfig?: RepoSentinelConfigInput;
   previewMode?: Repo['previewMode'];
   evidenceMode?: Repo['evidenceMode'];
   previewAdapter?: Repo['previewAdapter'];
@@ -91,6 +101,7 @@ export type CreateTaskInput = {
   llmReasoningEffort?: LlmReasoningEffort;
   codexModel?: CodexModel;
   codexReasoningEffort?: CodexReasoningEffort;
+  tags?: string[];
 };
 
 export type UpdateTaskInput = Partial<Omit<CreateTaskInput, 'repoId'>> & {
@@ -189,7 +200,7 @@ export interface AgentBoardApi {
   getScmCredential(scmProvider: UpsertScmCredentialInput['scmProvider'], host: string): Promise<ScmCredential | undefined>;
   upsertScmCredential(input: UpsertScmCredentialInput): Promise<ScmCredential>;
   createTask(input: CreateTaskInput): Promise<Task>;
-  listTasks(filter?: { repoId?: string }): Promise<Task[]>;
+  listTasks(filter?: { repoId?: string; tags?: string[] }): Promise<Task[]>;
   getTask(taskId: string): Promise<TaskDetail>;
   updateTask(taskId: string, patch: UpdateTaskInput): Promise<Task>;
   startRun(taskId: string): Promise<AgentRun>;

--- a/src/ui/domain/types.ts
+++ b/src/ui/domain/types.ts
@@ -75,6 +75,66 @@ export type RepoAutoReview = {
   provider: AutoReviewProvider;
   postInline: boolean;
 };
+export type RepoSentinelConfig = {
+  enabled: boolean;
+  globalMode: boolean;
+  defaultGroupTag?: string;
+  reviewGate: {
+    requireChecksGreen: boolean;
+    requireAutoReviewPass: boolean;
+  };
+  mergePolicy: {
+    autoMergeEnabled: boolean;
+    method: 'merge' | 'squash' | 'rebase';
+    deleteBranch: boolean;
+  };
+  conflictPolicy: {
+    rebaseBeforeMerge: boolean;
+    remediationEnabled: boolean;
+    maxAttempts: number;
+  };
+};
+export type SentinelScopeType = 'group' | 'global';
+export type SentinelRunStatus = 'running' | 'paused' | 'stopped' | 'failed' | 'completed';
+export type SentinelEventLevel = 'info' | 'warn' | 'error';
+export type SentinelEventType =
+  | 'sentinel.started'
+  | 'sentinel.paused'
+  | 'sentinel.resumed'
+  | 'sentinel.stopped'
+  | 'task.activated'
+  | 'run.started'
+  | 'review.gate.waiting'
+  | 'merge.attempted'
+  | 'merge.succeeded'
+  | 'merge.failed'
+  | 'remediation.started'
+  | 'remediation.succeeded'
+  | 'remediation.failed';
+export type SentinelRun = {
+  id: string;
+  tenantId: string;
+  repoId: string;
+  scopeType: SentinelScopeType;
+  scopeValue?: string;
+  status: SentinelRunStatus;
+  currentTaskId?: string;
+  currentRunId?: string;
+  attemptCount: number;
+  startedAt: string;
+  updatedAt: string;
+};
+export type SentinelEvent = {
+  id: string;
+  sentinelRunId: string;
+  tenantId: string;
+  repoId: string;
+  at: string;
+  level: SentinelEventLevel;
+  type: SentinelEventType;
+  message: string;
+  metadata?: Record<string, string | number | boolean>;
+};
 export type ReviewFindingSeverity = 'critical' | 'high' | 'medium' | 'low' | 'info';
 export type ReviewFindingStatus = 'open' | 'addressed' | 'ignored';
 export type ReviewPromptSource = 'task' | 'repo' | 'native';
@@ -214,6 +274,7 @@ export type Repo = {
   // Compatibility alias during migration to generic LLM executor fields.
   codexAuthBundleR2Key?: string;
   autoReview?: RepoAutoReview;
+  sentinelConfig?: RepoSentinelConfig;
   createdAt: string;
   updatedAt: string;
 };
@@ -301,6 +362,7 @@ export type Task = {
   taskPrompt: string;
   acceptanceCriteria: string[];
   context: TaskContext;
+  tags?: string[];
   status: TaskStatus;
   baselineUrlOverride?: string;
   createdAt: string;

--- a/src/ui/mock/local-agent-board-api.test.ts
+++ b/src/ui/mock/local-agent-board-api.test.ts
@@ -48,4 +48,29 @@ describe('LocalAgentBoardApi auth management', () => {
     const listedAfterRevoke = await api.listApiTokens();
     expect(listedAfterRevoke).toHaveLength(0);
   });
+
+  it('supports task tag filtering in listTasks', async () => {
+    const api = getLocalAgentBoardApi();
+    const repo = await api.createRepo({ slug: 'demo/repo', baselineUrl: 'https://example.com' });
+
+    await api.createTask({
+      repoId: repo.repoId,
+      title: 'Tagged task',
+      taskPrompt: 'Do tagged work',
+      acceptanceCriteria: ['done'],
+      context: { links: [] },
+      tags: ['p1', 'backend']
+    });
+    await api.createTask({
+      repoId: repo.repoId,
+      title: 'Untagged task',
+      taskPrompt: 'Do other work',
+      acceptanceCriteria: ['done'],
+      context: { links: [] }
+    });
+
+    const filtered = await api.listTasks({ repoId: repo.repoId, tags: ['p1'] });
+    expect(filtered).toHaveLength(1);
+    expect(filtered[0]?.title).toBe('Tagged task');
+  });
 });

--- a/src/ui/mock/local-agent-board-api.ts
+++ b/src/ui/mock/local-agent-board-api.ts
@@ -23,6 +23,7 @@ import { parseImportedBoard } from '../store/import-export';
 import { RunSimulator } from './run-simulator';
 import { normalizeOperatorSession, normalizeRunLlmState, normalizeTaskUiMeta } from '../../shared/llm';
 import { normalizeCredentialHost, normalizeRepo } from '../../shared/scm';
+import { DEFAULT_REPO_SENTINEL_CONFIG, normalizeRepoSentinelConfig } from '../../shared/sentinel';
 
 function nowIso() {
   return new Date().toISOString();
@@ -204,12 +205,37 @@ export class LocalAgentBoardApi implements AgentBoardApi {
 
   async createRepo(input: CreateRepoInput): Promise<Repo> {
     const timestamp = nowIso();
+    const normalizedAutoReview = {
+      enabled: input.autoReview?.enabled ?? false,
+      provider: input.autoReview?.provider ?? 'gitlab',
+      postInline: input.autoReview?.postInline ?? false,
+      ...(input.autoReview?.prompt ? { prompt: input.autoReview.prompt.trim() } : {})
+    };
+    const normalizedSentinelConfig = normalizeRepoSentinelConfig({
+      sentinelConfig: {
+        ...DEFAULT_REPO_SENTINEL_CONFIG,
+        ...input.sentinelConfig,
+        reviewGate: {
+          ...DEFAULT_REPO_SENTINEL_CONFIG.reviewGate,
+          ...(input.sentinelConfig?.reviewGate ?? {})
+        },
+        mergePolicy: {
+          ...DEFAULT_REPO_SENTINEL_CONFIG.mergePolicy,
+          ...(input.sentinelConfig?.mergePolicy ?? {})
+        },
+        conflictPolicy: {
+          ...DEFAULT_REPO_SENTINEL_CONFIG.conflictPolicy,
+          ...(input.sentinelConfig?.conflictPolicy ?? {})
+        }
+      }
+    }).sentinelConfig;
     const repo: Repo = normalizeRepo({
       repoId: randomId('repo'),
       slug: input.slug ?? input.projectPath ?? '',
       scmProvider: input.scmProvider,
       scmBaseUrl: input.scmBaseUrl,
-      autoReview: input.autoReview,
+      autoReview: normalizedAutoReview,
+      sentinelConfig: normalizedSentinelConfig,
       projectPath: input.projectPath,
       llmAdapter: input.llmAdapter,
       llmProfileId: input.llmProfileId,
@@ -247,17 +273,55 @@ export class LocalAgentBoardApi implements AgentBoardApi {
         }
 
         const hasAutoReviewPatch = Object.prototype.hasOwnProperty.call(patch, 'autoReview');
+        const hasSentinelConfigPatch = Object.prototype.hasOwnProperty.call(patch, 'sentinelConfig');
         const mergedAutoReview = hasAutoReviewPatch
           ? {
               ...(repo.autoReview ?? { enabled: false, provider: 'gitlab', postInline: false }),
               ...patch.autoReview
             }
           : repo.autoReview;
+        const mergedSentinelConfig = hasSentinelConfigPatch
+          ? {
+              ...(repo.sentinelConfig ?? {}),
+              ...patch.sentinelConfig,
+              reviewGate: {
+                ...(repo.sentinelConfig?.reviewGate ?? {}),
+                ...(patch.sentinelConfig?.reviewGate ?? {})
+              },
+              mergePolicy: {
+                ...(repo.sentinelConfig?.mergePolicy ?? {}),
+                ...(patch.sentinelConfig?.mergePolicy ?? {})
+              },
+              conflictPolicy: {
+                ...(repo.sentinelConfig?.conflictPolicy ?? {}),
+                ...(patch.sentinelConfig?.conflictPolicy ?? {})
+              }
+            }
+          : repo.sentinelConfig;
+        const normalizedSentinelConfig = normalizeRepoSentinelConfig({
+          sentinelConfig: {
+            ...DEFAULT_REPO_SENTINEL_CONFIG,
+            ...(mergedSentinelConfig ?? {}),
+            reviewGate: {
+              ...DEFAULT_REPO_SENTINEL_CONFIG.reviewGate,
+              ...(mergedSentinelConfig?.reviewGate ?? {})
+            },
+            mergePolicy: {
+              ...DEFAULT_REPO_SENTINEL_CONFIG.mergePolicy,
+              ...(mergedSentinelConfig?.mergePolicy ?? {})
+            },
+            conflictPolicy: {
+              ...DEFAULT_REPO_SENTINEL_CONFIG.conflictPolicy,
+              ...(mergedSentinelConfig?.conflictPolicy ?? {})
+            }
+          }
+        }).sentinelConfig;
 
         updatedRepo = normalizeRepo({
           ...repo,
-          autoReview: mergedAutoReview,
           ...patch,
+          autoReview: mergedAutoReview,
+          sentinelConfig: normalizedSentinelConfig,
           slug: patch.slug ?? patch.projectPath ?? repo.slug,
           projectPath: patch.projectPath ?? patch.slug ?? repo.projectPath,
           updatedAt: nowIso()
@@ -323,6 +387,7 @@ export class LocalAgentBoardApi implements AgentBoardApi {
       taskPrompt: input.taskPrompt,
       acceptanceCriteria: input.acceptanceCriteria,
       context: input.context,
+      tags: normalizeTaskTags(input.tags),
       baselineUrlOverride: input.baselineUrlOverride,
       status: input.status ?? 'INBOX',
       createdAt: timestamp,
@@ -348,8 +413,13 @@ export class LocalAgentBoardApi implements AgentBoardApi {
     return task;
   }
 
-  async listTasks(filter?: { repoId?: string }): Promise<Task[]> {
-    return getTasksForRepo(this.store.getSnapshot().tasks, filter?.repoId ?? 'all');
+  async listTasks(filter?: { repoId?: string; tags?: string[] }): Promise<Task[]> {
+    const tasks = getTasksForRepo(this.store.getSnapshot().tasks, filter?.repoId ?? 'all');
+    const tags = normalizeTaskTags(filter?.tags);
+    if (!tags) {
+      return tasks;
+    }
+    return tasks.filter((task) => tags.every((tag) => task.tags?.includes(tag)));
   }
 
   async getTask(taskId: string): Promise<TaskDetail> {
@@ -375,6 +445,7 @@ export class LocalAgentBoardApi implements AgentBoardApi {
           ...patch,
           sourceRef: patch.sourceRef ?? task.sourceRef,
           context: patch.context ?? task.context,
+          tags: Object.prototype.hasOwnProperty.call(patch, 'tags') ? normalizeTaskTags(patch.tags) : normalizeTaskTags(task.tags),
           acceptanceCriteria: patch.acceptanceCriteria ?? task.acceptanceCriteria,
           uiMeta: normalizeTaskUiMeta({
             simulationProfile: patch.simulationProfile ?? task.uiMeta?.simulationProfile ?? 'happy_path',
@@ -607,6 +678,23 @@ export class LocalAgentBoardApi implements AgentBoardApi {
     await this.startRun(task.taskId);
     return this.store.getSnapshot().tasks.find((candidate) => candidate.taskId === task.taskId)!;
   }
+}
+
+function normalizeTaskTags(tags: Task['tags']) {
+  if (!Array.isArray(tags)) {
+    return undefined;
+  }
+  const seen = new Set<string>();
+  const normalized: string[] = [];
+  for (const tag of tags) {
+    const trimmed = tag.trim();
+    if (!trimmed || seen.has(trimmed)) {
+      continue;
+    }
+    seen.add(trimmed);
+    normalized.push(trimmed);
+  }
+  return normalized.length ? normalized : undefined;
 }
 
 let singleton: LocalAgentBoardApi | undefined;


### PR DESCRIPTION
Task: S1 - Sentinel Domain and Persistence Foundation

Add sentinel config, task tags, runtime entities, and persistence primitives required for native orchestration.
Source ref: main

Acceptance criteria:
- Repo sentinel config persists and resolves with deterministic defaults.
- Task tags are persisted and queryable.
- Sentinel run and event entities are stored and readable.
- Backward compatibility is preserved for existing task/repo payloads.
- make sure that "yarn test" passes

Run ID: run_repo_abuiles_agents_kanban_mmbfqabjidq1