### PR TITLE
AR4 - Orchestrator Auto-Review Trigger and Manual Re-Run

### DIFF
--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -34,6 +34,7 @@ import {
   handleListTasks,
   handleMe,
   handleRequestChanges,
+  handleRerunReview,
   handleRetryEvidence,
   handleRetryPreview,
   handleRetryRun,
@@ -115,6 +116,9 @@ apiRouter.get('/api/runs/:runId', (c: Context) =>
 );
 apiRouter.post('/api/runs/:runId/retry', (c: Context) =>
   handleRetryRun(c.req.raw, c.env as Env, { runId: c.req.param('runId') }, c.executionCtx as unknown as ExecutionContext<unknown>)
+);
+apiRouter.post('/api/runs/:runId/review', (c: Context) =>
+  handleRerunReview(c.req.raw, c.env as Env, { runId: c.req.param('runId') }, c.executionCtx as unknown as ExecutionContext<unknown>)
 );
 apiRouter.post('/api/runs/:runId/cancel', (c: Context) =>
   handleCancelRun(c.req.raw, c.env as Env, { runId: c.req.param('runId') })

--- a/src/server/durable/repo-board.ts
+++ b/src/server/durable/repo-board.ts
@@ -37,7 +37,7 @@ const MAX_EVENT_MESSAGE_CHARS = 600;
 const MAX_COMMAND_PREVIEW_CHARS = 1000;
 
 type RepoScopedEvent = BoardEvent & { repoId?: string };
-type LocalJobs = Record<string, 'full_run' | 'evidence_only' | 'preview_only'>;
+type LocalJobs = Record<string, 'full_run' | 'evidence_only' | 'preview_only' | 'review_only'>;
 
 export class RepoBoardDO extends DurableObject<Env> {
   private state: RepoBoardState = EMPTY_REPO_BOARD_STATE;
@@ -504,7 +504,7 @@ export class RepoBoardDO extends DurableObject<Env> {
   async transitionRun(runId: string, patch: RunTransitionPatch, tenantId?: string): Promise<AgentRun> {
     await this.ready;
     const run = await this.getRun(runId, tenantId);
-    if (isTerminalRunStatus(run.status)) {
+    if (isTerminalRunStatus(run.status) && patch.status && patch.status !== run.status) {
       return run;
     }
     const nowIso = new Date().toISOString();
@@ -798,7 +798,7 @@ export class RepoBoardDO extends DurableObject<Env> {
     return updated;
   }
 
-  async scheduleLocalRun(runId: string, mode: 'full_run' | 'evidence_only' | 'preview_only') {
+  async scheduleLocalRun(runId: string, mode: 'full_run' | 'evidence_only' | 'preview_only' | 'review_only') {
     await this.ready;
     this.localJobs[runId] = mode;
     await this.persistLocalJobs();
@@ -1151,6 +1151,14 @@ function cloneRepoBoardState(state: RepoBoardState): RepoBoardState {
               : undefined
           }
         : undefined,
+      reviewExecution: run.reviewExecution ? { ...run.reviewExecution } : undefined,
+      reviewFindings: run.reviewFindings?.map((finding) => ({
+        ...finding,
+        replyContext: finding.replyContext ? [...finding.replyContext] : undefined
+      })),
+      reviewFindingsSummary: run.reviewFindingsSummary ? { ...run.reviewFindingsSummary } : undefined,
+      reviewArtifacts: run.reviewArtifacts ? { ...run.reviewArtifacts } : undefined,
+      reviewPostState: run.reviewPostState ? { ...run.reviewPostState, errors: [...(run.reviewPostState.errors ?? [])] } : undefined,
       artifacts: run.artifacts ? [...run.artifacts] : undefined,
       latestCodexResumeCommand: (run.llmAdapter ?? run.operatorSession?.llmAdapter ?? 'codex') === 'codex'
         ? (run.latestCodexResumeCommand ?? run.llmResumeCommand)
@@ -1217,7 +1225,15 @@ function normalizeRepoBoardState(state?: Partial<RepoBoardState> | null): RepoBo
                 }
               : undefined
           }
-        : undefined
+        : undefined,
+      reviewExecution: run.reviewExecution ? { ...run.reviewExecution } : undefined,
+      reviewFindings: run.reviewFindings?.map((finding) => ({
+        ...finding,
+        replyContext: finding.replyContext ? [...finding.replyContext] : undefined
+      })),
+      reviewFindingsSummary: run.reviewFindingsSummary ? { ...run.reviewFindingsSummary } : undefined,
+      reviewArtifacts: run.reviewArtifacts ? { ...run.reviewArtifacts } : undefined,
+      reviewPostState: run.reviewPostState ? { ...run.reviewPostState, errors: [...(run.reviewPostState.errors ?? [])] } : undefined
     };
   });
   const runTenantIds = new Map(normalizedRuns.map((run) => [run.runId, run.tenantId]));

--- a/src/server/router.review.test.ts
+++ b/src/server/router.review.test.ts
@@ -1,0 +1,121 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const tenantAuthDbMocks = vi.hoisted(() => ({
+  resolveSessionByToken: vi.fn(),
+  hasActiveTenantAccess: vi.fn(),
+  getTenantMembership: vi.fn(),
+  resolveApiToken: vi.fn(),
+  listUserMemberships: vi.fn()
+}));
+
+const orchestratorMocks = vi.hoisted(() => ({
+  scheduleRunJob: vi.fn()
+}));
+
+vi.mock('./tenant-auth-db', () => tenantAuthDbMocks);
+vi.mock('./run-orchestrator', () => orchestratorMocks);
+
+import { handleRerunReview } from './router';
+
+function createEnv(runOverrides: Record<string, unknown> = {}): Env {
+  let run = {
+    runId: 'run_repo_1_demo',
+    repoId: 'repo_1',
+    taskId: 'task_1',
+    reviewUrl: 'https://github.com/acme/demo/pull/7',
+    reviewNumber: 7,
+    reviewExecution: {
+      enabled: true,
+      trigger: 'auto_on_review',
+      promptSource: 'native',
+      status: 'completed',
+      round: 1
+    },
+    ...runOverrides
+  };
+
+  const repoBoard = {
+    getRun: vi.fn(async () => run),
+    transitionRun: vi.fn(async (_runId: string, patch: Record<string, unknown>) => {
+      run = { ...run, ...patch };
+      return run;
+    })
+  };
+
+  const board = {
+    findRunRepoId: vi.fn(async () => 'repo_1'),
+    getRepo: vi.fn(async () => ({ repoId: 'repo_1', tenantId: 'tenant_local' }))
+  };
+
+  return {
+    BOARD_INDEX: {
+      getByName: vi.fn(() => board)
+    },
+    REPO_BOARD: {
+      getByName: vi.fn(() => repoBoard)
+    }
+  } as unknown as Env;
+}
+
+describe('handleRerunReview', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    tenantAuthDbMocks.resolveSessionByToken.mockResolvedValue({
+      user: { id: 'user_1' },
+      session: { id: 'sess_1', activeTenantId: 'tenant_local' }
+    });
+    tenantAuthDbMocks.hasActiveTenantAccess.mockResolvedValue(true);
+    orchestratorMocks.scheduleRunJob.mockResolvedValue({ id: 'wf_review_1' });
+  });
+
+  it('queues manual review rerun using review_only mode', async () => {
+    const response = await handleRerunReview(
+      new Request('https://minions.example.test/api/runs/run_repo_1_demo/review', {
+        method: 'POST',
+        headers: { 'x-session-token': 'session-token' }
+      }),
+      createEnv(),
+      { runId: 'run_repo_1_demo' },
+      {} as ExecutionContext<unknown>
+    );
+
+    const body = await response.json() as { runId: string; workflowInstanceId?: string };
+
+    expect(response.status).toBe(200);
+    expect(orchestratorMocks.scheduleRunJob).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({ mode: 'review_only', runId: 'run_repo_1_demo' })
+    );
+    expect(body.runId).toBe('run_repo_1_demo');
+    expect(body.workflowInstanceId).toBe('wf_review_1');
+  });
+
+  it('is idempotent-safe when review execution is already running', async () => {
+    const env = createEnv({
+      reviewExecution: {
+        enabled: true,
+        trigger: 'manual_rerun',
+        promptSource: 'native',
+        status: 'running',
+        round: 2
+      }
+    });
+
+    const response = await handleRerunReview(
+      new Request('https://minions.example.test/api/runs/run_repo_1_demo/review', {
+        method: 'POST',
+        headers: { 'x-session-token': 'session-token' }
+      }),
+      env,
+      { runId: 'run_repo_1_demo' },
+      {} as ExecutionContext<unknown>
+    );
+
+    const body = await response.json() as { reviewExecution?: { status?: string; round?: number } };
+
+    expect(response.status).toBe(200);
+    expect(orchestratorMocks.scheduleRunJob).not.toHaveBeenCalled();
+    expect(body.reviewExecution).toMatchObject({ status: 'running', round: 2 });
+  });
+});

--- a/src/server/router.ts
+++ b/src/server/router.ts
@@ -31,6 +31,7 @@ import { parseBoardSnapshot } from '../ui/store/board-snapshot';
 import { scheduleRunJob } from './run-orchestrator';
 import { getRunUsage, getTenantRunUsage, getTenantUsageSummary } from './usage-reporting';
 import { normalizeTenantId, normalizeTenantIdStrict } from '../shared/tenant';
+import { hasRunReview } from '../shared/scm';
 import * as tenantAuthDb from './tenant-auth-db';
 import {
   handleSlackCommands as handleSlackCommandsHandler,
@@ -630,6 +631,38 @@ export async function handleRetryRun(request: Request, env: Env, params: RoutePa
       orchestrationMode: workflow.id.startsWith('local-alarm-') ? 'local_alarm' : 'workflow'
     });
     return json(await env.REPO_BOARD.getByName(repoId).getRun(run.runId, requestContext.activeTenantId));
+  });
+}
+
+export async function handleRerunReview(request: Request, env: Env, params: RouteParams, ctx: ExecutionContext<unknown>): Promise<Response> {
+  return withApiError(async () => {
+    const board = getBoard(env);
+    const requestContext = await resolveRequestTenantContext(env, board, request, { requireSession: true });
+    const runId = parsePathParam(params.runId);
+    const repoId = await resolveRepoIdForRun(board, runId);
+    await assertRepoAccess(env, board, requestContext, repoId);
+    const repoBoard = env.REPO_BOARD.getByName(repoId);
+    const run = await repoBoard.getRun(runId, requestContext.activeTenantId);
+    if (!hasRunReview(run)) {
+      throw badRequest('Manual review rerun requires an existing review context on this run.');
+    }
+    if (run.reviewExecution?.status === 'running') {
+      return json(run);
+    }
+
+    const workflow = await scheduleRunJob(env, ctx as unknown as ExecutionContext, {
+      tenantId: requestContext.activeTenantId,
+      repoId,
+      taskId: run.taskId,
+      runId,
+      mode: 'review_only'
+    });
+    await repoBoard.transitionRun(run.runId, {
+      workflowInstanceId: workflow.id,
+      orchestrationMode: workflow.id.startsWith('local-alarm-') ? 'local_alarm' : 'workflow',
+      appendTimelineNote: 'Manual review rerun queued.'
+    });
+    return json(await repoBoard.getRun(run.runId, requestContext.activeTenantId));
   });
 }
 

--- a/src/server/run-orchestrator.llm.test.ts
+++ b/src/server/run-orchestrator.llm.test.ts
@@ -254,7 +254,8 @@ function createHarness(task: Task, repo: Repo) {
     RUN_ARTIFACTS: {
       get: vi.fn().mockResolvedValue({
         arrayBuffer: async () => new TextEncoder().encode('bundle').buffer
-      })
+      }),
+      put: vi.fn().mockResolvedValue(undefined)
     }
   } as unknown as Env;
 
@@ -288,6 +289,113 @@ beforeEach(() => {
 });
 
 describe('executeRunJob LLM adapter coverage', () => {
+  it('auto-runs review on REVIEW entry when enabled', async () => {
+    const task = buildTask({
+      sourceRef: 'https://jira.example.com/browse/AK-123',
+      uiMeta: {
+        llmAdapter: 'codex',
+        llmModel: 'gpt-5.3-codex',
+        llmReasoningEffort: 'medium'
+      }
+    });
+    const repo = buildRepo({
+      autoReview: {
+        enabled: true,
+        provider: 'jira',
+        postInline: false
+      }
+    });
+    const harness = createHarness(task, repo);
+    (harness.env as unknown as { JIRA_TOKEN?: string }).JIRA_TOKEN = 'jira-token-test';
+    const sandbox = buildSandbox([
+      { type: 'stdout', data: 'Applied fix.\n' },
+      { type: 'exit', exitCode: 0 }
+    ]);
+    const baseExec = sandbox.exec.bind(sandbox);
+    sandbox.exec = async (command) => {
+      if (command.includes('/workspace/prompt-last-message.txt')) {
+        return {
+          success: true,
+          exitCode: 0,
+          stdout: '\n===CODEX_LAST_MESSAGE===\n{"findings":[{"severity":"high","title":"Missing empty state guard","description":"Add a guard for null payloads.","filePath":"src/index.ts","lineStart":12}]}\n'
+        };
+      }
+      return baseExec(command);
+    };
+    sandboxState.current = sandbox;
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes('/rest/api/2/issue/AK-123/comment') && init?.method === 'POST') {
+        return new Response(JSON.stringify({ id: '301' }), { status: 200 });
+      }
+      if (url.includes('/rest/api/2/issue/AK-123/comment')) {
+        return new Response(JSON.stringify({ comments: [] }), { status: 200 });
+      }
+      throw new Error(`Unexpected fetch URL: ${url}`);
+    }));
+
+    await executeRunJob(harness.env, { tenantId: 'tenant_legacy', repoId: repo.repoId, taskId: task.taskId, runId: 'run_1', mode: 'full_run' }, async () => {});
+
+    expect(harness.getRun().reviewExecution).toMatchObject({
+      enabled: true,
+      trigger: 'auto_on_review',
+      status: 'completed',
+      round: 1,
+      promptSource: 'native'
+    });
+    expect(harness.getRun().reviewFindingsSummary).toMatchObject({
+      total: 1,
+      open: 1,
+      posted: 1,
+      provider: 'jira'
+    });
+    expect(harness.getRun().reviewPostState).toMatchObject({
+      provider: 'jira',
+      status: 'completed',
+      postedCount: 1,
+      findingsCount: 1
+    });
+    expect(harness.getRun().reviewArtifacts).toEqual({
+      findingsJsonKey: 'tenants/tenant_legacy/runs/run_1/review/findings.json',
+      reviewMarkdownKey: 'tenants/tenant_legacy/runs/run_1/review/review-findings.md'
+    });
+    expect(harness.getRun().timeline.some((entry) => entry.note?.includes('Auto review started (round 1).'))).toBe(true);
+    expect(harness.getRun().timeline.some((entry) => entry.note?.includes('Review completed (round 1; 1 findings, 1 posted).'))).toBe(true);
+  });
+
+  it('skips auto-review when effective setting is disabled', async () => {
+    const task = buildTask({
+      uiMeta: {
+        llmAdapter: 'codex',
+        llmModel: 'gpt-5.3-codex',
+        llmReasoningEffort: 'medium'
+      }
+    });
+    const repo = buildRepo({
+      autoReview: {
+        enabled: false,
+        provider: 'jira',
+        postInline: false
+      }
+    });
+    const harness = createHarness(task, repo);
+    sandboxState.current = buildSandbox([
+      { type: 'stdout', data: 'Applied fix.\n' },
+      { type: 'exit', exitCode: 0 }
+    ]);
+
+    await executeRunJob(harness.env, { tenantId: 'tenant_legacy', repoId: repo.repoId, taskId: task.taskId, runId: 'run_1', mode: 'full_run' }, async () => {});
+
+    expect(harness.getRun().reviewExecution).toMatchObject({
+      enabled: false,
+      trigger: 'auto_on_review',
+      status: 'not_started',
+      round: 0
+    });
+    expect(harness.getRun().reviewFindings).toBeUndefined();
+    expect(harness.getRun().timeline.some((entry) => entry.note?.includes('Auto-review skipped: disabled for this run context.'))).toBe(true);
+  });
+
   it('preserves Codex resume/session parity through the adapterized execution path', async () => {
     const task = buildTask({
       uiMeta: {

--- a/src/server/run-orchestrator.ts
+++ b/src/server/run-orchestrator.ts
@@ -1,7 +1,7 @@
 import { getSandbox, type ExecResult } from '@cloudflare/sandbox';
 import type { RepoBoardDO } from './durable/repo-board';
 import type { BoardIndexDO } from './durable/board-index';
-import type { LlmReasoningEffort, Repo, RunCommand, RunCommandPhase, RunEvent, Task } from '../ui/domain/types';
+import type { AutoReviewProvider, LlmReasoningEffort, Repo, RunCommand, RunCommandPhase, RunEvent, Task } from '../ui/domain/types';
 import { buildRunLog, type RunJobParams } from './shared/real-run';
 import { NonRetryableError } from 'cloudflare:workflows';
 import { buildWorkflowInvocationId } from './workflow-id';
@@ -17,6 +17,18 @@ import type { PreviewAdapterContext, PreviewAdapterResult } from './preview/adap
 import { writeUsageLedgerEntriesBestEffort } from './usage-ledger';
 import { normalizeTenantId } from '../shared/tenant';
 import { redactSensitiveText } from './security/redaction';
+import {
+  attachReviewArtifactsToManifest,
+  buildReviewArtifactPointers,
+  buildReviewFindingsJsonArtifact,
+  buildReviewFindingsMarkdownArtifact,
+  buildRunReviewArtifacts,
+  parseReviewFindings,
+  resolveAutoReviewConfig,
+  REVIEW_FINDINGS_OUTPUT_SCHEMA
+} from './shared/review-contract';
+import { executePromptWithLlmAdapter } from './llm/runtime';
+import { getReviewPostingAdapter } from './review-posting/registry';
 
 type WorkflowBinding<T> = {
   create(options?: { id?: string; params?: T; retention?: { successRetention?: string | number; errorRetention?: string | number } }): Promise<{ id: string }>;
@@ -27,12 +39,13 @@ type Stage3Env = Env & {
   RUN_ARTIFACTS?: R2Bucket;
   GITHUB_TOKEN?: string;
   GITLAB_TOKEN?: string;
+  JIRA_TOKEN?: string;
   OPENAI_API_KEY?: string;
 };
 
 type SleepFn = (name: string, duration: number | `${number} ${string}`) => Promise<void>;
 type RunPhase = NonNullable<ReturnType<typeof buildRunLog>['phase']>;
-type SandboxRole = 'main' | 'preview' | 'evidence';
+type SandboxRole = 'main' | 'preview' | 'evidence' | 'review';
 type PushRemediationResult = {
   branchName?: string;
   diagnostics: string;
@@ -59,7 +72,7 @@ export async function executeRunJob(env: Env, params: RunJobParams, sleepFn: Sle
   const board = env.BOARD_INDEX.getByName('agentboard') as DurableObjectStub<BoardIndexDO>;
   const detail = await repoBoard.getTask(params.taskId);
   const run = await repoBoard.getRun(params.runId);
-  if (run.status === 'FAILED' || run.status === 'DONE') {
+  if ((run.status === 'FAILED' || run.status === 'DONE') && params.mode !== 'review_only') {
     return;
   }
   const repo = await board.getRepo(params.repoId);
@@ -136,6 +149,11 @@ export async function executeRunJob(env: Env, params: RunJobParams, sleepFn: Sle
         await getScmCredential(env as Stage3Env, repo, scmAdapter),
         promptRecipeRuntime
       );
+    }
+
+    if (params.mode === 'review_only') {
+      await executeRunReview(env as Stage3Env, repoBoard, detail.task, repo, params.runId, 'manual_rerun', sleepFn);
+      return;
     }
 
     const scmCredential = await getScmCredential(env as Stage3Env, repo, scmAdapter);
@@ -452,6 +470,8 @@ export async function executeRunJob(env: Env, params: RunJobParams, sleepFn: Sle
       throw error;
     }
 
+    await executeRunReview(env as Stage3Env, repoBoard, detail.task, repo, params.runId, 'auto_on_review', sleepFn);
+
     if (!shouldRunPreview(repo)) {
       await finishRunWithoutPreview(repoBoard, params.runId, 'Preview discovery and evidence are disabled for this repo.');
       return;
@@ -557,6 +577,270 @@ npx -y playwright install chromium
     await scmAdapter.upsertRunComment(repo, task, updated, scmCredential);
   }
   await repoBoard.transitionRun(runId, { status: 'DONE', evidenceStatus: 'READY', endedAt: new Date().toISOString(), appendTimelineNote: 'Evidence captured and manifest stored.' });
+}
+
+async function executeRunReview(
+  env: Stage3Env,
+  repoBoard: DurableObjectStub<RepoBoardDO>,
+  task: Task,
+  repo: Repo,
+  runId: string,
+  trigger: 'auto_on_review' | 'manual_rerun',
+  sleepFn: SleepFn
+) {
+  const baseRun = await repoBoard.getRun(runId);
+  if (baseRun.reviewExecution?.status === 'running') {
+    return;
+  }
+
+  const autoReview = resolveAutoReviewConfig(repo, task);
+  const previousRound = baseRun.reviewExecution?.round ?? 0;
+  if (!autoReview.enabled) {
+    await repoBoard.transitionRun(runId, {
+      reviewExecution: {
+        enabled: false,
+        trigger,
+        promptSource: autoReview.promptSource,
+        status: 'not_started',
+        round: previousRound
+      },
+      appendTimelineNote: trigger === 'auto_on_review'
+        ? 'Auto-review skipped: disabled for this run context.'
+        : 'Manual review rerun skipped: auto-review is disabled for this run context.'
+    });
+    return;
+  }
+
+  const startedAt = new Date().toISOString();
+  const round = previousRound + 1;
+  await repoBoard.transitionRun(runId, {
+    reviewExecution: {
+      enabled: true,
+      trigger,
+      promptSource: autoReview.promptSource,
+      status: 'running',
+      round,
+      startedAt
+    },
+    reviewPostState: {
+      provider: autoReview.provider,
+      round,
+      status: 'not_attempted',
+      startedAt,
+      postedCount: 0,
+      findingsCount: 0,
+      errors: []
+    },
+    appendTimelineNote: `${trigger === 'auto_on_review' ? 'Auto' : 'Manual'} review started (round ${round}).`
+  });
+  await repoBoard.appendRunLogs(runId, [
+    buildRunLog(runId, `Running ${trigger === 'auto_on_review' ? 'automatic' : 'manual'} review round ${round}.`, 'pr')
+  ]);
+
+  try {
+    const run = await repoBoard.getRun(runId);
+    const llmAdapterKind = resolveLlmAdapterKind(task, run.llmAdapter);
+    const llmAdapter = getLlmAdapter(llmAdapterKind);
+    const llmModel = task.uiMeta?.llmModel ?? task.uiMeta?.codexModel ?? 'gpt-5.1-codex-mini';
+    const llmReasoningEffort = task.uiMeta?.llmReasoningEffort ?? task.uiMeta?.codexReasoningEffort ?? 'medium';
+    const scmAdapter = getScmAdapter(repo);
+    const scmCredential = await getScmCredential(env, repo, scmAdapter);
+    const reviewSandbox = getSandbox(env.Sandbox, buildSandboxId(runId, 'review'));
+    const llmContext = { env, sandbox: reviewSandbox, repoBoard, runId };
+
+    await emitCommandLifecycle(repoBoard, runId, 'pr', 'mkdir -p /workspace/repo', () => reviewSandbox.exec('mkdir -p /workspace/repo'));
+    await configureSandboxRuntimeSecrets(reviewSandbox, env);
+    await reviewSandbox.gitCheckout(scmAdapter.buildCloneUrl(repo, scmCredential), {
+      branch: repo.defaultBranch,
+      targetDir: '/workspace/repo'
+    });
+    const checkout = await emitCommandLifecycle(
+      repoBoard,
+      runId,
+      'pr',
+      `cd /workspace/repo && git fetch origin ${shellEscape(run.branchName)} && git checkout -B ${shellEscape(run.branchName)} FETCH_HEAD`,
+      () => reviewSandbox.exec(`cd /workspace/repo && git fetch origin ${shellEscape(run.branchName)} && git checkout -B ${shellEscape(run.branchName)} FETCH_HEAD`)
+    );
+    if (!checkout.success) {
+      throw new Error(checkout.stderr || `Failed to prepare review branch ${run.branchName}.`);
+    }
+
+    const promptResult = await executePromptWithLlmAdapter(
+      llmAdapter,
+      llmContext,
+      {
+        repo,
+        task,
+        run,
+        cwd: '/workspace/repo',
+        prompt: buildReviewPrompt(task, repo, run, autoReview.prompt),
+        model: llmModel,
+        reasoningEffort: llmReasoningEffort,
+        timeoutMs: 180_000,
+        outputSchema: REVIEW_FINDINGS_OUTPUT_SCHEMA,
+        phase: 'pr'
+      },
+      sleepFn
+    );
+    if (promptResult.status !== 'success') {
+      throw new Error(
+        promptResult.status === 'timed_out'
+          ? `Review prompt timed out after ${promptResult.timeoutMs}ms.`
+          : promptResult.message
+      );
+    }
+
+    const parsed = parseReviewFindings(promptResult.rawOutput);
+    if (!parsed.ok) {
+      throw new Error(`${parsed.code}: ${parsed.message}`);
+    }
+
+    const postingStartedAt = new Date().toISOString();
+    let postErrors: string[] = [];
+    let postedCount = 0;
+    let findings = parsed.findings;
+    let summaryPosted: boolean | undefined;
+    let summaryThreadId: string | undefined;
+    let summaryThreadUrl: string | undefined;
+    const reviewCredential = getReviewPostingCredential(env, autoReview.provider);
+
+    if (!reviewCredential) {
+      postErrors = [`Missing ${autoReview.provider === 'gitlab' ? 'GITLAB_TOKEN' : 'JIRA_TOKEN'} for review posting provider ${autoReview.provider}.`];
+    } else {
+      try {
+        const postingAdapter = getReviewPostingAdapter(autoReview.provider);
+        const posting = await postingAdapter.postFindings({
+          repo,
+          task,
+          run,
+          findings,
+          credential: reviewCredential,
+          postInline: autoReview.postInline
+        });
+        findings = posting.updatedFindings;
+        postedCount = posting.findings.filter((entry) => entry.posted).length;
+        postErrors = posting.errors;
+        summaryPosted = posting.summary?.posted;
+        summaryThreadId = posting.summary?.providerThreadId;
+        summaryThreadUrl = posting.summary?.providerThreadUrl;
+      } catch (error) {
+        postErrors = [error instanceof Error ? error.message : String(error)];
+      }
+    }
+
+    const pointers = buildReviewArtifactPointers({ tenantId: run.tenantId, runId });
+    const findingsJson = buildReviewFindingsJsonArtifact(findings);
+    const findingsMarkdown = buildReviewFindingsMarkdownArtifact(findings);
+    await persistReviewArtifacts(env, run, pointers.findingsJson.key, findingsJson, pointers.reviewMarkdown.key, findingsMarkdown);
+    const reviewArtifacts = buildRunReviewArtifacts({ tenantId: run.tenantId, runId });
+    const latestRun = await repoBoard.getRun(runId);
+    const endedAt = new Date().toISOString();
+
+    await repoBoard.transitionRun(runId, {
+      reviewExecution: {
+        enabled: true,
+        trigger,
+        promptSource: autoReview.promptSource,
+        status: 'completed',
+        round,
+        startedAt,
+        endedAt,
+        durationMs: Math.max(0, Date.parse(endedAt) - Date.parse(startedAt))
+      },
+      reviewFindings: findings,
+      reviewFindingsSummary: {
+        total: findings.length,
+        open: findings.filter((finding) => finding.status === 'open').length,
+        posted: postedCount,
+        provider: autoReview.provider
+      },
+      reviewArtifacts,
+      reviewPostState: {
+        provider: autoReview.provider,
+        round,
+        status: postErrors.length ? 'failed' : 'completed',
+        startedAt: postingStartedAt,
+        endedAt,
+        postedCount,
+        findingsCount: findings.length,
+        errors: postErrors,
+        summaryPosted,
+        summaryThreadId,
+        summaryThreadUrl
+      },
+      artifactManifest: latestRun.artifactManifest
+        ? attachReviewArtifactsToManifest(latestRun.artifactManifest, { tenantId: run.tenantId, runId })
+        : undefined,
+      artifacts: [...new Set([...(latestRun.artifacts ?? []), reviewArtifacts.findingsJsonKey, reviewArtifacts.reviewMarkdownKey])],
+      appendTimelineNote: `Review completed (round ${round}; ${findings.length} findings, ${postedCount} posted).`
+    });
+    await repoBoard.appendRunLogs(runId, [
+      buildRunLog(runId, `Review round ${round} completed with ${findings.length} findings (${postedCount} posted).`, 'pr')
+    ]);
+  } catch (error) {
+    const endedAt = new Date().toISOString();
+    const message = redactSensitiveText(error instanceof Error ? error.message : String(error));
+    const latestRun = await repoBoard.getRun(runId);
+    await repoBoard.appendRunLogs(runId, [buildRunLog(runId, message, 'pr', 'error')]);
+    await repoBoard.transitionRun(runId, {
+      reviewExecution: {
+        enabled: true,
+        trigger,
+        promptSource: autoReview.promptSource,
+        status: 'failed',
+        round,
+        startedAt,
+        endedAt,
+        durationMs: Math.max(0, Date.parse(endedAt) - Date.parse(startedAt))
+      },
+      reviewPostState: latestRun.reviewPostState?.round === round
+        ? {
+            ...latestRun.reviewPostState,
+            status: 'failed',
+            endedAt,
+            errors: latestRun.reviewPostState.errors.length ? latestRun.reviewPostState.errors : [message]
+          }
+        : {
+            provider: autoReview.provider,
+            round,
+            status: 'failed',
+            startedAt,
+            endedAt,
+            postedCount: 0,
+            findingsCount: 0,
+            errors: [message]
+          },
+      appendTimelineNote: `Review failed (round ${round}): ${message}`
+    });
+  }
+}
+
+function buildReviewPrompt(task: Task, repo: Repo, run: Awaited<ReturnType<RepoBoardDO['getRun']>>, customPrompt?: string) {
+  const reviewIntent = customPrompt?.trim()
+    ? `Review instructions:\n${customPrompt.trim()}`
+    : [
+        'Review instructions:',
+        'Perform a code review focused on correctness, regressions, security risks, and missing tests.',
+        'Only report actionable findings that should block merge.'
+      ].join('\n');
+
+  return [
+    `You are reviewing code changes for ${repo.slug}.`,
+    `Run: ${run.runId}`,
+    `Branch: ${run.branchName}`,
+    '',
+    `Task: ${task.title}`,
+    task.description ? `Task description: ${task.description}` : undefined,
+    '',
+    'Acceptance criteria:',
+    ...task.acceptanceCriteria.map((item) => `- ${item}`),
+    '',
+    reviewIntent,
+    '',
+    'Return JSON only using this exact schema shape:',
+    '{ "findings": [ { "severity": "critical|high|medium|low|info", "title": "string", "description": "string", "filePath": "string?", "lineStart": "number?", "lineEnd": "number?" } ] }',
+    'If there are no issues, return {"findings":[]}.'
+  ].filter(Boolean).join('\n');
 }
 
 async function waitForPreview(
@@ -807,6 +1091,13 @@ async function getScmCredential(
   );
 }
 
+function getReviewPostingCredential(env: Stage3Env, provider: AutoReviewProvider) {
+  if (provider === 'gitlab') {
+    return env.GITLAB_TOKEN?.trim() ? { token: env.GITLAB_TOKEN.trim() } : undefined;
+  }
+  return env.JIRA_TOKEN?.trim() ? { token: env.JIRA_TOKEN.trim() } : undefined;
+}
+
 async function configureSandboxRuntimeSecrets(
   sandbox: ReturnType<typeof getSandbox>,
   env: Stage3Env
@@ -850,6 +1141,47 @@ async function persistArtifactManifest(env: Stage3Env, run: Awaited<ReturnType<R
       quantity: payload.length,
       source: 'workflow',
       metadata: { object: 'manifest.json' }
+    }
+  ]);
+}
+
+async function persistReviewArtifacts(
+  env: Stage3Env,
+  run: Awaited<ReturnType<RepoBoardDO['getRun']>>,
+  findingsJsonKey: string,
+  findingsJson: string,
+  reviewMarkdownKey: string,
+  reviewMarkdown: string
+) {
+  if (!env.RUN_ARTIFACTS) {
+    return;
+  }
+  await env.RUN_ARTIFACTS.put(findingsJsonKey, findingsJson, {
+    httpMetadata: { contentType: 'application/json' }
+  });
+  await env.RUN_ARTIFACTS.put(reviewMarkdownKey, reviewMarkdown, {
+    httpMetadata: { contentType: 'text/markdown; charset=utf-8' }
+  });
+  await writeUsageLedgerEntriesBestEffort(env, [
+    {
+      tenantId: normalizeTenantId(run.tenantId),
+      repoId: run.repoId,
+      taskId: run.taskId,
+      runId: run.runId,
+      category: 'r2_write_ops',
+      quantity: 2,
+      source: 'workflow',
+      metadata: { object: 'review-artifacts' }
+    },
+    {
+      tenantId: normalizeTenantId(run.tenantId),
+      repoId: run.repoId,
+      taskId: run.taskId,
+      runId: run.runId,
+      category: 'r2_storage_bytes',
+      quantity: findingsJson.length + reviewMarkdown.length,
+      source: 'workflow',
+      metadata: { object: 'review-artifacts' }
     }
   ]);
 }

--- a/src/server/shared/real-run.ts
+++ b/src/server/shared/real-run.ts
@@ -3,7 +3,7 @@ import { DEFAULT_SUPPORTS_RESUME_BY_ADAPTER, normalizeRunLlmState, normalizeTask
 import { normalizeRunReviewMetadata } from '../../shared/scm';
 import { normalizeTenantId } from '../../shared/tenant';
 
-export type RunJobMode = 'full_run' | 'evidence_only' | 'preview_only';
+export type RunJobMode = 'full_run' | 'evidence_only' | 'preview_only' | 'review_only';
 
 export type RunJobParams = {
   tenantId: string;
@@ -48,6 +48,11 @@ export type RunTransitionPatch = {
   artifactManifest?: ArtifactManifest;
   artifacts?: string[];
   executionSummary?: AgentRun['executionSummary'];
+  reviewExecution?: AgentRun['reviewExecution'];
+  reviewFindings?: AgentRun['reviewFindings'];
+  reviewFindingsSummary?: AgentRun['reviewFindingsSummary'];
+  reviewArtifacts?: AgentRun['reviewArtifacts'];
+  reviewPostState?: AgentRun['reviewPostState'];
   endedAt?: string;
   currentStepStartedAt?: string;
   appendTimelineNote?: string;
@@ -189,6 +194,20 @@ export function buildArtifactManifest(run: AgentRun, task: Task, repo: Repo, env
       label: 'Playwright video',
       url: `r2://${baseKey}/evidence/video.mp4`
     },
+    reviewFindingsJson: run.reviewArtifacts
+      ? {
+          key: run.reviewArtifacts.findingsJsonKey,
+          label: 'Review findings JSON',
+          url: `r2://${run.reviewArtifacts.findingsJsonKey}`
+        }
+      : undefined,
+    reviewMarkdown: run.reviewArtifacts
+      ? {
+          key: run.reviewArtifacts.reviewMarkdownKey,
+          label: 'Review markdown',
+          url: `r2://${run.reviewArtifacts.reviewMarkdownKey}`
+        }
+      : undefined,
     metadata: {
       tenantId: normalizeTenantId(run.tenantId),
       generatedAt: new Date().toISOString(),

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -205,6 +205,12 @@ export default function App({ api: providedApi }: { api?: AgentBoardApi }) {
     setNotice('Started a fresh run.');
   }
 
+  async function rerunReview(runId: string) {
+    const run = await api.rerunReview(runId);
+    await api.setSelectedTaskId(run.taskId);
+    setNotice('Queued manual review rerun for this review context.');
+  }
+
   async function retryPreview(runId: string) {
     const run = await api.retryPreview(runId);
     await api.setSelectedTaskId(run.taskId);
@@ -533,6 +539,7 @@ export default function App({ api: providedApi }: { api?: AgentBoardApi }) {
               onEditTask={(taskId) => setTaskToEditId(taskId)}
               onRequestChanges={(runId) => setChangeRequestRunId(runId)}
               onRetryRun={(runId) => void retryRun(runId)}
+              onRerunReview={(runId) => void rerunReview(runId)}
               onRetryPreview={(runId) => void retryPreview(runId)}
               onRetryEvidence={(runId) => void retryEvidence(runId)}
               onOpenTerminal={(runId) => void openTerminal(runId)}

--- a/src/ui/api/http-agent-board-api.ts
+++ b/src/ui/api/http-agent-board-api.ts
@@ -225,6 +225,12 @@ export class HttpAgentBoardApi implements AgentBoardApi {
     return run;
   }
 
+  async rerunReview(runId: string) {
+    const run = await this.request<AgentRun>(`/api/runs/${encodeURIComponent(runId)}/review`, { method: 'POST' });
+    await this.refresh();
+    return run;
+  }
+
   async requestRunChanges(runId: string, input: RequestRunChangesInput) {
     const run = await this.request<AgentRun>(`/api/runs/${encodeURIComponent(runId)}/request-changes`, {
       method: 'POST',

--- a/src/ui/components/DetailPanel.test.tsx
+++ b/src/ui/components/DetailPanel.test.tsx
@@ -115,6 +115,7 @@ function buildProps() {
     onEditTask: vi.fn(),
     onRequestChanges: vi.fn(),
     onRetryRun: vi.fn(),
+    onRerunReview: vi.fn(),
     onRetryPreview: vi.fn(),
     onRetryEvidence: vi.fn(),
     onOpenTerminal: vi.fn(),
@@ -295,5 +296,22 @@ describe('DetailPanel', () => {
 
     expect(onOpenTerminal).toHaveBeenCalledWith('run_demo');
     expect(onTakeOverRun).toHaveBeenCalledWith('run_demo');
+  });
+
+  it('routes re-run review clicks to the review rerun handler', async () => {
+    const user = userEvent.setup();
+    const onRerunReview = vi.fn();
+
+    render(
+      <DetailPanel
+        {...buildProps()}
+        onRerunReview={onRerunReview}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Re-run review' }));
+
+    expect(onRerunReview).toHaveBeenCalledTimes(1);
+    expect(onRerunReview).toHaveBeenCalledWith('run_demo');
   });
 });

--- a/src/ui/components/DetailPanel.tsx
+++ b/src/ui/components/DetailPanel.tsx
@@ -115,6 +115,7 @@ export function DetailPanel({
   onEditTask,
   onRequestChanges,
   onRetryRun,
+  onRerunReview,
   onRetryPreview,
   onRetryEvidence,
   onOpenTerminal,
@@ -128,6 +129,7 @@ export function DetailPanel({
   onEditTask: (taskId: string) => void;
   onRequestChanges: (runId: string) => void;
   onRetryRun: (runId: string) => void;
+  onRerunReview: (runId: string) => void;
   onRetryPreview: (runId: string) => void;
   onRetryEvidence: (runId: string) => void;
   onOpenTerminal: (runId: string) => void;
@@ -222,6 +224,13 @@ export function DetailPanel({
                 className="inline-flex h-9 items-center rounded-lg border border-cyan-400/35 bg-cyan-500/15 px-3 text-sm font-medium text-cyan-50 transition hover:bg-cyan-500/25"
               >
                 Retry run
+              </button>
+              <button
+                type="button"
+                onClick={() => onRerunReview(latestRun.runId)}
+                className="inline-flex h-9 items-center rounded-lg border border-indigo-400/35 bg-indigo-500/15 px-3 text-sm font-medium text-indigo-50 transition hover:bg-indigo-500/25"
+              >
+                Re-run review
               </button>
               <button
                 type="button"

--- a/src/ui/domain/api.ts
+++ b/src/ui/domain/api.ts
@@ -206,6 +206,7 @@ export interface AgentBoardApi {
   startRun(taskId: string): Promise<AgentRun>;
   getRun(runId: string): Promise<AgentRun>;
   retryRun(runId: string): Promise<AgentRun>;
+  rerunReview(runId: string): Promise<AgentRun>;
   requestRunChanges(runId: string, input: RequestRunChangesInput): Promise<AgentRun>;
   retryPreview(runId: string): Promise<AgentRun>;
   retryEvidence(runId: string): Promise<AgentRun>;

--- a/src/ui/domain/types.ts
+++ b/src/ui/domain/types.ts
@@ -160,6 +160,7 @@ export type RunReviewExecution = {
   round: number;
   startedAt?: string;
   endedAt?: string;
+  durationMs?: number;
 };
 export type RunReviewFindingsSummary = {
   total: number;
@@ -170,6 +171,19 @@ export type RunReviewFindingsSummary = {
 export type RunReviewArtifacts = {
   findingsJsonKey: string;
   reviewMarkdownKey: string;
+};
+export type RunReviewPostState = {
+  provider: AutoReviewProvider;
+  round: number;
+  status: 'not_attempted' | 'completed' | 'failed';
+  startedAt: string;
+  endedAt?: string;
+  postedCount: number;
+  findingsCount: number;
+  errors: string[];
+  summaryPosted?: boolean;
+  summaryThreadId?: string;
+  summaryThreadUrl?: string;
 };
 export type PreviewResolutionStatus = 'ready' | 'pending' | 'failed' | 'timed_out';
 export type PreviewDiagnostic = {
@@ -550,6 +564,7 @@ export type AgentRun = {
   reviewFindings?: ReviewFinding[];
   reviewFindingsSummary?: RunReviewFindingsSummary;
   reviewArtifacts?: RunReviewArtifacts;
+  reviewPostState?: RunReviewPostState;
   artifacts?: string[];
   artifactManifest?: ArtifactManifest;
   errors: RunError[];

--- a/src/ui/mock/local-agent-board-api.ts
+++ b/src/ui/mock/local-agent-board-api.ts
@@ -512,6 +512,43 @@ export class LocalAgentBoardApi implements AgentBoardApi {
     });
   }
 
+  async rerunReview(runId: string): Promise<AgentRun> {
+    const run = await this.getRun(runId);
+    const startedAt = nowIso();
+    const round = (run.reviewExecution?.round ?? 0) + 1;
+    const reviewExecution = {
+      enabled: true,
+      trigger: 'manual_rerun' as const,
+      promptSource: run.reviewExecution?.promptSource ?? 'native',
+      status: 'completed' as const,
+      round,
+      startedAt,
+      endedAt: startedAt,
+      durationMs: 0
+    };
+
+    let updatedRun: AgentRun | undefined;
+    this.store.update((snapshot) => ({
+      ...snapshot,
+      runs: snapshot.runs.map((candidate) => {
+        if (candidate.runId !== runId) {
+          return candidate;
+        }
+        updatedRun = {
+          ...candidate,
+          reviewExecution,
+          timeline: [...candidate.timeline, { status: candidate.status, at: startedAt, note: 'Manual review rerun completed (mock).' }]
+        };
+        return updatedRun;
+      })
+    }));
+
+    if (!updatedRun) {
+      throw new Error(`Run ${runId} not found.`);
+    }
+    return updatedRun;
+  }
+
   async requestRunChanges(runId: string, input: RequestRunChangesInput): Promise<AgentRun> {
     const run = await this.getRun(runId);
     const task = this.store.getSnapshot().tasks.find((candidate) => candidate.taskId === run.taskId);


### PR DESCRIPTION
Task: AR4 - Orchestrator Auto-Review Trigger and Manual Re-Run

Integrate auto-review into run lifecycle on REVIEW and add a manual review re-run endpoint/action.
Source ref: main

Acceptance criteria:
- Auto-review runs on REVIEW when enabled and skips when disabled.
- Manual re-run review endpoint is functional and idempotent-safe.
- Run timeline/metadata include review execution details and artifacts.
- Existing run lifecycle behavior remains stable.
- make sure that "yarn test" passes

Run ID: run_repo_abuiles_agents_kanban_mmbg9w7j1gz2