### PR TITLE
T4 - Slack Timeline Updates + GitLab Review Feedback Mirror

### DIFF
--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -47,7 +47,8 @@ import {
   handleUpsertScmCredential,
   handleSlackCommands,
   handleSlackEvents,
-  handleSlackInteractions
+  handleSlackInteractions,
+  handleGitlabWebhook
 } from './router';
 import { json } from './http/response';
 
@@ -77,6 +78,9 @@ apiRouter.post('/api/integrations/slack/events', (c: Context) =>
 );
 apiRouter.post('/api/integrations/slack/interactions', (c: Context) =>
   handleSlackInteractions(c.req.raw, c.env as Env, c.executionCtx as unknown as ExecutionContext<unknown>)
+);
+apiRouter.post('/api/integrations/gitlab/webhook', (c: Context) =>
+  handleGitlabWebhook(c.req.raw, c.env as Env)
 );
 apiRouter.get('/api/board/ws', (c: Context) => handleBoardWs(c.req.raw, c.env as Env));
 apiRouter.get('/api/repos', (c: Context) => handleListRepos(c.req.raw, c.env as Env));

--- a/src/server/durable/repo-board.ts
+++ b/src/server/durable/repo-board.ts
@@ -26,6 +26,7 @@ import { resolveRunSource } from '../shared/run-source-resolution';
 import { normalizeOperatorSession, normalizeRunLlmState, normalizeTaskUiMeta } from '../../shared/llm';
 import { hasRunReview, normalizeDependencyReviewMetadata, normalizeRunReviewMetadata, normalizeTaskBranchSourceReviewMetadata } from '../../shared/scm';
 import { DEFAULT_TENANT_ID, normalizeTenantId } from '../../shared/tenant';
+import { mapRunStatusToLifecycleMilestone, mirrorRunLifecycleMilestone } from '../integrations/slack/timeline';
 
 const STORAGE_KEY = 'repo-board-state';
 const LOCAL_JOBS_KEY = 'repo-board-local-jobs';
@@ -547,6 +548,13 @@ export class RepoBoardDO extends DurableObject<Env> {
       await this.emit({ type: 'run.events_appended', payload: { runId, events } }, updated.repoId);
     }
     await this.emitDependencyRefreshUpdates(updated.repoId, refreshedTasks, [finalTask.taskId]);
+    const previousMilestone = mapRunStatusToLifecycleMilestone(run.status);
+    const nextMilestone = mapRunStatusToLifecycleMilestone(updated.status);
+    if (nextMilestone && nextMilestone !== previousMilestone) {
+      await mirrorRunLifecycleMilestone(this.env, updated, nextMilestone, `${updated.runId}:${nextMilestone}:${nowIso}`).catch(() => {
+        // Slack timeline mirroring is best effort.
+      });
+    }
     return updated;
   }
 

--- a/src/server/integrations/gitlab/handlers.test.ts
+++ b/src/server/integrations/gitlab/handlers.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../tenant-auth-db', () => ({
+  getPrimaryTenantId: vi.fn(async () => 'tenant_local')
+}));
+
+import { handleGitlabWebhook } from './handlers';
+
+class KvStore {
+  values = new Map<string, string>();
+
+  async get(key: string) {
+    return this.values.get(key) ?? null;
+  }
+
+  async put(key: string, value: string) {
+    this.values.set(key, value);
+  }
+}
+
+function buildEnv(kv: KvStore): Env {
+  return {
+    SECRETS_KV: kv as unknown as KVNamespace,
+    BOARD_INDEX: {
+      getByName: () => ({
+        listRepos: async () => []
+      })
+    },
+    REPO_BOARD: {
+      getByName: () => ({
+        getBoardSlice: async () => ({ runs: [] })
+      })
+    },
+  } as unknown as Env;
+}
+
+function gitlabReviewPendingPayload() {
+  return JSON.stringify({
+    object_kind: 'merge_request',
+    project: { path_with_namespace: 'group/project' },
+    object_attributes: {
+      iid: 42,
+      action: 'open',
+      state: 'opened',
+      url: 'https://gitlab.example/group/project/-/merge_requests/42'
+    }
+  });
+}
+
+describe('gitlab webhook handler', () => {
+  it('dedupes repeated webhook deliveries by delivery id', async () => {
+    const kv = new KvStore();
+    kv.values.set('gitlab/webhook-secret', 'shared-token');
+    const env = buildEnv(kv);
+    const body = gitlabReviewPendingPayload();
+
+    const first = await handleGitlabWebhook(new Request('https://example.test/api/integrations/gitlab/webhook', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-gitlab-token': 'shared-token',
+        'x-gitlab-event-uuid': 'evt-123'
+      },
+      body
+    }), env);
+    const second = await handleGitlabWebhook(new Request('https://example.test/api/integrations/gitlab/webhook', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-gitlab-token': 'shared-token',
+        'x-gitlab-event-uuid': 'evt-123'
+      },
+      body
+    }), env);
+
+    expect(first.status).toBe(200);
+    expect(await first.json()).toMatchObject({ status: 'ignored_repo_unmapped' });
+    expect(await second.json()).toMatchObject({ status: 'duplicate_delivery' });
+  });
+
+  it('rejects invalid webhook secret', async () => {
+    const kv = new KvStore();
+    kv.values.set('gitlab/webhook-secret', 'shared-token');
+    const env = buildEnv(kv);
+
+    const response = await handleGitlabWebhook(new Request('https://example.test/api/integrations/gitlab/webhook', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-gitlab-token': 'bad-token'
+      },
+      body: gitlabReviewPendingPayload()
+    }), env);
+
+    expect(response.status).toBe(401);
+  });
+});

--- a/src/server/integrations/gitlab/handlers.ts
+++ b/src/server/integrations/gitlab/handlers.ts
@@ -1,0 +1,140 @@
+import type { Repo } from '../../../ui/domain/types';
+import * as tenantAuthDb from '../../tenant-auth-db';
+import { json, handleError } from '../../http/response';
+import { buildIdempotencyKey } from '../idempotency';
+import { getRepoProjectPath, getRepoScmProvider, getRunReviewNumber } from '../../../shared/scm';
+import { verifyGitlabWebhookSecret } from './verification';
+import { normalizeGitlabReviewEvent } from './normalize';
+import {
+  buildGitlabFeedbackSlackMessage,
+  mirrorRunLifecycleMilestone
+} from '../slack/timeline';
+import { listSlackThreadBindingsForTask, postSlackThreadMessage } from '../slack/client';
+
+const BOARD_OBJECT_NAME = 'agentboard';
+const DEDUPE_TTL_SECONDS = 7 * 24 * 60 * 60;
+
+async function resolveTenantId(env: Env) {
+  return tenantAuthDb.getPrimaryTenantId(env);
+}
+
+async function resolveRepoByProjectPath(env: Env, tenantId: string, projectPath: string): Promise<Repo | undefined> {
+  const board = env.BOARD_INDEX.getByName(BOARD_OBJECT_NAME);
+  const repos = await board.listRepos(tenantId);
+  const normalizedTarget = projectPath.trim().toLowerCase();
+  return repos.find((repo) => (
+    getRepoScmProvider(repo) === 'gitlab'
+    && getRepoProjectPath(repo).toLowerCase() === normalizedTarget
+  ));
+}
+
+async function shouldProcessDelivery(env: Env, key: string) {
+  const existing = await env.SECRETS_KV.get(key);
+  if (existing) {
+    return false;
+  }
+  await env.SECRETS_KV.put(key, '1', { expirationTtl: DEDUPE_TTL_SECONDS });
+  return true;
+}
+
+function hashText(value: string): string {
+  let hash = 0;
+  for (let i = 0; i < value.length; i += 1) {
+    hash = ((hash << 5) - hash) + value.charCodeAt(i);
+    hash |= 0;
+  }
+  return Math.abs(hash).toString(16);
+}
+
+function readDeliveryId(request: Request, rawBody: string, normalizedProviderEventId: string) {
+  const fromHeader = request.headers.get('x-gitlab-event-uuid')?.trim();
+  if (fromHeader) {
+    return fromHeader;
+  }
+  return `${normalizedProviderEventId}:${hashText(rawBody)}`;
+}
+
+export async function handleGitlabWebhook(request: Request, env: Env): Promise<Response> {
+  try {
+    const tenantId = await resolveTenantId(env);
+    await verifyGitlabWebhookSecret(env, tenantId, request);
+    const rawBody = await request.text();
+    const payload = JSON.parse(rawBody) as unknown;
+    const normalized = normalizeGitlabReviewEvent(payload);
+    if (!normalized) {
+      return json({ ok: true, status: 'ignored' });
+    }
+
+    const deliveryId = readDeliveryId(request, rawBody, normalized.providerEventId);
+    const deliveryDedupeKey = buildIdempotencyKey({
+      provider: 'gitlab',
+      tenantId,
+      eventType: 'webhook.delivery',
+      providerEventId: deliveryId,
+      subjectId: normalized.projectPath,
+      metadata: { reviewNumber: normalized.reviewNumber }
+    });
+    if (!(await shouldProcessDelivery(env, deliveryDedupeKey))) {
+      return json({ ok: true, status: 'duplicate_delivery' });
+    }
+
+    const repo = await resolveRepoByProjectPath(env, tenantId, normalized.projectPath);
+    if (!repo) {
+      return json({ ok: true, status: 'ignored_repo_unmapped' });
+    }
+
+    const repoBoard = env.REPO_BOARD.getByName(repo.repoId);
+    const slice = await repoBoard.getBoardSlice();
+    const run = [...slice.runs]
+      .filter((candidate) => getRunReviewNumber(candidate) === normalized.reviewNumber)
+      .sort((left, right) => right.startedAt.localeCompare(left.startedAt))
+      .at(0);
+    if (!run) {
+      return json({ ok: true, status: 'ignored_run_unmapped' });
+    }
+
+    if (normalized.type === 'review_pending') {
+      await mirrorRunLifecycleMilestone(env, run, 'review_pending', `${deliveryId}:review_pending`);
+      return json({ ok: true, status: 'mirrored_review_pending', runId: run.runId });
+    }
+
+    await mirrorRunLifecycleMilestone(env, run, 'review_pending', `${deliveryId}:review_pending`);
+    const bindings = await listSlackThreadBindingsForTask(env, run.tenantId, run.taskId);
+    const message = buildGitlabFeedbackSlackMessage({
+      reviewNumber: normalized.reviewNumber,
+      authorUsername: normalized.authorUsername,
+      note: normalized.note ?? ''
+    });
+
+    await Promise.all(bindings.map(async (binding) => {
+      const dedupeKey = buildIdempotencyKey({
+        provider: 'gitlab',
+        tenantId: run.tenantId,
+        eventType: 'review_feedback',
+        providerEventId: `${deliveryId}:${normalized.providerEventId}`,
+        subjectId: `${binding.channelId}:${binding.threadTs}`,
+        metadata: {
+          runId: run.runId,
+          reviewNumber: normalized.reviewNumber
+        }
+      });
+      if (!(await shouldProcessDelivery(env, dedupeKey))) {
+        return;
+      }
+
+      await postSlackThreadMessage(env, {
+        tenantId: run.tenantId,
+        repoId: run.repoId,
+        channelId: binding.channelId,
+        threadTs: binding.threadTs,
+        text: message
+      }).catch(() => {
+        // Slack mirroring is best effort.
+      });
+    }));
+
+    return json({ ok: true, status: 'mirrored_feedback', runId: run.runId });
+  } catch (error) {
+    return handleError(error);
+  }
+}

--- a/src/server/integrations/gitlab/normalize.test.ts
+++ b/src/server/integrations/gitlab/normalize.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeGitlabReviewEvent } from './normalize';
+
+describe('gitlab feedback normalization', () => {
+  it('normalizes merge-request note feedback events', () => {
+    const normalized = normalizeGitlabReviewEvent({
+      object_kind: 'note',
+      project: { path_with_namespace: 'group/project' },
+      merge_request: { iid: 42, web_url: 'https://gitlab.example/group/project/-/merge_requests/42' },
+      user: { username: 'alice' },
+      object_attributes: {
+        id: 9001,
+        noteable_type: 'MergeRequest',
+        note: 'Please add tests for this path.',
+        system: false
+      }
+    });
+
+    expect(normalized).toMatchObject({
+      type: 'review_feedback',
+      projectPath: 'group/project',
+      reviewNumber: 42,
+      authorUsername: 'alice',
+      note: 'Please add tests for this path.'
+    });
+  });
+
+  it('normalizes merge request open/reopen/update events to review pending', () => {
+    const normalized = normalizeGitlabReviewEvent({
+      object_kind: 'merge_request',
+      project: { path_with_namespace: 'group/project' },
+      object_attributes: {
+        iid: 7,
+        action: 'open',
+        state: 'opened',
+        url: 'https://gitlab.example/group/project/-/merge_requests/7'
+      }
+    });
+
+    expect(normalized).toMatchObject({
+      type: 'review_pending',
+      projectPath: 'group/project',
+      reviewNumber: 7
+    });
+  });
+
+  it('ignores non-review webhook payloads', () => {
+    const normalized = normalizeGitlabReviewEvent({ object_kind: 'pipeline' });
+    expect(normalized).toBeUndefined();
+  });
+});

--- a/src/server/integrations/gitlab/normalize.ts
+++ b/src/server/integrations/gitlab/normalize.ts
@@ -1,0 +1,153 @@
+import type { ReviewIntegration } from '../interfaces';
+
+export type NormalizedGitlabReviewEvent = {
+  type: 'review_pending' | 'review_feedback';
+  providerEventId: string;
+  projectPath: string;
+  reviewNumber: number;
+  reviewUrl?: string;
+  authorUsername?: string;
+  note?: string;
+};
+
+type GitlabProject = {
+  path_with_namespace?: string;
+  web_url?: string;
+};
+
+type GitlabMrAttributes = {
+  iid?: number;
+  url?: string;
+  action?: string;
+  state?: string;
+};
+
+type GitlabMr = {
+  iid?: number;
+  web_url?: string;
+};
+
+type GitlabNoteEvent = {
+  object_kind?: string;
+  event_type?: string;
+  project?: GitlabProject;
+  merge_request?: GitlabMr;
+  object_attributes?: {
+    id?: number;
+    note?: string;
+    noteable_type?: string;
+    system?: boolean;
+  };
+  user?: {
+    username?: string;
+  };
+};
+
+type GitlabMergeRequestEvent = {
+  object_kind?: string;
+  event_type?: string;
+  project?: GitlabProject;
+  object_attributes?: GitlabMrAttributes;
+  user?: {
+    username?: string;
+  };
+};
+
+function normalizeProjectPath(raw: string | undefined) {
+  if (!raw) {
+    return undefined;
+  }
+  const value = raw.trim().replace(/^\/+|\/+$/g, '');
+  return value || undefined;
+}
+
+function normalizeNoteEvent(payload: GitlabNoteEvent): NormalizedGitlabReviewEvent | undefined {
+  if ((payload.object_kind ?? '').toLowerCase() !== 'note' && (payload.event_type ?? '').toLowerCase() !== 'note') {
+    return undefined;
+  }
+
+  const attrs = payload.object_attributes;
+  if (!attrs || attrs.noteable_type !== 'MergeRequest') {
+    return undefined;
+  }
+  if (attrs.system) {
+    return undefined;
+  }
+
+  const note = attrs.note?.trim();
+  const projectPath = normalizeProjectPath(payload.project?.path_with_namespace);
+  const reviewNumber = payload.merge_request?.iid;
+  if (!projectPath || !reviewNumber || !note) {
+    return undefined;
+  }
+
+  return {
+    type: 'review_feedback',
+    providerEventId: attrs.id ? `note:${attrs.id}` : `note:${reviewNumber}:${note.slice(0, 40)}`,
+    projectPath,
+    reviewNumber,
+    reviewUrl: payload.merge_request?.web_url,
+    authorUsername: payload.user?.username,
+    note
+  };
+}
+
+function normalizeMergeRequestEvent(payload: GitlabMergeRequestEvent): NormalizedGitlabReviewEvent | undefined {
+  if ((payload.object_kind ?? '').toLowerCase() !== 'merge_request' && (payload.event_type ?? '').toLowerCase() !== 'merge_request') {
+    return undefined;
+  }
+
+  const attrs = payload.object_attributes;
+  const action = attrs?.action?.toLowerCase();
+  const state = attrs?.state?.toLowerCase();
+  const isReviewPending = action === 'open' || action === 'reopen' || (action === 'update' && state === 'opened');
+  if (!isReviewPending) {
+    return undefined;
+  }
+
+  const projectPath = normalizeProjectPath(payload.project?.path_with_namespace);
+  const reviewNumber = attrs?.iid;
+  if (!projectPath || !reviewNumber) {
+    return undefined;
+  }
+
+  return {
+    type: 'review_pending',
+    providerEventId: `merge_request:${reviewNumber}:${action ?? 'update'}`,
+    projectPath,
+    reviewNumber,
+    reviewUrl: attrs?.url
+  };
+}
+
+export function normalizeGitlabReviewEvent(payload: unknown): NormalizedGitlabReviewEvent | undefined {
+  if (!payload || typeof payload !== 'object') {
+    return undefined;
+  }
+  const note = normalizeNoteEvent(payload as GitlabNoteEvent);
+  if (note) {
+    return note;
+  }
+  return normalizeMergeRequestEvent(payload as GitlabMergeRequestEvent);
+}
+
+export class GitLabReviewIntegration implements ReviewIntegration {
+  readonly pluginKind = 'gitlab' as const;
+
+  normalizeWebhookReview(payload: unknown) {
+    const normalized = normalizeGitlabReviewEvent(payload);
+    if (!normalized) {
+      return undefined;
+    }
+
+    return {
+      tenantId: 'tenant_local',
+      providerEventId: normalized.providerEventId,
+      projectPath: normalized.projectPath,
+      runId: normalized.reviewNumber ? `mr:${normalized.reviewNumber}` : undefined,
+      note: normalized.note
+    };
+  }
+}
+
+export const gitlabReviewIntegration = new GitLabReviewIntegration();

--- a/src/server/integrations/gitlab/verification.test.ts
+++ b/src/server/integrations/gitlab/verification.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { verifyGitlabWebhookSecret } from './verification';
+
+class KvStore {
+  values = new Map<string, string>();
+
+  async get(key: string) {
+    return this.values.get(key) ?? null;
+  }
+
+  async put(key: string, value: string) {
+    this.values.set(key, value);
+  }
+}
+
+describe('gitlab verification', () => {
+  it('accepts requests signed with configured webhook token', async () => {
+    const kv = new KvStore();
+    kv.values.set('gitlab/webhook-secret', 'shared-token');
+
+    const request = new Request('https://example.test/api/integrations/gitlab/webhook', {
+      method: 'POST',
+      headers: {
+        'x-gitlab-token': 'shared-token'
+      },
+      body: '{}'
+    });
+
+    await expect(verifyGitlabWebhookSecret({ SECRETS_KV: kv as unknown as KVNamespace } as Env, 'tenant_local', request)).resolves.toBeUndefined();
+  });
+
+  it('rejects requests with invalid webhook token', async () => {
+    const kv = new KvStore();
+    kv.values.set('gitlab/webhook-secret', 'shared-token');
+
+    const request = new Request('https://example.test/api/integrations/gitlab/webhook', {
+      method: 'POST',
+      headers: {
+        'x-gitlab-token': 'wrong-token'
+      },
+      body: '{}'
+    });
+
+    await expect(verifyGitlabWebhookSecret({ SECRETS_KV: kv as unknown as KVNamespace } as Env, 'tenant_local', request)).rejects.toThrow(/Invalid GitLab webhook token/);
+  });
+});

--- a/src/server/integrations/gitlab/verification.ts
+++ b/src/server/integrations/gitlab/verification.ts
@@ -1,0 +1,40 @@
+import { unauthorized } from '../../http/errors';
+
+const DEFAULT_WEBHOOK_SECRET_KEY = 'gitlab/webhook-secret';
+const TENANT_WEBHOOK_SECRET_PREFIX = 'gitlab/webhook-secret';
+
+function timingSafeEqual(left: string, right: string): boolean {
+  if (left.length !== right.length) {
+    return false;
+  }
+  let diff = 0;
+  for (let index = 0; index < left.length; index += 1) {
+    diff |= left.charCodeAt(index) ^ right.charCodeAt(index);
+  }
+  return diff === 0;
+}
+
+async function resolveWebhookSecret(env: Env, tenantId: string) {
+  const tenantScoped = await env.SECRETS_KV.get(`${TENANT_WEBHOOK_SECRET_PREFIX}:${tenantId}`);
+  if (tenantScoped?.trim()) {
+    return tenantScoped.trim();
+  }
+  const fallback = await env.SECRETS_KV.get(DEFAULT_WEBHOOK_SECRET_KEY);
+  return fallback?.trim() || undefined;
+}
+
+export async function verifyGitlabWebhookSecret(env: Env, tenantId: string, request: Request) {
+  const actual = request.headers.get('x-gitlab-token')?.trim();
+  if (!actual) {
+    throw unauthorized('Missing GitLab webhook token.');
+  }
+
+  const expected = await resolveWebhookSecret(env, tenantId);
+  if (!expected) {
+    throw unauthorized('Missing GitLab webhook secret.');
+  }
+
+  if (!timingSafeEqual(actual, expected)) {
+    throw unauthorized('Invalid GitLab webhook token.');
+  }
+}

--- a/src/server/integrations/slack/client.ts
+++ b/src/server/integrations/slack/client.ts
@@ -1,0 +1,97 @@
+import type { IntegrationConfig, IntegrationConfigSettings, SlackThreadBinding } from '../../../ui/domain/types';
+import { resolveIntegrationConfig } from '../config-resolution';
+import * as tenantAuthDb from '../../tenant-auth-db';
+
+const DEFAULT_BOT_TOKEN_SECRET_KEY = 'slack/bot-token';
+const TENANT_BOT_TOKEN_SECRET_PREFIX = 'slack/bot-token';
+
+function readSettingString(settings: IntegrationConfigSettings, key: string) {
+  const value = settings[key];
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
+async function resolveSlackBotToken(env: Env, config: IntegrationConfig | undefined, tenantId: string) {
+  const tokenFromSettings = config
+    ? readSettingString(config.settings, 'botToken') ?? readSettingString(config.settings, 'token')
+    : undefined;
+  if (tokenFromSettings) {
+    return tokenFromSettings;
+  }
+
+  if (config?.secretRef?.trim()) {
+    const value = await env.SECRETS_KV.get(config.secretRef.trim());
+    if (value?.trim()) {
+      return value.trim();
+    }
+  }
+
+  const tenantScoped = await env.SECRETS_KV.get(`${TENANT_BOT_TOKEN_SECRET_PREFIX}:${tenantId}`);
+  if (tenantScoped?.trim()) {
+    return tenantScoped.trim();
+  }
+
+  const fallback = await env.SECRETS_KV.get(DEFAULT_BOT_TOKEN_SECRET_KEY);
+  return fallback?.trim() || undefined;
+}
+
+async function resolveSlackConfig(env: Env, target: { tenantId: string; repoId: string; channelId: string }) {
+  const configs = await tenantAuthDb.listIntegrationConfigs(env, target.tenantId, {
+    pluginKind: 'slack',
+    enabledOnly: true
+  });
+
+  return resolveIntegrationConfig(configs, {
+    tenantId: target.tenantId,
+    pluginKind: 'slack',
+    repoId: target.repoId,
+    channelId: target.channelId
+  });
+}
+
+export async function listSlackThreadBindingsForTask(env: Env, tenantId: string, taskId: string): Promise<SlackThreadBinding[]> {
+  return tenantAuthDb.listSlackThreadBindings(env, tenantId, { taskId });
+}
+
+export async function postSlackThreadMessage(
+  env: Env,
+  target: {
+    tenantId: string;
+    repoId: string;
+    channelId: string;
+    threadTs: string;
+    text: string;
+  }
+): Promise<{ delivered: boolean; reason?: string }> {
+  const config = await resolveSlackConfig(env, target);
+  const token = await resolveSlackBotToken(env, config, target.tenantId);
+  if (!token) {
+    return { delivered: false, reason: 'missing_slack_bot_token' };
+  }
+
+  const response = await fetch('https://slack.com/api/chat.postMessage', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json; charset=utf-8'
+    },
+    body: JSON.stringify({
+      channel: target.channelId,
+      thread_ts: target.threadTs,
+      text: target.text,
+      unfurl_links: false,
+      unfurl_media: false,
+      mrkdwn: true
+    })
+  });
+
+  if (!response.ok) {
+    return { delivered: false, reason: `slack_http_${response.status}` };
+  }
+
+  const payload = await response.json().catch(() => undefined) as { ok?: boolean } | undefined;
+  if (payload?.ok !== true) {
+    return { delivered: false, reason: 'slack_api_error' };
+  }
+
+  return { delivered: true };
+}

--- a/src/server/integrations/slack/handlers.ts
+++ b/src/server/integrations/slack/handlers.ts
@@ -11,6 +11,7 @@ import {
   type ParsedSlackInteraction
 } from './payload';
 import { resolveThreadTenant, verifySlackRequest } from './verification';
+import { mirrorRunLifecycleMilestone } from './timeline';
 
 const DEFAULT_TASK_ID_PREFIX = 'issue';
 const DEFAULT_REVIEW_ROUND = 0;
@@ -243,6 +244,9 @@ async function startRunForTask(
   await repoBoard.transitionRun(run.runId, {
     workflowInstanceId: workflow.id,
     orchestrationMode: workflow.id.startsWith('local-alarm-') ? 'local_alarm' : 'workflow'
+  });
+  await mirrorRunLifecycleMilestone(env, run, 'queued', `${run.runId}:queued`).catch(() => {
+    // Slack timeline mirroring is best effort.
   });
   return { taskId: task.taskId, runId: run.runId };
 }

--- a/src/server/integrations/slack/timeline.test.ts
+++ b/src/server/integrations/slack/timeline.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { collectLifecycleMilestonesFromStatuses, mapRunStatusToLifecycleMilestone, truncateFeedbackText } from './timeline';
+
+describe('slack timeline lifecycle mapping', () => {
+  it('maps run statuses to milestones in low-noise order', () => {
+    const milestones = collectLifecycleMilestonesFromStatuses([
+      'QUEUED',
+      'QUEUED',
+      'BOOTSTRAPPING',
+      'RUNNING_CODEX',
+      'RUNNING_TESTS',
+      'PUSHING_BRANCH',
+      'PR_OPEN',
+      'WAITING_PREVIEW',
+      'EVIDENCE_RUNNING',
+      'DONE'
+    ]);
+
+    expect(milestones).toEqual(['queued', 'running', 'mr_open', 'done']);
+  });
+
+  it('maps failure status to failed milestone', () => {
+    expect(mapRunStatusToLifecycleMilestone('FAILED')).toBe('failed');
+  });
+
+  it('truncates feedback notes for concise Slack output', () => {
+    const long = 'x'.repeat(500);
+    const truncated = truncateFeedbackText(long);
+    expect(truncated.length).toBeLessThanOrEqual(220);
+    expect(truncated.endsWith('...')).toBe(true);
+  });
+});

--- a/src/server/integrations/slack/timeline.ts
+++ b/src/server/integrations/slack/timeline.ts
@@ -1,0 +1,132 @@
+import type { AgentRun, RunStatus } from '../../../ui/domain/types';
+import { buildIdempotencyKey } from '../idempotency';
+import { listSlackThreadBindingsForTask, postSlackThreadMessage } from './client';
+
+const DEDUPE_TTL_SECONDS = 7 * 24 * 60 * 60;
+
+export type SlackLifecycleMilestone = 'queued' | 'running' | 'mr_open' | 'review_pending' | 'done' | 'failed';
+
+export function mapRunStatusToLifecycleMilestone(status: RunStatus): SlackLifecycleMilestone | undefined {
+  if (status === 'QUEUED') {
+    return 'queued';
+  }
+  if (status === 'BOOTSTRAPPING' || status === 'RUNNING_CODEX' || status === 'RUNNING_TESTS' || status === 'PUSHING_BRANCH') {
+    return 'running';
+  }
+  if (status === 'PR_OPEN') {
+    return 'mr_open';
+  }
+  if (status === 'DONE') {
+    return 'done';
+  }
+  if (status === 'FAILED') {
+    return 'failed';
+  }
+  return undefined;
+}
+
+export function collectLifecycleMilestonesFromStatuses(statuses: RunStatus[]): SlackLifecycleMilestone[] {
+  const milestones: SlackLifecycleMilestone[] = [];
+  let previous: SlackLifecycleMilestone | undefined;
+  for (const status of statuses) {
+    const next = mapRunStatusToLifecycleMilestone(status);
+    if (!next || next === previous) {
+      continue;
+    }
+    milestones.push(next);
+    previous = next;
+  }
+  return milestones;
+}
+
+function buildLifecycleMessage(run: AgentRun, milestone: SlackLifecycleMilestone) {
+  if (milestone === 'queued') {
+    return `Run ${run.runId} queued.`;
+  }
+  if (milestone === 'running') {
+    return `Run ${run.runId} is running.`;
+  }
+  if (milestone === 'mr_open') {
+    const reviewLabel = run.reviewNumber ?? run.prNumber ? `MR !${run.reviewNumber ?? run.prNumber}` : 'Merge request';
+    if (run.reviewUrl ?? run.prUrl) {
+      return `${reviewLabel} opened: ${run.reviewUrl ?? run.prUrl}`;
+    }
+    return `${reviewLabel} opened.`;
+  }
+  if (milestone === 'review_pending') {
+    return run.reviewNumber ?? run.prNumber
+      ? `Review pending on MR !${run.reviewNumber ?? run.prNumber}.`
+      : 'Review pending.';
+  }
+  if (milestone === 'done') {
+    return `Run ${run.runId} done.`;
+  }
+  return `Run ${run.runId} failed.`;
+}
+
+async function markDeliveryIfNew(env: Env, dedupeKey: string) {
+  const seen = await env.SECRETS_KV.get(dedupeKey);
+  if (seen) {
+    return false;
+  }
+  await env.SECRETS_KV.put(dedupeKey, '1', { expirationTtl: DEDUPE_TTL_SECONDS });
+  return true;
+}
+
+export async function mirrorRunLifecycleMilestone(
+  env: Env,
+  run: AgentRun,
+  milestone: SlackLifecycleMilestone,
+  eventId: string
+) {
+  const bindings = await listSlackThreadBindingsForTask(env, run.tenantId, run.taskId);
+  if (bindings.length === 0) {
+    return;
+  }
+
+  const text = buildLifecycleMessage(run, milestone);
+  await Promise.all(bindings.map(async (binding) => {
+    const dedupeKey = buildIdempotencyKey({
+      provider: 'slack',
+      tenantId: run.tenantId,
+      eventType: `timeline.${milestone}`,
+      providerEventId: eventId,
+      subjectId: `${binding.channelId}:${binding.threadTs}`,
+      metadata: {
+        runId: run.runId,
+        taskId: run.taskId
+      }
+    });
+    const shouldDeliver = await markDeliveryIfNew(env, dedupeKey);
+    if (!shouldDeliver) {
+      return;
+    }
+
+    await postSlackThreadMessage(env, {
+      tenantId: run.tenantId,
+      repoId: run.repoId,
+      channelId: binding.channelId,
+      threadTs: binding.threadTs,
+      text
+    }).catch(() => {
+      // Slack timeline mirroring is best effort.
+    });
+  }));
+}
+
+export function truncateFeedbackText(note: string) {
+  const compact = note.replace(/\s+/g, ' ').trim();
+  if (compact.length <= 220) {
+    return compact;
+  }
+  return `${compact.slice(0, 217)}...`;
+}
+
+export function buildGitlabFeedbackSlackMessage(input: {
+  reviewNumber: number;
+  authorUsername?: string;
+  note: string;
+}) {
+  const actor = input.authorUsername?.trim() ? `@${input.authorUsername.trim()}` : 'reviewer';
+  return `GitLab feedback on MR !${input.reviewNumber} from ${actor}: ${truncateFeedbackText(input.note)}`;
+}

--- a/src/server/router.ts
+++ b/src/server/router.ts
@@ -38,6 +38,7 @@ import {
   handleSlackEvents as handleSlackEventsHandler,
   handleSlackInteractions as handleSlackInteractionsHandler
 } from './integrations/slack/handlers';
+import { handleGitlabWebhook as handleGitlabWebhookHandler } from './integrations/gitlab/handlers';
 
 const BOARD_OBJECT_NAME = 'agentboard';
 
@@ -99,6 +100,10 @@ export async function handleSlackEvents(request: Request, env: Env): Promise<Res
 
 export async function handleSlackInteractions(request: Request, env: Env, ctx: ExecutionContext<unknown>): Promise<Response> {
   return handleSlackInteractionsHandler(request, env, ctx);
+}
+
+export async function handleGitlabWebhook(request: Request, env: Env): Promise<Response> {
+  return handleGitlabWebhookHandler(request, env);
 }
 
 export async function handleAuthSignup(request: Request, env: Env): Promise<Response> {

--- a/src/server/tenant-auth-db.test.ts
+++ b/src/server/tenant-auth-db.test.ts
@@ -15,6 +15,7 @@ import {
   listIntegrationConfigs,
   listJiraProjectRepoMappings,
   listJiraProjectRepoMappingsByProject,
+  listSlackThreadBindings,
   listSentinelEvents,
   listSentinelRuns,
   upsertIntegrationConfig,
@@ -279,13 +280,17 @@ class FakeTenantAuthDb {
     if (sql.includes('SELECT * FROM slack_thread_bindings')) {
       const tenantId = String(bindings[0]);
       let rows = this.slackThreadBindings.filter((row) => row.tenant_id === tenantId);
+      let index = 1;
       if (sql.includes('task_id = ?')) {
-        const taskId = String(bindings[1]);
+        const taskId = String(bindings[index++]);
         rows = rows.filter((row) => row.task_id === taskId);
       }
+      if (sql.includes('current_run_id = ?')) {
+        const currentRunId = String(bindings[index++]);
+        rows = rows.filter((row) => String(row.current_run_id ?? '') === currentRunId);
+      }
       if (sql.includes('channel_id = ?')) {
-        const taskIdProvided = sql.includes('task_id = ?');
-        const channelId = String(bindings[taskIdProvided ? 2 : 1]);
+        const channelId = String(bindings[index++]);
         rows = rows.filter((row) => row.channel_id === channelId);
       }
       if (sql.includes('LIMIT 1')) {
@@ -946,6 +951,14 @@ describe('tenant-auth-db single-tenant auth store', () => {
     expect(lookedUp?.threadTs).toBe(updated.threadTs);
     expect(lookedUp?.currentRunId).toBe('run_1');
     expect(lookedUp?.latestReviewRound).toBe(2);
+
+    const byTask = await listSlackThreadBindings(env, tenantId, { taskId: 'task_1' });
+    expect(byTask).toHaveLength(1);
+    expect(byTask[0]?.currentRunId).toBe('run_1');
+
+    const byRun = await listSlackThreadBindings(env, tenantId, { currentRunId: 'run_1' });
+    expect(byRun).toHaveLength(1);
+    expect(byRun[0]?.taskId).toBe('task_1');
 
     await deleteSlackThreadBinding(env, tenantId, 'task_1', 'C123');
     const afterDelete = await getSlackThreadBinding(env, tenantId, 'task_1', 'C123');

--- a/src/server/tenant-auth-db.ts
+++ b/src/server/tenant-auth-db.ts
@@ -1100,6 +1100,29 @@ export async function getSlackThreadBinding(
   return mapSlackThreadBinding(result);
 }
 
+export async function listSlackThreadBindings(
+  env: Env,
+  tenantId: string,
+  filters?: { taskId?: string; currentRunId?: string }
+): Promise<SlackThreadBinding[]> {
+  const db = getDb(env);
+  await ensureSchema(db);
+  const clauses: string[] = ['tenant_id = ?'];
+  const values: unknown[] = [tenantId];
+  if (filters?.taskId?.trim()) {
+    clauses.push('task_id = ?');
+    values.push(filters.taskId.trim());
+  }
+  if (filters?.currentRunId?.trim()) {
+    clauses.push('current_run_id = ?');
+    values.push(filters.currentRunId.trim());
+  }
+
+  const query = `SELECT * FROM slack_thread_bindings WHERE ${clauses.join(' AND ')} ORDER BY updated_at DESC`;
+  const result = await db.prepare(query).bind(...values).all<Record<string, unknown>>();
+  return (result.results ?? []).map(mapSlackThreadBinding);
+}
+
 export async function deleteSlackThreadBinding(
   env: Env,
   tenantId: string,


### PR DESCRIPTION
Task: T4 - Slack Timeline Updates + GitLab Review Feedback Mirror

Mirror run lifecycle and GitLab review feedback into Slack threads with signature-verified GitLab webhook ingress.
Source ref: main

Acceptance criteria:
- Operators can track run and review milestones in the same Slack thread.
- Duplicate GitLab webhook deliveries do not duplicate mirrored messages.
- GitLab write operations remain in the existing SCM adapter path.
- Lifecycle and feedback mirroring are covered by tests.
- make sure that "yarn test" passes

Run ID: run_repo_abuiles_agents_kanban_mmbgs7ewamjq