### PR TITLE
S2 - Sentinel APIs and Repo Controls

### DIFF
--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -17,6 +17,7 @@ import {
   handleDebugSandboxRun,
   handleDeleteApiToken,
   handleDeleteTask,
+  handleGetRepoSentinel,
   handleGetRun,
   handleGetRunArtifacts,
   handleGetRunCommands,
@@ -33,12 +34,18 @@ import {
   handleListScmCredentials,
   handleListTasks,
   handleMe,
+  handlePatchRepoSentinelConfig,
+  handlePauseRepoSentinel,
   handleRequestChanges,
+  handleResumeRepoSentinel,
   handleRerunReview,
   handleRetryEvidence,
   handleRetryPreview,
   handleRetryRun,
   handleRunTask,
+  handleStartRepoSentinel,
+  handleStopRepoSentinel,
+  handleListRepoSentinelEvents,
   handleTakeoverRun,
   handleTenantRunUsage,
   handleTenantUsageSummary,
@@ -83,6 +90,27 @@ apiRouter.get('/api/repos', (c: Context) => handleListRepos(c.req.raw, c.env as 
 apiRouter.post('/api/repos', (c: Context) => handleCreateRepo(c.req.raw, c.env as Env));
 apiRouter.patch('/api/repos/:repoId', (c: Context) =>
   handleUpdateRepo(c.req.raw, c.env as Env, { repoId: c.req.param('repoId') })
+);
+apiRouter.get('/api/repos/:repoId/sentinel', (c: Context) =>
+  handleGetRepoSentinel(c.req.raw, c.env as Env, { repoId: c.req.param('repoId') })
+);
+apiRouter.patch('/api/repos/:repoId/sentinel/config', (c: Context) =>
+  handlePatchRepoSentinelConfig(c.req.raw, c.env as Env, { repoId: c.req.param('repoId') })
+);
+apiRouter.post('/api/repos/:repoId/sentinel/start', (c: Context) =>
+  handleStartRepoSentinel(c.req.raw, c.env as Env, { repoId: c.req.param('repoId') })
+);
+apiRouter.post('/api/repos/:repoId/sentinel/pause', (c: Context) =>
+  handlePauseRepoSentinel(c.req.raw, c.env as Env, { repoId: c.req.param('repoId') })
+);
+apiRouter.post('/api/repos/:repoId/sentinel/resume', (c: Context) =>
+  handleResumeRepoSentinel(c.req.raw, c.env as Env, { repoId: c.req.param('repoId') })
+);
+apiRouter.post('/api/repos/:repoId/sentinel/stop', (c: Context) =>
+  handleStopRepoSentinel(c.req.raw, c.env as Env, { repoId: c.req.param('repoId') })
+);
+apiRouter.get('/api/repos/:repoId/sentinel/events', (c: Context) =>
+  handleListRepoSentinelEvents(c.req.raw, c.env as Env, { repoId: c.req.param('repoId') })
 );
 
 apiRouter.get('/api/scm/credentials', (c: Context) => handleListScmCredentials(c.req.raw, c.env as Env));

--- a/src/server/http/validation.test.ts
+++ b/src/server/http/validation.test.ts
@@ -6,7 +6,9 @@ import {
   parseCreateRepoInput,
   parseCreateTaskInput,
   parseCreateUserApiTokenInput,
+  parseStartRepoSentinelInput,
   parseRequestRunChangesInput,
+  parseUpdateRepoSentinelConfigInput,
   parseUpdateRepoInput,
   parseUpdateTaskInput,
   parseUpsertScmCredentialInput
@@ -325,6 +327,38 @@ describe('repo validation', () => {
         }
       })
     ).toThrow('Invalid sentinelConfig.mergePolicy.method.');
+  });
+
+  it('parses repo sentinel config patch payloads', () => {
+    expect(parseUpdateRepoSentinelConfigInput({
+      enabled: true,
+      conflictPolicy: {
+        maxAttempts: 4
+      }
+    })).toEqual({
+      enabled: true,
+      conflictPolicy: {
+        maxAttempts: 4
+      }
+    });
+  });
+
+  it('rejects invalid sentinel config patch payloads', () => {
+    expect(() => parseUpdateRepoSentinelConfigInput('invalid')).toThrow('Invalid sentinel config patch payload.');
+  });
+
+  it('parses sentinel start payloads', () => {
+    expect(parseStartRepoSentinelInput({
+      scopeType: 'group',
+      scopeValue: 'payments'
+    })).toEqual({
+      scopeType: 'group',
+      scopeValue: 'payments'
+    });
+  });
+
+  it('rejects invalid sentinel start payload scope types', () => {
+    expect(() => parseStartRepoSentinelInput({ scopeType: 'team' })).toThrow('Invalid scopeType.');
   });
 
   it('defaults repo auto-review provider and includes prompt when enabled', () => {

--- a/src/server/http/validation.ts
+++ b/src/server/http/validation.ts
@@ -1,6 +1,7 @@
 import type {
   CreateRepoInput,
   CreateTaskInput,
+  RepoSentinelConfigInput,
   RequestRunChangesInput,
   UpdateRepoInput,
   UpdateTaskInput,
@@ -746,6 +747,29 @@ export function parseRequestRunChangesInput(body: unknown): RequestRunChangesInp
   return {
     prompt,
     reviewSelection: readRequestRunChangesSelection(body.reviewSelection, 'reviewSelection')
+  };
+}
+
+export function parseUpdateRepoSentinelConfigInput(body: unknown): RepoSentinelConfigInput {
+  if (!isRecord(body)) {
+    throw badRequest('Invalid sentinel config patch payload.');
+  }
+  return readSentinelConfig(body, 'sentinelConfig', true) ?? {};
+}
+
+export function parseStartRepoSentinelInput(body: unknown): { scopeType?: 'group' | 'global'; scopeValue?: string } {
+  if (!isRecord(body)) {
+    throw badRequest('Invalid sentinel start payload.');
+  }
+  const scopeType = hasOwn(body, 'scopeType')
+    ? readEnumValue(body.scopeType, 'scopeType', new Set(['group', 'global'] as const), false)
+    : undefined;
+  const scopeValue = hasOwn(body, 'scopeValue')
+    ? readTrimmedString(body.scopeValue, 'scopeValue', false)
+    : undefined;
+  return {
+    ...(scopeType ? { scopeType } : {}),
+    ...(scopeValue ? { scopeValue } : {})
   };
 }
 

--- a/src/server/router.sentinel.test.ts
+++ b/src/server/router.sentinel.test.ts
@@ -1,0 +1,211 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const tenantAuthDbMocks = vi.hoisted(() => ({
+  resolveSessionByToken: vi.fn(),
+  hasActiveTenantAccess: vi.fn(),
+  listSentinelRuns: vi.fn(),
+  listSentinelEvents: vi.fn(),
+  createSentinelRun: vi.fn(),
+  updateSentinelRun: vi.fn(),
+  appendSentinelEvent: vi.fn(),
+  upsertRepoSentinelConfig: vi.fn(),
+  resolveApiToken: vi.fn(),
+  listUserMemberships: vi.fn()
+}));
+
+vi.mock('./tenant-auth-db', () => tenantAuthDbMocks);
+
+import {
+  handleGetRepoSentinel,
+  handleListRepoSentinelEvents,
+  handlePatchRepoSentinelConfig,
+  handlePauseRepoSentinel,
+  handleResumeRepoSentinel,
+  handleStartRepoSentinel,
+  handleStopRepoSentinel
+} from './router';
+
+function createEnv(overrides?: {
+  repoTenantId?: string;
+  sentinelConfig?: Record<string, unknown>;
+}) {
+  const boardStub = {
+    getRepo: vi.fn(async () => ({
+      repoId: 'repo_1',
+      tenantId: overrides?.repoTenantId ?? 'tenant_local',
+      sentinelConfig: {
+        enabled: true,
+        globalMode: true,
+        reviewGate: { requireChecksGreen: true, requireAutoReviewPass: true },
+        mergePolicy: { autoMergeEnabled: false, method: 'squash', deleteBranch: true },
+        conflictPolicy: { rebaseBeforeMerge: true, remediationEnabled: true, maxAttempts: 2 },
+        ...(overrides?.sentinelConfig ?? {})
+      }
+    })),
+    updateRepo: vi.fn(async (_repoId: string, patch: Record<string, unknown>) => ({
+      repoId: 'repo_1',
+      tenantId: 'tenant_local',
+      sentinelConfig: patch.sentinelConfig
+    }))
+  };
+
+  return {
+    BOARD_INDEX: {
+      getByName: vi.fn(() => boardStub)
+    }
+  } as unknown as Env;
+}
+
+function authHeaders() {
+  return { 'x-session-token': 'sess_token' };
+}
+
+describe('repo sentinel router handlers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    tenantAuthDbMocks.resolveSessionByToken.mockResolvedValue({
+      user: { id: 'user_1' },
+      session: { id: 'sess_1', activeTenantId: 'tenant_local' }
+    });
+    tenantAuthDbMocks.hasActiveTenantAccess.mockResolvedValue(true);
+    tenantAuthDbMocks.listSentinelEvents.mockResolvedValue([]);
+    tenantAuthDbMocks.appendSentinelEvent.mockResolvedValue({});
+  });
+
+  it('returns repo sentinel status', async () => {
+    tenantAuthDbMocks.listSentinelRuns.mockResolvedValue([
+      { id: 'sentinel_run_1', repoId: 'repo_1', tenantId: 'tenant_local', scopeType: 'global', status: 'running', attemptCount: 0, startedAt: '2026-01-01T00:00:00.000Z', updatedAt: '2026-01-01T00:00:00.000Z' }
+    ]);
+    tenantAuthDbMocks.listSentinelEvents.mockResolvedValue([{ id: 'event_1' }]);
+
+    const response = await handleGetRepoSentinel(
+      new Request('https://minions.example.test/api/repos/repo_1/sentinel', { headers: authHeaders() }),
+      createEnv(),
+      { repoId: 'repo_1' }
+    );
+    const body = await response.json() as { repoId: string; run?: { id: string }; events: Array<{ id: string }> };
+
+    expect(response.status).toBe(200);
+    expect(body.repoId).toBe('repo_1');
+    expect(body.run?.id).toBe('sentinel_run_1');
+    expect(body.events[0]?.id).toBe('event_1');
+  });
+
+  it('updates sentinel config via API and repo model', async () => {
+    tenantAuthDbMocks.listSentinelRuns.mockResolvedValue([]);
+    tenantAuthDbMocks.upsertRepoSentinelConfig.mockResolvedValue({
+      enabled: true,
+      globalMode: false,
+      defaultGroupTag: 'payments',
+      reviewGate: { requireChecksGreen: true, requireAutoReviewPass: true },
+      mergePolicy: { autoMergeEnabled: false, method: 'squash', deleteBranch: true },
+      conflictPolicy: { rebaseBeforeMerge: true, remediationEnabled: true, maxAttempts: 2 }
+    });
+
+    const response = await handlePatchRepoSentinelConfig(
+      new Request('https://minions.example.test/api/repos/repo_1/sentinel/config', {
+        method: 'PATCH',
+        headers: { ...authHeaders(), 'content-type': 'application/json' },
+        body: JSON.stringify({ globalMode: false, defaultGroupTag: 'payments' })
+      }),
+      createEnv(),
+      { repoId: 'repo_1' }
+    );
+    const body = await response.json() as { config: { globalMode: boolean; defaultGroupTag?: string } };
+
+    expect(response.status).toBe(200);
+    expect(body.config.globalMode).toBe(false);
+    expect(body.config.defaultGroupTag).toBe('payments');
+    expect(tenantAuthDbMocks.upsertRepoSentinelConfig).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps start idempotent when sentinel is already running', async () => {
+    tenantAuthDbMocks.listSentinelRuns.mockResolvedValue([
+      { id: 'sentinel_run_1', repoId: 'repo_1', tenantId: 'tenant_local', scopeType: 'global', status: 'running', attemptCount: 0, startedAt: '2026-01-01T00:00:00.000Z', updatedAt: '2026-01-01T00:00:00.000Z' }
+    ]);
+
+    const response = await handleStartRepoSentinel(
+      new Request('https://minions.example.test/api/repos/repo_1/sentinel/start', {
+        method: 'POST',
+        headers: { ...authHeaders(), 'content-type': 'application/json' },
+        body: JSON.stringify({})
+      }),
+      createEnv(),
+      { repoId: 'repo_1' }
+    );
+    const body = await response.json() as { changed: boolean; run?: { id: string } };
+
+    expect(response.status).toBe(200);
+    expect(body.changed).toBe(false);
+    expect(body.run?.id).toBe('sentinel_run_1');
+    expect(tenantAuthDbMocks.createSentinelRun).not.toHaveBeenCalled();
+  });
+
+  it('supports pause, resume, and stop transitions', async () => {
+    tenantAuthDbMocks.listSentinelRuns.mockResolvedValue([
+      { id: 'sentinel_run_1', repoId: 'repo_1', tenantId: 'tenant_local', scopeType: 'global', status: 'running', attemptCount: 0, startedAt: '2026-01-01T00:00:00.000Z', updatedAt: '2026-01-01T00:00:00.000Z' }
+    ]);
+    tenantAuthDbMocks.updateSentinelRun.mockImplementation(async (_env: Env, _tenantId: string, runId: string, patch: { status?: string }) => ({
+      id: runId,
+      repoId: 'repo_1',
+      tenantId: 'tenant_local',
+      scopeType: 'global',
+      status: patch.status ?? 'running',
+      attemptCount: 0,
+      startedAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z'
+    }));
+
+    const pauseResponse = await handlePauseRepoSentinel(
+      new Request('https://minions.example.test/api/repos/repo_1/sentinel/pause', { method: 'POST', headers: authHeaders() }),
+      createEnv(),
+      { repoId: 'repo_1' }
+    );
+    const pauseBody = await pauseResponse.json() as { changed: boolean };
+    expect(pauseBody.changed).toBe(true);
+
+    tenantAuthDbMocks.listSentinelRuns.mockResolvedValue([
+      { id: 'sentinel_run_1', repoId: 'repo_1', tenantId: 'tenant_local', scopeType: 'global', status: 'paused', attemptCount: 0, startedAt: '2026-01-01T00:00:00.000Z', updatedAt: '2026-01-01T00:00:00.000Z' }
+    ]);
+    const resumeResponse = await handleResumeRepoSentinel(
+      new Request('https://minions.example.test/api/repos/repo_1/sentinel/resume', { method: 'POST', headers: authHeaders() }),
+      createEnv(),
+      { repoId: 'repo_1' }
+    );
+    const resumeBody = await resumeResponse.json() as { changed: boolean };
+    expect(resumeBody.changed).toBe(true);
+
+    const stopResponse = await handleStopRepoSentinel(
+      new Request('https://minions.example.test/api/repos/repo_1/sentinel/stop', { method: 'POST', headers: authHeaders() }),
+      createEnv(),
+      { repoId: 'repo_1' }
+    );
+    const stopBody = await stopResponse.json() as { changed: boolean };
+    expect(stopBody.changed).toBe(true);
+    expect(tenantAuthDbMocks.updateSentinelRun).toHaveBeenCalled();
+  });
+
+  it('validates sentinel events limit query', async () => {
+    const response = await handleListRepoSentinelEvents(
+      new Request('https://minions.example.test/api/repos/repo_1/sentinel/events?limit=0', { headers: authHeaders() }),
+      createEnv(),
+      { repoId: 'repo_1' }
+    );
+    const body = await response.json() as { code: string };
+    expect(response.status).toBe(400);
+    expect(body.code).toBe('BAD_REQUEST');
+  });
+
+  it('enforces tenant access checks for sentinel endpoints', async () => {
+    tenantAuthDbMocks.hasActiveTenantAccess.mockResolvedValue(false);
+    const response = await handleGetRepoSentinel(
+      new Request('https://minions.example.test/api/repos/repo_1/sentinel', { headers: authHeaders() }),
+      createEnv(),
+      { repoId: 'repo_1' }
+    );
+    const body = await response.json() as { code: string };
+    expect(response.status).toBe(403);
+    expect(body.code).toBe('FORBIDDEN');
+  });
+});
+

--- a/src/server/router.ts
+++ b/src/server/router.ts
@@ -9,6 +9,7 @@ import { handleError, json } from './http/response';
 import {
   parseAcceptTenantInviteInput,
   parseAuthLoginInput,
+  parseStartRepoSentinelInput,
   parseCreateTenantInviteInput,
   parseCreateUserApiTokenInput,
   parseAuthSignupInput,
@@ -20,6 +21,7 @@ import {
   parsePlatformSupportAssumeTenantInput,
   parseSetActiveTenantInput,
   parseRequestRunChangesInput,
+  parseUpdateRepoSentinelConfigInput,
   parseUpdateRepoInput,
   parseUpdateTaskInput,
   parseUpdateTenantMemberInput,
@@ -33,6 +35,7 @@ import { getRunUsage, getTenantRunUsage, getTenantUsageSummary } from './usage-r
 import { normalizeTenantId, normalizeTenantIdStrict } from '../shared/tenant';
 import { hasRunReview } from '../shared/scm';
 import * as tenantAuthDb from './tenant-auth-db';
+import { DEFAULT_REPO_SENTINEL_CONFIG } from '../shared/sentinel';
 import {
   handleSlackCommands as handleSlackCommandsHandler,
   handleSlackEvents as handleSlackEventsHandler,
@@ -456,6 +459,273 @@ export async function handleUpdateRepo(request: Request, env: Env, params: Route
       throw forbidden('Repo tenantId cannot be changed.');
     }
     return json(await board.updateRepo(repoId, patch));
+  });
+}
+
+function mergeRepoSentinelConfig(
+  base: typeof DEFAULT_REPO_SENTINEL_CONFIG,
+  patch: {
+    enabled?: boolean;
+    globalMode?: boolean;
+    defaultGroupTag?: string;
+    reviewGate?: Partial<(typeof DEFAULT_REPO_SENTINEL_CONFIG)['reviewGate']>;
+    mergePolicy?: Partial<(typeof DEFAULT_REPO_SENTINEL_CONFIG)['mergePolicy']>;
+    conflictPolicy?: Partial<(typeof DEFAULT_REPO_SENTINEL_CONFIG)['conflictPolicy']>;
+  }
+) {
+  return {
+    ...base,
+    ...patch,
+    reviewGate: {
+      ...base.reviewGate,
+      ...(patch.reviewGate ?? {})
+    },
+    mergePolicy: {
+      ...base.mergePolicy,
+      ...(patch.mergePolicy ?? {})
+    },
+    conflictPolicy: {
+      ...base.conflictPolicy,
+      ...(patch.conflictPolicy ?? {})
+    }
+  };
+}
+
+async function getLatestRepoSentinelRun(env: Env, tenantId: string, repoId: string) {
+  const runs = await tenantAuthDb.listSentinelRuns(env, tenantId, { repoId });
+  return runs[0];
+}
+
+async function buildRepoSentinelState(env: Env, tenantId: string, repoId: string) {
+  const [run, events] = await Promise.all([
+    getLatestRepoSentinelRun(env, tenantId, repoId),
+    tenantAuthDb.listSentinelEvents(env, tenantId, { repoId, limit: 20 })
+  ]);
+  return {
+    run,
+    events
+  };
+}
+
+export async function handleGetRepoSentinel(request: Request, env: Env, params: RouteParams): Promise<Response> {
+  return withApiError(async () => {
+    const board = getBoard(env);
+    const requestContext = await resolveRequestTenantContext(env, board, request, { requireSession: true });
+    const repoId = parsePathParam(params.repoId);
+    const repo = await assertRepoAccess(env, board, requestContext, repoId);
+    const state = await buildRepoSentinelState(env, requestContext.activeTenantId, repoId);
+    return json({
+      repoId,
+      config: repo.sentinelConfig ?? DEFAULT_REPO_SENTINEL_CONFIG,
+      ...state
+    });
+  });
+}
+
+export async function handlePatchRepoSentinelConfig(request: Request, env: Env, params: RouteParams): Promise<Response> {
+  return withApiError(async () => {
+    const board = getBoard(env);
+    const requestContext = await resolveRequestTenantContext(env, board, request, { requireSession: true });
+    const repoId = parsePathParam(params.repoId);
+    const repo = await assertRepoAccess(env, board, requestContext, repoId);
+    const patch = parseUpdateRepoSentinelConfigInput(await readJson(request));
+    const merged = mergeRepoSentinelConfig(repo.sentinelConfig ?? DEFAULT_REPO_SENTINEL_CONFIG, patch);
+    const [savedConfig, updatedRepo] = await Promise.all([
+      tenantAuthDb.upsertRepoSentinelConfig(env, {
+        tenantId: requestContext.activeTenantId,
+        repoId,
+        config: merged
+      }),
+      board.updateRepo(repoId, { sentinelConfig: merged })
+    ]);
+    const state = await buildRepoSentinelState(env, requestContext.activeTenantId, repoId);
+    return json({
+      repoId,
+      config: savedConfig,
+      repo: updatedRepo,
+      ...state
+    });
+  });
+}
+
+async function transitionRepoSentinelRun(
+  env: Env,
+  tenantId: string,
+  repoId: string,
+  action: 'start' | 'pause' | 'resume' | 'stop',
+  options?: { scopeType?: 'group' | 'global'; scopeValue?: string }
+) {
+  const current = await getLatestRepoSentinelRun(env, tenantId, repoId);
+  const now = new Date().toISOString();
+  let changed = false;
+  let run = current;
+  let eventType: Parameters<typeof tenantAuthDb.appendSentinelEvent>[1]['type'] | undefined;
+  let eventMessage: string | undefined;
+
+  if (action === 'start') {
+    if (!current) {
+      run = await tenantAuthDb.createSentinelRun(env, {
+        tenantId,
+        repoId,
+        scopeType: options?.scopeType ?? 'global',
+        scopeValue: options?.scopeValue,
+        status: 'running',
+        startedAt: now,
+        updatedAt: now
+      });
+      changed = true;
+      eventType = 'sentinel.started';
+      eventMessage = `Sentinel started for ${repoId}.`;
+    } else if (current.status === 'paused') {
+      run = await tenantAuthDb.updateSentinelRun(env, tenantId, current.id, { status: 'running', updatedAt: now });
+      changed = true;
+      eventType = 'sentinel.resumed';
+      eventMessage = `Sentinel resumed for ${repoId}.`;
+    } else if (current.status !== 'running') {
+      run = await tenantAuthDb.createSentinelRun(env, {
+        tenantId,
+        repoId,
+        scopeType: options?.scopeType ?? current.scopeType,
+        scopeValue: options?.scopeValue ?? current.scopeValue,
+        status: 'running',
+        startedAt: now,
+        updatedAt: now
+      });
+      changed = true;
+      eventType = 'sentinel.started';
+      eventMessage = `Sentinel started for ${repoId}.`;
+    }
+  } else if (action === 'pause' && current && current.status === 'running') {
+    run = await tenantAuthDb.updateSentinelRun(env, tenantId, current.id, { status: 'paused', updatedAt: now });
+    changed = true;
+    eventType = 'sentinel.paused';
+    eventMessage = `Sentinel paused for ${repoId}.`;
+  } else if (action === 'resume' && current && current.status === 'paused') {
+    run = await tenantAuthDb.updateSentinelRun(env, tenantId, current.id, { status: 'running', updatedAt: now });
+    changed = true;
+    eventType = 'sentinel.resumed';
+    eventMessage = `Sentinel resumed for ${repoId}.`;
+  } else if (action === 'stop' && current && (current.status === 'running' || current.status === 'paused')) {
+    run = await tenantAuthDb.updateSentinelRun(env, tenantId, current.id, {
+      status: 'stopped',
+      currentTaskId: undefined,
+      currentRunId: undefined,
+      updatedAt: now
+    });
+    changed = true;
+    eventType = 'sentinel.stopped';
+    eventMessage = `Sentinel stopped for ${repoId}.`;
+  }
+
+  if (changed && run && eventType && eventMessage) {
+    await tenantAuthDb.appendSentinelEvent(env, {
+      tenantId,
+      repoId,
+      sentinelRunId: run.id,
+      type: eventType,
+      level: 'info',
+      message: eventMessage,
+      at: now
+    });
+  }
+
+  return {
+    run,
+    changed
+  };
+}
+
+export async function handleStartRepoSentinel(request: Request, env: Env, params: RouteParams): Promise<Response> {
+  return withApiError(async () => {
+    const board = getBoard(env);
+    const requestContext = await resolveRequestTenantContext(env, board, request, { requireSession: true });
+    const repoId = parsePathParam(params.repoId);
+    const repo = await assertRepoAccess(env, board, requestContext, repoId);
+    const body = await readJson(request).catch(() => ({}));
+    const input = parseStartRepoSentinelInput(body);
+    const scopeType = input.scopeType ?? (repo.sentinelConfig?.globalMode ? 'global' : 'group');
+    const scopeValue = scopeType === 'group'
+      ? (input.scopeValue ?? repo.sentinelConfig?.defaultGroupTag)
+      : undefined;
+    const transition = await transitionRepoSentinelRun(env, requestContext.activeTenantId, repoId, 'start', { scopeType, scopeValue });
+    const state = await buildRepoSentinelState(env, requestContext.activeTenantId, repoId);
+    return json({
+      repoId,
+      config: repo.sentinelConfig ?? DEFAULT_REPO_SENTINEL_CONFIG,
+      ...transition,
+      ...state
+    });
+  });
+}
+
+export async function handlePauseRepoSentinel(request: Request, env: Env, params: RouteParams): Promise<Response> {
+  return withApiError(async () => {
+    const board = getBoard(env);
+    const requestContext = await resolveRequestTenantContext(env, board, request, { requireSession: true });
+    const repoId = parsePathParam(params.repoId);
+    const repo = await assertRepoAccess(env, board, requestContext, repoId);
+    const transition = await transitionRepoSentinelRun(env, requestContext.activeTenantId, repoId, 'pause');
+    const state = await buildRepoSentinelState(env, requestContext.activeTenantId, repoId);
+    return json({
+      repoId,
+      config: repo.sentinelConfig ?? DEFAULT_REPO_SENTINEL_CONFIG,
+      ...transition,
+      ...state
+    });
+  });
+}
+
+export async function handleResumeRepoSentinel(request: Request, env: Env, params: RouteParams): Promise<Response> {
+  return withApiError(async () => {
+    const board = getBoard(env);
+    const requestContext = await resolveRequestTenantContext(env, board, request, { requireSession: true });
+    const repoId = parsePathParam(params.repoId);
+    const repo = await assertRepoAccess(env, board, requestContext, repoId);
+    const transition = await transitionRepoSentinelRun(env, requestContext.activeTenantId, repoId, 'resume');
+    const state = await buildRepoSentinelState(env, requestContext.activeTenantId, repoId);
+    return json({
+      repoId,
+      config: repo.sentinelConfig ?? DEFAULT_REPO_SENTINEL_CONFIG,
+      ...transition,
+      ...state
+    });
+  });
+}
+
+export async function handleStopRepoSentinel(request: Request, env: Env, params: RouteParams): Promise<Response> {
+  return withApiError(async () => {
+    const board = getBoard(env);
+    const requestContext = await resolveRequestTenantContext(env, board, request, { requireSession: true });
+    const repoId = parsePathParam(params.repoId);
+    const repo = await assertRepoAccess(env, board, requestContext, repoId);
+    const transition = await transitionRepoSentinelRun(env, requestContext.activeTenantId, repoId, 'stop');
+    const state = await buildRepoSentinelState(env, requestContext.activeTenantId, repoId);
+    return json({
+      repoId,
+      config: repo.sentinelConfig ?? DEFAULT_REPO_SENTINEL_CONFIG,
+      ...transition,
+      ...state
+    });
+  });
+}
+
+export async function handleListRepoSentinelEvents(request: Request, env: Env, params: RouteParams): Promise<Response> {
+  return withApiError(async () => {
+    const url = new URL(request.url);
+    const board = getBoard(env);
+    const requestContext = await resolveRequestTenantContext(env, board, request, { requireSession: true });
+    const repoId = parsePathParam(params.repoId);
+    await assertRepoAccess(env, board, requestContext, repoId);
+    const limitRaw = url.searchParams.get('limit');
+    const limit = limitRaw ? Number(limitRaw) : undefined;
+    if (typeof limit !== 'undefined' && (!Number.isInteger(limit) || limit <= 0)) {
+      throw badRequest('Invalid limit.');
+    }
+    const events = await tenantAuthDb.listSentinelEvents(env, requestContext.activeTenantId, {
+      repoId,
+      ...(typeof limit === 'number' ? { limit } : {})
+    });
+    return json(events);
   });
 }
 

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -8,7 +8,7 @@ import { Modal } from './components/Modal';
 import { RunTerminal } from './components/RunTerminal';
 import { getTaskDetail, getTasksByColumn, getTasksForRepo } from './domain/selectors';
 import type { RunCommand, RunEvent, RunLogEntry, TaskStatus, TerminalBootstrap } from './domain/types';
-import type { AgentBoardApi, AuthSession, InviteRecord, UserApiTokenRecord } from './domain/api';
+import type { AgentBoardApi, AuthSession, InviteRecord, RepoSentinelStatus, UserApiTokenRecord } from './domain/api';
 import { getAgentBoardApi } from './api';
 import { downloadJson } from './store/import-export';
 import { getSelectedTaskIdFromUrl, setSelectedTaskIdInUrl } from './url-state';
@@ -54,6 +54,9 @@ export default function App({ api: providedApi }: { api?: AgentBoardApi }) {
   const [createdApiToken, setCreatedApiToken] = useState<string | undefined>();
   const [apiTokenError, setApiTokenError] = useState<string | undefined>();
   const [taskSelectionHydrated, setTaskSelectionHydrated] = useState(false);
+  const [repoSentinelStatus, setRepoSentinelStatus] = useState<RepoSentinelStatus | undefined>();
+  const [repoSentinelLoading, setRepoSentinelLoading] = useState(false);
+  const [repoSentinelError, setRepoSentinelError] = useState<string | undefined>();
 
   const selectedRepoId = snapshot.ui.selectedRepoId;
   const selectedTaskId = snapshot.ui.selectedTaskId;
@@ -162,6 +165,26 @@ export default function App({ api: providedApi }: { api?: AgentBoardApi }) {
       setSelectedTaskIdInUrl(undefined);
     }
   }, [api, selectedTaskId, snapshot.tasks, taskSelectionHydrated]);
+
+  useEffect(() => {
+    if (!repoToEditId) {
+      setRepoSentinelStatus(undefined);
+      setRepoSentinelError(undefined);
+      setRepoSentinelLoading(false);
+      return;
+    }
+    setRepoSentinelLoading(true);
+    setRepoSentinelError(undefined);
+    void api.getRepoSentinel(repoToEditId)
+      .then((status) => {
+        setRepoSentinelStatus(status);
+        setRepoSentinelLoading(false);
+      })
+      .catch((error) => {
+        setRepoSentinelError(error instanceof Error ? error.message : 'Failed to load sentinel status.');
+        setRepoSentinelLoading(false);
+      });
+  }, [api, repoToEditId]);
 
   useEffect(() => {
     if (!taskSelectionHydrated) {
@@ -377,6 +400,26 @@ export default function App({ api: providedApi }: { api?: AgentBoardApi }) {
     }
   }
 
+  async function triggerRepoSentinelAction(
+    repoId: string,
+    action: 'start' | 'pause' | 'resume' | 'stop'
+  ) {
+    setRepoSentinelError(undefined);
+    try {
+      const result = action === 'start'
+        ? await api.startRepoSentinel(repoId)
+        : action === 'pause'
+          ? await api.pauseRepoSentinel(repoId)
+          : action === 'resume'
+            ? await api.resumeRepoSentinel(repoId)
+            : await api.stopRepoSentinel(repoId);
+      setRepoSentinelStatus(result);
+      setNotice(`Sentinel ${action}${result.changed ? ' applied' : ' already in target state'}.`);
+    } catch (error) {
+      setRepoSentinelError(error instanceof Error ? error.message : `Failed to ${action} sentinel.`);
+    }
+  }
+
   if (authLoading) {
     return <div className="min-h-screen px-4 py-8 text-slate-100">Loading...</div>;
   }
@@ -563,34 +606,100 @@ export default function App({ api: providedApi }: { api?: AgentBoardApi }) {
 
       {repoToEdit ? (
         <Modal title={`Edit ${repoToEdit.projectPath ?? repoToEdit.slug}`} onClose={() => setRepoToEditId(undefined)}>
-          <RepoForm
-            initialValues={{
-              slug: repoToEdit.slug,
-              scmProvider: repoToEdit.scmProvider,
-              scmBaseUrl: repoToEdit.scmBaseUrl,
-              projectPath: repoToEdit.projectPath,
-              defaultBranch: repoToEdit.defaultBranch,
-              baselineUrl: repoToEdit.baselineUrl,
-              previewMode: repoToEdit.previewMode,
-              evidenceMode: repoToEdit.evidenceMode,
-              previewAdapter: repoToEdit.previewAdapter,
-              previewConfig: repoToEdit.previewConfig,
-              commitConfig: repoToEdit.commitConfig,
-              previewProvider: repoToEdit.previewProvider,
-              previewCheckName: repoToEdit.previewCheckName,
-              llmAdapter: repoToEdit.llmAdapter,
-              llmProfileId: repoToEdit.llmProfileId,
-              llmAuthBundleR2Key: repoToEdit.llmAuthBundleR2Key,
-              codexAuthBundleR2Key: repoToEdit.codexAuthBundleR2Key,
-              autoReview: repoToEdit.autoReview
-            }}
-            submitLabel="Save repo"
-            onSubmit={async (input) => {
-              await api.updateRepo(repoToEdit.repoId, input);
-              setRepoToEditId(undefined);
-              setNotice(`Updated ${input.projectPath ?? input.slug ?? repoToEdit.projectPath ?? repoToEdit.slug}.`);
-            }}
-          />
+          <div className="space-y-4">
+            <RepoForm
+              initialValues={{
+                slug: repoToEdit.slug,
+                scmProvider: repoToEdit.scmProvider,
+                scmBaseUrl: repoToEdit.scmBaseUrl,
+                projectPath: repoToEdit.projectPath,
+                defaultBranch: repoToEdit.defaultBranch,
+                baselineUrl: repoToEdit.baselineUrl,
+                previewMode: repoToEdit.previewMode,
+                evidenceMode: repoToEdit.evidenceMode,
+                previewAdapter: repoToEdit.previewAdapter,
+                previewConfig: repoToEdit.previewConfig,
+                commitConfig: repoToEdit.commitConfig,
+                previewProvider: repoToEdit.previewProvider,
+                previewCheckName: repoToEdit.previewCheckName,
+                llmAdapter: repoToEdit.llmAdapter,
+                llmProfileId: repoToEdit.llmProfileId,
+                llmAuthBundleR2Key: repoToEdit.llmAuthBundleR2Key,
+                codexAuthBundleR2Key: repoToEdit.codexAuthBundleR2Key,
+                autoReview: repoToEdit.autoReview,
+                sentinelConfig: repoToEdit.sentinelConfig
+              }}
+              submitLabel="Save repo"
+              onSubmit={async (input) => {
+                const { sentinelConfig, ...repoPatch } = input;
+                await api.updateRepo(repoToEdit.repoId, repoPatch);
+                if (sentinelConfig) {
+                  const status = await api.updateRepoSentinelConfig(repoToEdit.repoId, sentinelConfig);
+                  setRepoSentinelStatus(status);
+                }
+                setRepoToEditId(undefined);
+                setNotice(`Updated ${input.projectPath ?? input.slug ?? repoToEdit.projectPath ?? repoToEdit.slug}.`);
+              }}
+            />
+            <section className="rounded-xl border border-slate-800 bg-slate-950/40 p-4">
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <div>
+                  <div className="text-sm font-semibold text-slate-100">Sentinel status</div>
+                  <div className="mt-1 text-xs text-slate-400">
+                    {repoSentinelLoading
+                      ? 'Loading status...'
+                      : `Run state: ${repoSentinelStatus?.run?.status ?? 'idle'} · Scope: ${repoSentinelStatus?.run?.scopeType ?? 'n/a'}`}
+                  </div>
+                </div>
+                <div className="flex flex-wrap gap-2">
+                  <button
+                    type="button"
+                    className="rounded-lg border border-emerald-400/35 bg-emerald-500/10 px-3 py-1.5 text-xs text-emerald-100"
+                    onClick={() => void triggerRepoSentinelAction(repoToEdit.repoId, 'start')}
+                  >
+                    Start
+                  </button>
+                  <button
+                    type="button"
+                    className="rounded-lg border border-amber-400/35 bg-amber-500/10 px-3 py-1.5 text-xs text-amber-100"
+                    onClick={() => void triggerRepoSentinelAction(repoToEdit.repoId, 'pause')}
+                  >
+                    Pause
+                  </button>
+                  <button
+                    type="button"
+                    className="rounded-lg border border-cyan-400/35 bg-cyan-500/10 px-3 py-1.5 text-xs text-cyan-100"
+                    onClick={() => void triggerRepoSentinelAction(repoToEdit.repoId, 'resume')}
+                  >
+                    Resume
+                  </button>
+                  <button
+                    type="button"
+                    className="rounded-lg border border-rose-400/35 bg-rose-500/10 px-3 py-1.5 text-xs text-rose-100"
+                    onClick={() => void triggerRepoSentinelAction(repoToEdit.repoId, 'stop')}
+                  >
+                    Stop
+                  </button>
+                </div>
+              </div>
+              {repoSentinelError ? <div className="mt-2 text-sm text-rose-300">{repoSentinelError}</div> : null}
+              <div className="mt-3 max-h-52 space-y-2 overflow-auto">
+                {(repoSentinelStatus?.events ?? []).length ? (
+                  repoSentinelStatus?.events.map((event) => (
+                    <div key={event.id} className="rounded-lg border border-slate-800 bg-slate-950/70 px-3 py-2 text-xs text-slate-300">
+                      <div className="flex items-center justify-between gap-2">
+                        <span>{event.type}</span>
+                        <span className="text-slate-500">{new Date(event.at).toLocaleString()}</span>
+                      </div>
+                      <div className="mt-1 text-slate-400">{event.message}</div>
+                    </div>
+                  ))
+                ) : (
+                  <div className="text-xs text-slate-500">No sentinel events yet.</div>
+                )}
+              </div>
+            </section>
+          </div>
         </Modal>
       ) : null}
 

--- a/src/ui/api/http-agent-board-api.ts
+++ b/src/ui/api/http-agent-board-api.ts
@@ -6,6 +6,10 @@ import type {
   CreateInviteInput,
   CreateInviteResult,
   CreateRepoInput,
+  RepoSentinelActionResult,
+  RepoSentinelConfigInput,
+  RepoSentinelStartInput,
+  RepoSentinelStatus,
   CreateTaskInput,
   CreateUserApiTokenInput,
   CreateUserApiTokenResult,
@@ -159,6 +163,52 @@ export class HttpAgentBoardApi implements AgentBoardApi {
     const repo = await this.request<Repo>(`/api/repos/${encodeURIComponent(repoId)}`, { method: 'PATCH', body: JSON.stringify(patch) });
     await this.refresh();
     return repo;
+  }
+
+  async getRepoSentinel(repoId: string) {
+    return this.request<RepoSentinelStatus>(`/api/repos/${encodeURIComponent(repoId)}/sentinel`);
+  }
+
+  async updateRepoSentinelConfig(repoId: string, patch: RepoSentinelConfigInput) {
+    const status = await this.request<RepoSentinelStatus>(`/api/repos/${encodeURIComponent(repoId)}/sentinel/config`, {
+      method: 'PATCH',
+      body: JSON.stringify(patch)
+    });
+    await this.refresh();
+    return status;
+  }
+
+  async startRepoSentinel(repoId: string, input?: RepoSentinelStartInput) {
+    return this.request<RepoSentinelActionResult>(`/api/repos/${encodeURIComponent(repoId)}/sentinel/start`, {
+      method: 'POST',
+      body: JSON.stringify(input ?? {})
+    });
+  }
+
+  async pauseRepoSentinel(repoId: string) {
+    return this.request<RepoSentinelActionResult>(`/api/repos/${encodeURIComponent(repoId)}/sentinel/pause`, {
+      method: 'POST',
+      body: JSON.stringify({})
+    });
+  }
+
+  async resumeRepoSentinel(repoId: string) {
+    return this.request<RepoSentinelActionResult>(`/api/repos/${encodeURIComponent(repoId)}/sentinel/resume`, {
+      method: 'POST',
+      body: JSON.stringify({})
+    });
+  }
+
+  async stopRepoSentinel(repoId: string) {
+    return this.request<RepoSentinelActionResult>(`/api/repos/${encodeURIComponent(repoId)}/sentinel/stop`, {
+      method: 'POST',
+      body: JSON.stringify({})
+    });
+  }
+
+  async listRepoSentinelEvents(repoId: string, options?: { limit?: number }) {
+    const query = options?.limit ? `?limit=${options.limit}` : '';
+    return this.request<RepoSentinelStatus['events']>(`/api/repos/${encodeURIComponent(repoId)}/sentinel/events${query}`);
   }
 
   async listScmCredentials() {

--- a/src/ui/components/Forms.tsx
+++ b/src/ui/components/Forms.tsx
@@ -7,6 +7,7 @@ import type {
   LlmAdapter,
   LlmReasoningEffort,
   PreviewAdapterKind,
+  RepoSentinelConfig,
   Repo,
   ScmProvider,
   TaskContextLink,
@@ -97,6 +98,17 @@ export function RepoForm({
   const initialCommitMessageTemplate = initialValues?.commitConfig?.messageTemplate ?? '';
   const initialCommitMessageRegex = initialValues?.commitConfig?.messageRegex ?? '';
   const initialCommitMessageExamples = (initialValues?.commitConfig?.messageExamples ?? []).join('\n');
+  const initialSentinelEnabled = initialValues?.sentinelConfig?.enabled ?? false;
+  const initialSentinelGlobalMode = initialValues?.sentinelConfig?.globalMode ?? true;
+  const initialSentinelGroupTag = initialValues?.sentinelConfig?.defaultGroupTag ?? '';
+  const initialSentinelRequireChecksGreen = initialValues?.sentinelConfig?.reviewGate?.requireChecksGreen ?? true;
+  const initialSentinelRequireAutoReviewPass = initialValues?.sentinelConfig?.reviewGate?.requireAutoReviewPass ?? true;
+  const initialSentinelAutoMergeEnabled = initialValues?.sentinelConfig?.mergePolicy?.autoMergeEnabled ?? false;
+  const initialSentinelMergeMethod = initialValues?.sentinelConfig?.mergePolicy?.method ?? 'squash';
+  const initialSentinelDeleteBranch = initialValues?.sentinelConfig?.mergePolicy?.deleteBranch ?? true;
+  const initialSentinelRebaseBeforeMerge = initialValues?.sentinelConfig?.conflictPolicy?.rebaseBeforeMerge ?? true;
+  const initialSentinelRemediationEnabled = initialValues?.sentinelConfig?.conflictPolicy?.remediationEnabled ?? true;
+  const initialSentinelMaxAttempts = String(initialValues?.sentinelConfig?.conflictPolicy?.maxAttempts ?? 2);
 
   const [scmProvider, setScmProvider] = useState<ScmProvider>(initialScmProvider);
   const [scmBaseUrl, setScmBaseUrl] = useState(initialScmBaseUrl);
@@ -119,6 +131,17 @@ export function RepoForm({
   const [commitMessageTemplate, setCommitMessageTemplate] = useState(initialCommitMessageTemplate);
   const [commitMessageRegex, setCommitMessageRegex] = useState(initialCommitMessageRegex);
   const [commitMessageExamples, setCommitMessageExamples] = useState(initialCommitMessageExamples);
+  const [sentinelEnabled, setSentinelEnabled] = useState(initialSentinelEnabled);
+  const [sentinelGlobalMode, setSentinelGlobalMode] = useState(initialSentinelGlobalMode);
+  const [sentinelGroupTag, setSentinelGroupTag] = useState(initialSentinelGroupTag);
+  const [sentinelRequireChecksGreen, setSentinelRequireChecksGreen] = useState(initialSentinelRequireChecksGreen);
+  const [sentinelRequireAutoReviewPass, setSentinelRequireAutoReviewPass] = useState(initialSentinelRequireAutoReviewPass);
+  const [sentinelAutoMergeEnabled, setSentinelAutoMergeEnabled] = useState(initialSentinelAutoMergeEnabled);
+  const [sentinelMergeMethod, setSentinelMergeMethod] = useState<RepoSentinelConfig['mergePolicy']['method']>(initialSentinelMergeMethod);
+  const [sentinelDeleteBranch, setSentinelDeleteBranch] = useState(initialSentinelDeleteBranch);
+  const [sentinelRebaseBeforeMerge, setSentinelRebaseBeforeMerge] = useState(initialSentinelRebaseBeforeMerge);
+  const [sentinelRemediationEnabled, setSentinelRemediationEnabled] = useState(initialSentinelRemediationEnabled);
+  const [sentinelMaxAttempts, setSentinelMaxAttempts] = useState(initialSentinelMaxAttempts);
 
   useEffect(() => {
     setScmProvider(initialScmProvider);
@@ -142,6 +165,17 @@ export function RepoForm({
     setCommitMessageTemplate(initialCommitMessageTemplate);
     setCommitMessageRegex(initialCommitMessageRegex);
     setCommitMessageExamples(initialCommitMessageExamples);
+    setSentinelEnabled(initialSentinelEnabled);
+    setSentinelGlobalMode(initialSentinelGlobalMode);
+    setSentinelGroupTag(initialSentinelGroupTag);
+    setSentinelRequireChecksGreen(initialSentinelRequireChecksGreen);
+    setSentinelRequireAutoReviewPass(initialSentinelRequireAutoReviewPass);
+    setSentinelAutoMergeEnabled(initialSentinelAutoMergeEnabled);
+    setSentinelMergeMethod(initialSentinelMergeMethod);
+    setSentinelDeleteBranch(initialSentinelDeleteBranch);
+    setSentinelRebaseBeforeMerge(initialSentinelRebaseBeforeMerge);
+    setSentinelRemediationEnabled(initialSentinelRemediationEnabled);
+    setSentinelMaxAttempts(initialSentinelMaxAttempts);
   }, [
     initialScmProvider,
     initialScmBaseUrl,
@@ -163,7 +197,18 @@ export function RepoForm({
     initialCodexAuthBundleR2Key,
     initialCommitMessageTemplate,
     initialCommitMessageRegex,
-    initialCommitMessageExamples
+    initialCommitMessageExamples,
+    initialSentinelEnabled,
+    initialSentinelGlobalMode,
+    initialSentinelGroupTag,
+    initialSentinelRequireChecksGreen,
+    initialSentinelRequireAutoReviewPass,
+    initialSentinelAutoMergeEnabled,
+    initialSentinelMergeMethod,
+    initialSentinelDeleteBranch,
+    initialSentinelRebaseBeforeMerge,
+    initialSentinelRemediationEnabled,
+    initialSentinelMaxAttempts
   ]);
 
   const projectPathHint = scmProvider === 'gitlab'
@@ -191,6 +236,10 @@ export function RepoForm({
     ...(commitMessageRegex.trim() ? { messageRegex: commitMessageRegex.trim() } : {}),
     ...(commitMessageExamplesList.length ? { messageExamples: commitMessageExamplesList } : {})
   };
+  const parsedSentinelMaxAttempts = Number.parseInt(sentinelMaxAttempts, 10);
+  const normalizedSentinelMaxAttempts = Number.isInteger(parsedSentinelMaxAttempts) && parsedSentinelMaxAttempts > 0
+    ? parsedSentinelMaxAttempts
+    : 1;
 
   return (
     <form
@@ -220,7 +269,26 @@ export function RepoForm({
           previewConfig: Object.keys(previewConfig).length > 0 ? previewConfig : undefined,
           commitConfig: Object.keys(commitConfig).length > 0 ? commitConfig : undefined,
           previewCheckName: previewCheckName || undefined,
-          codexAuthBundleR2Key: codexAuthBundleR2Key || (llmAdapter === 'codex' ? (llmAuthBundleR2Key || undefined) : undefined)
+          codexAuthBundleR2Key: codexAuthBundleR2Key || (llmAdapter === 'codex' ? (llmAuthBundleR2Key || undefined) : undefined),
+          sentinelConfig: {
+            enabled: sentinelEnabled,
+            globalMode: sentinelGlobalMode,
+            defaultGroupTag: sentinelGlobalMode ? undefined : (sentinelGroupTag.trim() || undefined),
+            reviewGate: {
+              requireChecksGreen: sentinelRequireChecksGreen,
+              requireAutoReviewPass: sentinelRequireAutoReviewPass
+            },
+            mergePolicy: {
+              autoMergeEnabled: sentinelAutoMergeEnabled,
+              method: sentinelMergeMethod,
+              deleteBranch: sentinelDeleteBranch
+            },
+            conflictPolicy: {
+              rebaseBeforeMerge: sentinelRebaseBeforeMerge,
+              remediationEnabled: sentinelRemediationEnabled,
+              maxAttempts: normalizedSentinelMaxAttempts
+            }
+          }
         });
         setScmProvider('github');
         setScmBaseUrl(DEFAULT_SCM_BASE_URLS.github);
@@ -243,6 +311,17 @@ export function RepoForm({
         setCommitMessageTemplate('');
         setCommitMessageRegex('');
         setCommitMessageExamples('');
+        setSentinelEnabled(false);
+        setSentinelGlobalMode(true);
+        setSentinelGroupTag('');
+        setSentinelRequireChecksGreen(true);
+        setSentinelRequireAutoReviewPass(true);
+        setSentinelAutoMergeEnabled(false);
+        setSentinelMergeMethod('squash');
+        setSentinelDeleteBranch(true);
+        setSentinelRebaseBeforeMerge(true);
+        setSentinelRemediationEnabled(true);
+        setSentinelMaxAttempts('2');
       }}
     >
       <div className="grid gap-4 md:grid-cols-3">
@@ -418,6 +497,115 @@ export function RepoForm({
           placeholder={'feat(cp): Add banner block support [task_abc123]\nfix(cp): Correct CTA URL handling [task_def456]'}
         />
       </FieldShell>
+      <div className="rounded-xl border border-slate-800 bg-slate-950/40 p-4">
+        <div className="text-sm font-semibold text-slate-100">Sentinel</div>
+        <div className="mt-3 grid gap-4 md:grid-cols-2">
+          <FieldShell label="Enabled" hint="Allow operators to orchestrate this repo with sentinel APIs.">
+            <div className="flex h-11 items-center gap-3 rounded-xl border border-slate-700 bg-slate-900/90 px-3 text-sm text-slate-100">
+              <input
+                type="checkbox"
+                checked={sentinelEnabled}
+                onChange={(event) => setSentinelEnabled(event.target.checked)}
+                className="h-4 w-4 rounded border-slate-600 bg-slate-950 text-cyan-400 focus:ring-cyan-400/30"
+              />
+              <span>{sentinelEnabled ? 'Enabled' : 'Disabled'}</span>
+            </div>
+          </FieldShell>
+          <FieldShell label="Scope mode">
+            <select className={inputClass()} value={sentinelGlobalMode ? 'global' : 'group'} onChange={(event) => setSentinelGlobalMode(event.target.value === 'global')}>
+              <option value="global">Global</option>
+              <option value="group">Group tag</option>
+            </select>
+          </FieldShell>
+          {!sentinelGlobalMode ? (
+            <FieldShell label="Default group tag" hint="Used by start API when no scope tag is provided.">
+              <input className={inputClass()} value={sentinelGroupTag} onChange={(event) => setSentinelGroupTag(event.target.value)} placeholder="payments" />
+            </FieldShell>
+          ) : null}
+        </div>
+        <div className="mt-3 grid gap-4 md:grid-cols-2">
+          <FieldShell label="Require checks green">
+            <div className="flex h-11 items-center gap-3 rounded-xl border border-slate-700 bg-slate-900/90 px-3 text-sm text-slate-100">
+              <input
+                type="checkbox"
+                checked={sentinelRequireChecksGreen}
+                onChange={(event) => setSentinelRequireChecksGreen(event.target.checked)}
+                className="h-4 w-4 rounded border-slate-600 bg-slate-950 text-cyan-400 focus:ring-cyan-400/30"
+              />
+              <span>{sentinelRequireChecksGreen ? 'Required' : 'Optional'}</span>
+            </div>
+          </FieldShell>
+          <FieldShell label="Require auto-review pass">
+            <div className="flex h-11 items-center gap-3 rounded-xl border border-slate-700 bg-slate-900/90 px-3 text-sm text-slate-100">
+              <input
+                type="checkbox"
+                checked={sentinelRequireAutoReviewPass}
+                onChange={(event) => setSentinelRequireAutoReviewPass(event.target.checked)}
+                className="h-4 w-4 rounded border-slate-600 bg-slate-950 text-cyan-400 focus:ring-cyan-400/30"
+              />
+              <span>{sentinelRequireAutoReviewPass ? 'Required' : 'Optional'}</span>
+            </div>
+          </FieldShell>
+        </div>
+        <div className="mt-3 grid gap-4 md:grid-cols-3">
+          <FieldShell label="Auto-merge enabled">
+            <div className="flex h-11 items-center gap-3 rounded-xl border border-slate-700 bg-slate-900/90 px-3 text-sm text-slate-100">
+              <input
+                type="checkbox"
+                checked={sentinelAutoMergeEnabled}
+                onChange={(event) => setSentinelAutoMergeEnabled(event.target.checked)}
+                className="h-4 w-4 rounded border-slate-600 bg-slate-950 text-cyan-400 focus:ring-cyan-400/30"
+              />
+              <span>{sentinelAutoMergeEnabled ? 'Enabled' : 'Disabled'}</span>
+            </div>
+          </FieldShell>
+          <FieldShell label="Merge method">
+            <select className={inputClass()} value={sentinelMergeMethod} onChange={(event) => setSentinelMergeMethod(event.target.value as RepoSentinelConfig['mergePolicy']['method'])}>
+              <option value="merge">Merge</option>
+              <option value="squash">Squash</option>
+              <option value="rebase">Rebase</option>
+            </select>
+          </FieldShell>
+          <FieldShell label="Delete branch on merge">
+            <div className="flex h-11 items-center gap-3 rounded-xl border border-slate-700 bg-slate-900/90 px-3 text-sm text-slate-100">
+              <input
+                type="checkbox"
+                checked={sentinelDeleteBranch}
+                onChange={(event) => setSentinelDeleteBranch(event.target.checked)}
+                className="h-4 w-4 rounded border-slate-600 bg-slate-950 text-cyan-400 focus:ring-cyan-400/30"
+              />
+              <span>{sentinelDeleteBranch ? 'Delete' : 'Keep'}</span>
+            </div>
+          </FieldShell>
+        </div>
+        <div className="mt-3 grid gap-4 md:grid-cols-3">
+          <FieldShell label="Rebase before merge">
+            <div className="flex h-11 items-center gap-3 rounded-xl border border-slate-700 bg-slate-900/90 px-3 text-sm text-slate-100">
+              <input
+                type="checkbox"
+                checked={sentinelRebaseBeforeMerge}
+                onChange={(event) => setSentinelRebaseBeforeMerge(event.target.checked)}
+                className="h-4 w-4 rounded border-slate-600 bg-slate-950 text-cyan-400 focus:ring-cyan-400/30"
+              />
+              <span>{sentinelRebaseBeforeMerge ? 'Enabled' : 'Disabled'}</span>
+            </div>
+          </FieldShell>
+          <FieldShell label="Remediation enabled">
+            <div className="flex h-11 items-center gap-3 rounded-xl border border-slate-700 bg-slate-900/90 px-3 text-sm text-slate-100">
+              <input
+                type="checkbox"
+                checked={sentinelRemediationEnabled}
+                onChange={(event) => setSentinelRemediationEnabled(event.target.checked)}
+                className="h-4 w-4 rounded border-slate-600 bg-slate-950 text-cyan-400 focus:ring-cyan-400/30"
+              />
+              <span>{sentinelRemediationEnabled ? 'Enabled' : 'Disabled'}</span>
+            </div>
+          </FieldShell>
+          <FieldShell label="Max remediation attempts">
+            <input className={inputClass()} type="number" min={1} step={1} value={sentinelMaxAttempts} onChange={(event) => setSentinelMaxAttempts(event.target.value)} />
+          </FieldShell>
+        </div>
+      </div>
       <PrimaryButton>{submitLabel}</PrimaryButton>
     </form>
   );
@@ -704,7 +892,7 @@ export function TaskForm({
       </div>
       <div className="grid gap-4 xl:grid-cols-2">
         <FieldShell label="Auto-review mode" hint="inherit uses repo setting; on/off force behavior for this task.">
-          <select className={inputClass()} value={autoReviewMode} onChange={(event) => setAutoReviewMode(event.target.value as CreateTaskInput['autoReviewMode'])}>
+          <select className={inputClass()} value={autoReviewMode} onChange={(event) => setAutoReviewMode(event.target.value as NonNullable<CreateTaskInput['autoReviewMode']>)}>
             <option value="inherit">Inherit</option>
             <option value="on">On</option>
             <option value="off">Off</option>

--- a/src/ui/domain/api.ts
+++ b/src/ui/domain/api.ts
@@ -9,6 +9,8 @@ import type {
   LlmReasoningEffort,
   Repo,
   RepoSentinelConfig,
+  SentinelEvent,
+  SentinelRun,
   RunCommand,
   RunEvent,
   RunLogEntry,
@@ -36,6 +38,22 @@ export type RepoSentinelConfigInput = {
   reviewGate?: Partial<RepoSentinelConfig['reviewGate']>;
   mergePolicy?: Partial<RepoSentinelConfig['mergePolicy']>;
   conflictPolicy?: Partial<RepoSentinelConfig['conflictPolicy']>;
+};
+
+export type RepoSentinelStartInput = {
+  scopeType?: 'group' | 'global';
+  scopeValue?: string;
+};
+
+export type RepoSentinelStatus = {
+  repoId: string;
+  config: RepoSentinelConfig;
+  run?: SentinelRun;
+  events: SentinelEvent[];
+};
+
+export type RepoSentinelActionResult = RepoSentinelStatus & {
+  changed: boolean;
 };
 
 export type RequestRunChangesSelection = {
@@ -196,6 +214,13 @@ export interface AgentBoardApi {
   createRepo(input: CreateRepoInput): Promise<Repo>;
   listRepos(): Promise<Repo[]>;
   updateRepo(repoId: string, patch: UpdateRepoInput): Promise<Repo>;
+  getRepoSentinel(repoId: string): Promise<RepoSentinelStatus>;
+  updateRepoSentinelConfig(repoId: string, patch: RepoSentinelConfigInput): Promise<RepoSentinelStatus>;
+  startRepoSentinel(repoId: string, input?: RepoSentinelStartInput): Promise<RepoSentinelActionResult>;
+  pauseRepoSentinel(repoId: string): Promise<RepoSentinelActionResult>;
+  resumeRepoSentinel(repoId: string): Promise<RepoSentinelActionResult>;
+  stopRepoSentinel(repoId: string): Promise<RepoSentinelActionResult>;
+  listRepoSentinelEvents(repoId: string, options?: { limit?: number }): Promise<SentinelEvent[]>;
   listScmCredentials(): Promise<ScmCredential[]>;
   getScmCredential(scmProvider: UpsertScmCredentialInput['scmProvider'], host: string): Promise<ScmCredential | undefined>;
   upsertScmCredential(input: UpsertScmCredentialInput): Promise<ScmCredential>;

--- a/src/ui/mock/local-agent-board-api.ts
+++ b/src/ui/mock/local-agent-board-api.ts
@@ -6,6 +6,10 @@ import type {
   CreateInviteInput,
   CreateInviteResult,
   CreateRepoInput,
+  RepoSentinelActionResult,
+  RepoSentinelConfigInput,
+  RepoSentinelStartInput,
+  RepoSentinelStatus,
   CreateTaskInput,
   CreateUserApiTokenInput,
   CreateUserApiTokenResult,
@@ -38,6 +42,8 @@ export class LocalAgentBoardApi implements AgentBoardApi {
   private readonly scmCredentials = new Map<string, ScmCredential & { token: string }>();
   private readonly invites = new Map<string, InviteRecord & { token: string }>();
   private readonly userApiTokens = new Map<string, UserApiTokenRecord & { token: string }>();
+  private readonly repoSentinelRuns = new Map<string, NonNullable<RepoSentinelStatus['run']>>();
+  private readonly repoSentinelEvents = new Map<string, RepoSentinelStatus['events']>();
   private authSession?: AuthSession;
 
   private createLocalAuthSession(userOverride?: Partial<User> & Pick<User, 'id' | 'email'>, role: TenantMember['role'] = 'owner'): AuthSession {
@@ -335,6 +341,140 @@ export class LocalAgentBoardApi implements AgentBoardApi {
     }
 
     return updatedRepo;
+  }
+
+  async getRepoSentinel(repoId: string): Promise<RepoSentinelStatus> {
+    const repo = this.store.getSnapshot().repos.find((candidate) => candidate.repoId === repoId);
+    if (!repo) {
+      throw new Error(`Repo ${repoId} not found.`);
+    }
+    const events = this.repoSentinelEvents.get(repoId) ?? [];
+    return {
+      repoId,
+      config: repo.sentinelConfig ?? DEFAULT_REPO_SENTINEL_CONFIG,
+      run: this.repoSentinelRuns.get(repoId),
+      events: [...events].sort((left, right) => right.at.localeCompare(left.at))
+    };
+  }
+
+  async updateRepoSentinelConfig(repoId: string, patch: RepoSentinelConfigInput): Promise<RepoSentinelStatus> {
+    await this.updateRepo(repoId, { sentinelConfig: patch });
+    return this.getRepoSentinel(repoId);
+  }
+
+  async startRepoSentinel(repoId: string, input?: RepoSentinelStartInput): Promise<RepoSentinelActionResult> {
+    const repo = this.store.getSnapshot().repos.find((candidate) => candidate.repoId === repoId);
+    if (!repo) {
+      throw new Error(`Repo ${repoId} not found.`);
+    }
+    const current = this.repoSentinelRuns.get(repoId);
+    if (current?.status === 'running') {
+      return { ...(await this.getRepoSentinel(repoId)), changed: false };
+    }
+    const now = nowIso();
+    const next = current
+      ? { ...current, status: 'running' as const, updatedAt: now }
+      : {
+          id: randomId('sentinel_run'),
+          tenantId: repo.tenantId ?? 'tenant_local',
+          repoId,
+          scopeType: input?.scopeType ?? (repo.sentinelConfig?.globalMode ? 'global' : 'group'),
+          scopeValue: input?.scopeValue ?? repo.sentinelConfig?.defaultGroupTag,
+          status: 'running' as const,
+          attemptCount: 0,
+          startedAt: now,
+          updatedAt: now
+        };
+    this.repoSentinelRuns.set(repoId, next);
+    this.pushSentinelEvent(repoId, {
+      id: randomId('sentinel_event'),
+      sentinelRunId: next.id,
+      tenantId: next.tenantId,
+      repoId,
+      at: now,
+      level: 'info',
+      type: current ? 'sentinel.resumed' : 'sentinel.started',
+      message: current ? `Sentinel resumed for ${repo.slug}.` : `Sentinel started for ${repo.slug}.`
+    });
+    return { ...(await this.getRepoSentinel(repoId)), changed: true };
+  }
+
+  async pauseRepoSentinel(repoId: string): Promise<RepoSentinelActionResult> {
+    const current = this.repoSentinelRuns.get(repoId);
+    if (!current || current.status !== 'running') {
+      return { ...(await this.getRepoSentinel(repoId)), changed: false };
+    }
+    const now = nowIso();
+    const next = { ...current, status: 'paused' as const, updatedAt: now };
+    this.repoSentinelRuns.set(repoId, next);
+    this.pushSentinelEvent(repoId, {
+      id: randomId('sentinel_event'),
+      sentinelRunId: next.id,
+      tenantId: next.tenantId,
+      repoId,
+      at: now,
+      level: 'info',
+      type: 'sentinel.paused',
+      message: `Sentinel paused for ${repoId}.`
+    });
+    return { ...(await this.getRepoSentinel(repoId)), changed: true };
+  }
+
+  async resumeRepoSentinel(repoId: string): Promise<RepoSentinelActionResult> {
+    const current = this.repoSentinelRuns.get(repoId);
+    if (!current || current.status !== 'paused') {
+      return { ...(await this.getRepoSentinel(repoId)), changed: false };
+    }
+    const now = nowIso();
+    const next = { ...current, status: 'running' as const, updatedAt: now };
+    this.repoSentinelRuns.set(repoId, next);
+    this.pushSentinelEvent(repoId, {
+      id: randomId('sentinel_event'),
+      sentinelRunId: next.id,
+      tenantId: next.tenantId,
+      repoId,
+      at: now,
+      level: 'info',
+      type: 'sentinel.resumed',
+      message: `Sentinel resumed for ${repoId}.`
+    });
+    return { ...(await this.getRepoSentinel(repoId)), changed: true };
+  }
+
+  async stopRepoSentinel(repoId: string): Promise<RepoSentinelActionResult> {
+    const current = this.repoSentinelRuns.get(repoId);
+    if (!current || (current.status !== 'running' && current.status !== 'paused')) {
+      return { ...(await this.getRepoSentinel(repoId)), changed: false };
+    }
+    const now = nowIso();
+    const next = {
+      ...current,
+      status: 'stopped' as const,
+      currentTaskId: undefined,
+      currentRunId: undefined,
+      updatedAt: now
+    };
+    this.repoSentinelRuns.set(repoId, next);
+    this.pushSentinelEvent(repoId, {
+      id: randomId('sentinel_event'),
+      sentinelRunId: next.id,
+      tenantId: next.tenantId,
+      repoId,
+      at: now,
+      level: 'info',
+      type: 'sentinel.stopped',
+      message: `Sentinel stopped for ${repoId}.`
+    });
+    return { ...(await this.getRepoSentinel(repoId)), changed: true };
+  }
+
+  async listRepoSentinelEvents(repoId: string, options?: { limit?: number }) {
+    const events = this.repoSentinelEvents.get(repoId) ?? [];
+    const sorted = [...events].sort((left, right) => right.at.localeCompare(left.at));
+    if (!options?.limit || options.limit < 1) {
+      return sorted;
+    }
+    return sorted.slice(0, options.limit);
   }
 
   async listScmCredentials(): Promise<ScmCredential[]> {
@@ -714,6 +854,11 @@ export class LocalAgentBoardApi implements AgentBoardApi {
   private async updateTaskStatusAndStartRun(task: Task) {
     await this.startRun(task.taskId);
     return this.store.getSnapshot().tasks.find((candidate) => candidate.taskId === task.taskId)!;
+  }
+
+  private pushSentinelEvent(repoId: string, event: RepoSentinelStatus['events'][number]) {
+    const existing = this.repoSentinelEvents.get(repoId) ?? [];
+    this.repoSentinelEvents.set(repoId, [event, ...existing].slice(0, 500));
   }
 }
 


### PR DESCRIPTION
Task: S2 - Sentinel APIs and Repo Controls

Expose sentinel config/status/action APIs and repo-level controls for operators.
Source ref: main

Acceptance criteria:
- Operators can start/pause/resume/stop sentinel via API.
- Repo sentinel settings are editable via UI and API.
- Sentinel status/events endpoints return consistent state.
- Action endpoints are idempotent-safe under retries.
- make sure that "yarn test" passes
- Before pushing the branch, run yarn typecheck and fix all issues.

Run ID: run_repo_abuiles_agents_kanban_mmbgrzolhias