### PR TITLE
AR5 - Flexible Request-Changes Scope and Reply-Aware Context

### DIFF
--- a/src/server/durable/repo-board.ts
+++ b/src/server/durable/repo-board.ts
@@ -331,7 +331,11 @@ export class RepoBoardDO extends DurableObject<Env> {
     return this.startRun(run.taskId, { forceNew: true, baseRunId: run.runId, tenantId });
   }
 
-  async requestRunChanges(runId: string, prompt: string, tenantId?: string) {
+  async requestRunChanges(
+    runId: string,
+    request: Omit<NonNullable<AgentRun['changeRequest']>, 'requestedAt'>,
+    tenantId?: string
+  ) {
     await this.ready;
     const existingRun = await this.getRun(runId, tenantId);
     const task = this.state.tasks.find((candidate) => candidate.taskId === existingRun.taskId);
@@ -354,7 +358,7 @@ export class RepoBoardDO extends DurableObject<Env> {
       baseRunId: existingRun.runId,
       dependencyContext: existingRun.dependencyContext,
       changeRequest: {
-        prompt,
+        ...request,
         requestedAt: now.toISOString()
       }
     });

--- a/src/server/http/validation.test.ts
+++ b/src/server/http/validation.test.ts
@@ -542,6 +542,34 @@ describe('request run validation', () => {
       includeReplies: true
     });
   });
+
+  it('accepts freeform and exclude selection payloads', () => {
+    const exclude = parseRequestRunChangesInput({
+      prompt: 'Adjust only the highest priority finding.',
+      reviewSelection: {
+        mode: 'exclude',
+        findingIds: ['f2'],
+        includeReplies: false
+      }
+    });
+    expect(exclude.reviewSelection).toMatchObject({
+      mode: 'exclude',
+      findingIds: ['f2'],
+      includeReplies: false
+    });
+
+    const freeform = parseRequestRunChangesInput({
+      prompt: 'Please ignore non-blockers and focus on accessibility.',
+      reviewSelection: {
+        mode: 'freeform',
+        instruction: 'Address accessibility blockers first.'
+      }
+    });
+    expect(freeform.reviewSelection).toEqual({
+      mode: 'freeform',
+      instruction: 'Address accessibility blockers first.'
+    });
+  });
 });
 
 describe('SCM credential validation', () => {

--- a/src/server/request-changes.test.ts
+++ b/src/server/request-changes.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from 'vitest';
+import type { ReviewFinding } from '../ui/domain/types';
+import { buildRequestChangesPrompt, resolveRequestRunChangesSelection } from './request-changes';
+
+const findings: ReviewFinding[] = [
+  {
+    findingId: 'finding_1',
+    severity: 'high',
+    title: 'Spacing issue',
+    description: 'Buttons should use a 12px gap.',
+    filePath: 'src/components/spacing.ts',
+    lineStart: 10,
+    lineEnd: 11,
+    status: 'open'
+  },
+  {
+    findingId: 'finding_2',
+    severity: 'medium',
+    title: 'Copy issue',
+    description: 'Text should be sentence case.',
+    filePath: 'src/components/copy.ts',
+    lineStart: 20,
+    status: 'addressed'
+  },
+  {
+    findingId: 'finding_3',
+    severity: 'low',
+    title: 'Legacy issue',
+    description: 'Consolidate duplicate helper imports.',
+    filePath: 'src/lib/helpers.ts',
+    lineStart: 3,
+    status: 'open'
+  }
+];
+
+describe('resolveRequestRunChangesSelection', () => {
+  it('resolves include mode with unknown ids', () => {
+    const resolution = resolveRequestRunChangesSelection({
+      findings,
+      reviewSelection: {
+        mode: 'include',
+        findingIds: ['finding_1', 'missing_1'],
+        includeReplies: true
+      }
+    });
+
+    expect(resolution).toEqual({
+      mode: 'include',
+      selectedFindingIds: ['finding_1'],
+      unknownFindingIds: ['missing_1'],
+      includeReplies: true,
+      requestedFindingIds: ['finding_1', 'missing_1']
+    });
+  });
+
+  it('resolves all mode deterministically', () => {
+    const resolution = resolveRequestRunChangesSelection({
+      findings,
+      reviewSelection: {
+        mode: 'all'
+      }
+    });
+
+    expect(resolution).toEqual({
+      mode: 'all',
+      selectedFindingIds: ['finding_1', 'finding_3'],
+      includeReplies: false
+    });
+  });
+
+  it('resolves exclude mode deterministically', () => {
+    const resolution = resolveRequestRunChangesSelection({
+      findings,
+      reviewSelection: {
+        mode: 'exclude',
+        findingIds: ['finding_3']
+      }
+    });
+
+    expect(resolution).toEqual({
+      mode: 'exclude',
+      selectedFindingIds: ['finding_1'],
+      includeReplies: false,
+      requestedFindingIds: ['finding_3']
+    });
+  });
+
+  it('supports freeform mode for natural language intent', () => {
+    const resolution = resolveRequestRunChangesSelection({
+      findings,
+      reviewSelection: {
+        mode: 'freeform',
+        instruction: 'Prioritize accessibility blockers first.'
+      }
+    });
+
+    expect(resolution).toEqual({
+      mode: 'freeform',
+      selectedFindingIds: ['finding_1', 'finding_3'],
+      includeReplies: false,
+      instruction: 'Prioritize accessibility blockers first.'
+    });
+  });
+});
+
+describe('buildRequestChangesPrompt', () => {
+  it('builds a deterministic request context with reply context', () => {
+    const prompt = buildRequestChangesPrompt({
+      operatorPrompt: 'Address the findings in this review.',
+      selection: {
+        mode: 'include',
+        requestedFindingIds: ['finding_1', 'missing_2'],
+        selectedFindingIds: ['finding_1'],
+        unknownFindingIds: ['missing_2'],
+        includeReplies: true,
+        instruction: 'Focus on spacing and labels.'
+      },
+      selectedFindings: [findings[0]],
+      replyContext: {
+        finding_1: ['Reviewer said this spacing change will break 4k layouts.', 'Also align to 16px baseline.']
+      }
+    });
+
+    expect(prompt).toContain('Review change request context:');
+    expect(prompt).toContain('Mode: include');
+    expect(prompt).toContain('Selected findings: finding_1');
+    expect(prompt).toContain('Requested findings: finding_1, missing_2');
+    expect(prompt).toContain('Unknown findings: missing_2');
+    expect(prompt).toContain('Include provider replies: enabled');
+    expect(prompt).toContain('Rerun intent:');
+    expect(prompt).toContain('Selected finding context:');
+    expect(prompt).toContain('Provider replies for finding_1:');
+    expect(prompt).toContain('Reviewer said this spacing change will break 4k layouts.');
+  });
+});

--- a/src/server/request-changes.ts
+++ b/src/server/request-changes.ts
@@ -1,0 +1,160 @@
+import type { ReviewReplyContext } from './review-posting/adapter';
+import type { RequestRunChangesSelection } from '../ui/domain/api';
+import type { ChangeRequestSelection, ReviewFinding, ReviewSelectionMode } from '../ui/domain/types';
+
+const MAX_DESCRIPTION_SNIPPET_LENGTH = 280;
+
+function normalizeFindingIds(value: string[] | undefined) {
+  const normalized: string[] = [];
+  const seen = new Set<string>();
+
+  for (const rawId of value ?? []) {
+    const normalizedId = rawId.trim();
+    if (!normalizedId || seen.has(normalizedId)) {
+      continue;
+    }
+
+    seen.add(normalizedId);
+    normalized.push(normalizedId);
+  }
+
+  return normalized;
+}
+
+function getOpenFindings(findings: ReviewFinding[]) {
+  return findings.filter((finding) => finding.status === 'open');
+}
+
+export function resolveRequestRunChangesSelection(input: {
+  findings: ReviewFinding[];
+  reviewSelection?: RequestRunChangesSelection;
+}): ChangeRequestSelection | undefined {
+  if (!input.reviewSelection) {
+    return undefined;
+  }
+
+  const findings = getOpenFindings(input.findings);
+  const availableIds = findings.map((finding) => finding.findingId);
+  const availableIdSet = new Set(availableIds);
+  const requestedFindingIds = normalizeFindingIds(input.reviewSelection.findingIds);
+
+  const resolved: ChangeRequestSelection = {
+    mode: input.reviewSelection.mode,
+    selectedFindingIds: [],
+    includeReplies: Boolean(input.reviewSelection.includeReplies),
+    ...(input.reviewSelection.instruction?.trim() ? { instruction: input.reviewSelection.instruction.trim() } : {})
+  };
+
+  const requestedSet = new Set(requestedFindingIds);
+  switch (input.reviewSelection.mode) {
+    case 'all':
+      resolved.selectedFindingIds = [...availableIds];
+      break;
+    case 'include':
+      resolved.selectedFindingIds = findings
+        .filter((finding) => requestedSet.has(finding.findingId))
+        .map((finding) => finding.findingId);
+      break;
+    case 'exclude': {
+      const excludedSet = new Set(requestedFindingIds);
+      resolved.selectedFindingIds = findings
+        .filter((finding) => !excludedSet.has(finding.findingId))
+        .map((finding) => finding.findingId);
+      break;
+    }
+    case 'freeform':
+      resolved.selectedFindingIds = [...availableIds];
+      break;
+    default:
+      resolved.mode = 'all' as ReviewSelectionMode;
+      resolved.selectedFindingIds = [...availableIds];
+  }
+
+  const unknownFindingIds = requestedFindingIds.filter((id) => !availableIdSet.has(id));
+  if (unknownFindingIds.length) {
+    resolved.unknownFindingIds = unknownFindingIds;
+  }
+
+  if (requestedFindingIds.length) {
+    resolved.requestedFindingIds = requestedFindingIds;
+  }
+
+  return resolved;
+}
+
+function formatFindingLine(finding: ReviewFinding) {
+  const location = finding.filePath
+    ? ` (${finding.filePath}${finding.lineStart ? `:${finding.lineStart}` : ''}${finding.lineEnd ? `-${finding.lineEnd}` : ''})`
+    : '';
+  const severity = finding.severity.toUpperCase();
+
+  return `- ${finding.findingId} · ${finding.title}${location} [${severity}]`;
+}
+
+function formatFindingContext(finding: ReviewFinding) {
+  return [
+    formatFindingLine(finding),
+    `  description: ${finding.description.slice(0, MAX_DESCRIPTION_SNIPPET_LENGTH)}${finding.description.length > MAX_DESCRIPTION_SNIPPET_LENGTH ? '...' : ''}`
+  ];
+}
+
+function formatReplyContext(id: string, replyContext?: ReviewReplyContext) {
+  const replies = replyContext?.[id];
+  if (!replies?.length) {
+    return [];
+  }
+
+  return [
+    `Provider replies for ${id}:`,
+    ...replies.map((reply) => `- ${reply}`)
+  ];
+}
+
+export function buildRequestChangesPrompt(input: {
+  operatorPrompt: string;
+  selection?: ChangeRequestSelection;
+  selectedFindings: ReviewFinding[];
+  replyContext?: ReviewReplyContext;
+}) {
+  const trimmedPrompt = input.operatorPrompt.trim();
+  if (!input.selection) {
+    return trimmedPrompt;
+  }
+
+  const findingIds = input.selection.selectedFindingIds;
+  const lines = [
+    trimmedPrompt,
+    '',
+    'Review change request context:',
+    `Mode: ${input.selection.mode}`,
+    `Selected findings: ${findingIds.length ? findingIds.join(', ') : 'None'}`
+  ];
+
+  if (input.selection.requestedFindingIds?.length) {
+    lines.push(`Requested findings: ${input.selection.requestedFindingIds.join(', ')}`);
+  }
+
+  if (input.selection.unknownFindingIds?.length) {
+    lines.push(`Unknown findings: ${input.selection.unknownFindingIds.join(', ')}`);
+  }
+
+  if (input.selection.includeReplies) {
+    lines.push('Include provider replies: enabled');
+  }
+
+  if (input.selection.instruction) {
+    lines.push('', 'Rerun intent:', input.selection.instruction);
+  }
+
+  if (input.selectedFindings.length) {
+    lines.push('', 'Selected finding context:');
+    input.selectedFindings.forEach((finding) => {
+      lines.push(...formatFindingContext(finding));
+      lines.push(...formatReplyContext(finding.findingId, input.replyContext));
+    });
+  } else {
+    lines.push('', 'No selected findings were available for this request.');
+  }
+
+  return lines.join('\n');
+}

--- a/src/server/router.ts
+++ b/src/server/router.ts
@@ -33,18 +33,20 @@ import { parseBoardSnapshot } from '../ui/store/board-snapshot';
 import { scheduleRunJob } from './run-orchestrator';
 import { getRunUsage, getTenantRunUsage, getTenantUsageSummary } from './usage-reporting';
 import { normalizeTenantId, normalizeTenantIdStrict } from '../shared/tenant';
-import { hasRunReview } from '../shared/scm';
+import { getRepoHost, getRunReviewProvider, hasRunReview } from '../shared/scm';
 import * as tenantAuthDb from './tenant-auth-db';
 import { DEFAULT_REPO_SENTINEL_CONFIG } from '../shared/sentinel';
 import { SentinelController } from './sentinel';
+import { buildRequestChangesPrompt, resolveRequestRunChangesSelection } from './request-changes';
 import {
   handleSlackCommands as handleSlackCommandsHandler,
   handleSlackEvents as handleSlackEventsHandler,
   handleSlackInteractions as handleSlackInteractionsHandler
 } from './integrations/slack/handlers';
 import { handleGitlabWebhook as handleGitlabWebhookHandler } from './integrations/gitlab/handlers';
-import type { Repo, SentinelRun } from '../ui/domain/types';
+import type { AutoReviewProvider, Repo, SentinelRun } from '../ui/domain/types';
 import { getScmAdapter } from './scm/registry';
+import { getReviewPostingAdapter } from './review-posting/registry';
 
 const BOARD_OBJECT_NAME = 'agentboard';
 
@@ -1026,8 +1028,54 @@ export async function handleRequestChanges(request: Request, env: Env, params: R
     const runId = parsePathParam(params.runId);
     const body = parseRequestRunChangesInput(await readJson(request));
     const repoId = await resolveRepoIdForRun(board, runId);
-    await assertRepoAccess(env, board, requestContext, repoId);
-    const run = await env.REPO_BOARD.getByName(repoId).requestRunChanges(body.prompt, requestContext.activeTenantId);
+    const repo = await assertRepoAccess(env, board, requestContext, repoId);
+    const repoBoard = env.REPO_BOARD.getByName(repoId);
+    const existingRun = await repoBoard.getRun(runId, requestContext.activeTenantId);
+    const selection = resolveRequestRunChangesSelection({
+      findings: existingRun.reviewFindings ?? [],
+      reviewSelection: body.reviewSelection
+    });
+    const selectedFindingIds = new Set(selection?.selectedFindingIds);
+    const selectedFindings = existingRun.reviewFindings?.filter(
+      (finding) => finding.status === 'open' && selectedFindingIds.has(finding.findingId)
+    ) ?? [];
+    let replyContext;
+    if (selection?.includeReplies && selectedFindings.length) {
+      const reviewProvider = getRunReviewProvider(existingRun) as AutoReviewProvider | undefined;
+      if (reviewProvider !== 'gitlab' && reviewProvider !== 'jira') {
+        throw badRequest('Cannot include replies for this review provider.');
+      }
+      if (!repo.scmProvider) {
+        throw badRequest('Cannot include replies without SCM provider metadata for this repo.');
+      }
+      const token = await board.getScmCredentialSecret(repo.scmProvider, getRepoHost(repo));
+      if (!token) {
+        throw badRequest(`No SCM credential found for ${repo.scmProvider} host ${getRepoHost(repo)}.`);
+      }
+      const taskDetail = await repoBoard.getTask(existingRun.taskId, requestContext.activeTenantId);
+      replyContext = await getReviewPostingAdapter(reviewProvider).fetchReplyContext({
+        repo,
+        task: taskDetail.task,
+        run: existingRun,
+        credential: { token },
+        findingIds: selection.selectedFindingIds
+      });
+    }
+
+    const prompt = buildRequestChangesPrompt({
+      operatorPrompt: body.prompt,
+      selection,
+      selectedFindings,
+      replyContext
+    });
+    const run = await repoBoard.requestRunChanges(
+      runId,
+      {
+        prompt,
+        ...(selection ? { selection } : {})
+      },
+      requestContext.activeTenantId
+    );
     const workflow = await scheduleRunJob(env, ctx as unknown as ExecutionContext, {
       tenantId: requestContext.activeTenantId,
       repoId,

--- a/src/ui/App.test.tsx
+++ b/src/ui/App.test.tsx
@@ -202,6 +202,10 @@ describe('App', () => {
 
     await screen.findByRole('heading', { name: 'Fix settings navigation overflow' });
     await user.click(await screen.findByRole('button', { name: 'Request changes' }));
+    await user.selectOptions(screen.getByLabelText(/Review scope/i), 'include');
+    await user.type(screen.getByLabelText(/Finding IDs/i), 'finding_1, finding_2');
+    await user.type(screen.getByLabelText(/Rerun intent/i), 'Prioritize spacing and alignment issues.');
+    await user.click(screen.getByRole('checkbox', { name: /include provider replies/i }));
     await user.type(
       await screen.findByPlaceholderText('Describe the changes you want on the current PR.'),
       'Tighten the spacing and update the review copy.'
@@ -217,7 +221,10 @@ describe('App', () => {
       expect(latestRun.baseRunId).toBe('run_nav_1');
       expect(latestRun.branchName).toBe('agent/task_nav/run_nav_1');
       expect(latestRun.changeRequest?.prompt).toContain('Tighten the spacing');
+      expect(latestRun.changeRequest?.selection?.mode).toBe('include');
+      expect(latestRun.changeRequest?.selection?.selectedFindingIds).toEqual(['finding_1', 'finding_2']);
       expect(latestRun.prUrl).toBe(previousRun?.prUrl);
+      expect(latestRun.changeRequest?.selection?.includeReplies).toBe(true);
     });
 
     expect(await screen.findByText('Started a review rerun on the existing PR branch.')).toBeInTheDocument();

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -26,6 +26,10 @@ export default function App({ api: providedApi }: { api?: AgentBoardApi }) {
   const [taskToEditId, setTaskToEditId] = useState<string | undefined>();
   const [changeRequestRunId, setChangeRequestRunId] = useState<string | undefined>();
   const [changeRequestPrompt, setChangeRequestPrompt] = useState('');
+  const [changeRequestMode, setChangeRequestMode] = useState<'all' | 'include' | 'exclude' | 'freeform'>('all');
+  const [changeRequestFindingIds, setChangeRequestFindingIds] = useState('');
+  const [changeRequestInstruction, setChangeRequestInstruction] = useState('');
+  const [changeRequestIncludeReplies, setChangeRequestIncludeReplies] = useState(false);
   const [selectedRunEvents, setSelectedRunEvents] = useState<RunEvent[]>([]);
   const [selectedRunCommands, setSelectedRunCommands] = useState<RunCommand[]>([]);
   const [terminalBootstrap, setTerminalBootstrap] = useState<TerminalBootstrap | undefined>();
@@ -271,12 +275,44 @@ export default function App({ api: providedApi }: { api?: AgentBoardApi }) {
       return;
     }
 
-    const run = await api.requestRunChanges(runId, { prompt });
+    const requestedFindingIds = changeRequestFindingIds
+      .split(/[\n,]+/)
+      .map((value) => value.trim())
+      .filter(Boolean);
+
+    const reviewSelection = {
+      mode: changeRequestMode,
+      ...(requestedFindingIds.length ? { findingIds: requestedFindingIds } : {}),
+      ...(changeRequestInstruction.trim() ? { instruction: changeRequestInstruction.trim() } : {}),
+      ...(changeRequestIncludeReplies ? { includeReplies: true } : {})
+    };
+
+    const run = await api.requestRunChanges(runId, {
+      prompt,
+      ...(Object.keys(reviewSelection).length ? { reviewSelection } : {})
+    });
+
+    setChangeRequestPrompt('');
+    setChangeRequestMode('all');
+    setChangeRequestFindingIds('');
+    setChangeRequestInstruction('');
+    setChangeRequestIncludeReplies(false);
     await api.setSelectedTaskId(run.taskId);
     setChangeRequestRunId(undefined);
-    setChangeRequestPrompt('');
     setNotice('Started a review rerun on the existing PR branch.');
   }
+
+  useEffect(() => {
+    if (!changeRequestRunId) {
+      return;
+    }
+
+    setChangeRequestPrompt('');
+    setChangeRequestMode('all');
+    setChangeRequestFindingIds('');
+    setChangeRequestInstruction('');
+    setChangeRequestIncludeReplies(false);
+  }, [changeRequestRunId]);
 
   async function toggleTaskSelection(taskId: string) {
     await api.setSelectedTaskId(selectedTaskId === taskId ? undefined : taskId);
@@ -777,6 +813,53 @@ export default function App({ api: providedApi }: { api?: AgentBoardApi }) {
                 required
               />
               <span className="text-xs text-slate-500">This creates a fresh run on the existing review branch and updates the same PR.</span>
+            </label>
+            <label className="grid gap-2 text-sm">
+              <span className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-400">Review scope</span>
+              <select
+                className="rounded-xl border border-slate-700 bg-slate-900/90 px-3 py-2.5 text-sm text-slate-100 outline-none transition focus:border-cyan-400 focus:ring-2 focus:ring-cyan-400/20"
+                value={changeRequestMode}
+                onChange={(event) => {
+                  setChangeRequestMode(event.target.value as 'all' | 'include' | 'exclude' | 'freeform');
+                  setChangeRequestFindingIds('');
+                }}
+              >
+                <option value="all">All findings</option>
+                <option value="include">Include finding IDs</option>
+                <option value="exclude">Exclude finding IDs</option>
+                <option value="freeform">Freeform instruction</option>
+              </select>
+            </label>
+            <label className="grid gap-2 text-sm">
+              <span className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-400">
+                Finding IDs (comma or newline separated)
+              </span>
+              <textarea
+                className="rounded-xl border border-slate-700 bg-slate-900/90 px-3 py-2.5 text-sm text-slate-100 outline-none transition focus:border-cyan-400 focus:ring-2 focus:ring-cyan-400/20"
+                value={changeRequestFindingIds}
+                onChange={(event) => setChangeRequestFindingIds(event.target.value)}
+                rows={2}
+                placeholder="f1, f2, f3"
+              />
+            </label>
+            <label className="grid gap-2 text-sm">
+              <span className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-400">Rerun intent</span>
+              <textarea
+                className="rounded-xl border border-slate-700 bg-slate-900/90 px-3 py-2.5 text-sm text-slate-100 outline-none transition focus:border-cyan-400 focus:ring-2 focus:ring-cyan-400/20"
+                value={changeRequestInstruction}
+                onChange={(event) => setChangeRequestInstruction(event.target.value)}
+                rows={2}
+                placeholder="Optional instruction to prioritize or scope your rerun."
+              />
+            </label>
+            <label className="flex items-center gap-2 text-sm">
+              <input
+                checked={changeRequestIncludeReplies}
+                onChange={(event) => setChangeRequestIncludeReplies(event.target.checked)}
+                type="checkbox"
+                className="h-4 w-4 rounded border-slate-600 bg-slate-900 text-cyan-400 focus:ring-2 focus:ring-cyan-400/35 focus:ring-offset-0"
+              />
+              <span>Include provider replies in request context</span>
             </label>
             <button
               type="submit"

--- a/src/ui/domain/types.ts
+++ b/src/ui/domain/types.ts
@@ -152,6 +152,16 @@ export type ReviewFinding = {
   status: ReviewFindingStatus;
   replyContext?: string[];
 };
+export type ReviewSelectionMode = 'all' | 'include' | 'exclude' | 'freeform';
+
+export type ChangeRequestSelection = {
+  mode: ReviewSelectionMode;
+  requestedFindingIds?: string[];
+  selectedFindingIds: string[];
+  unknownFindingIds?: string[];
+  includeReplies?: boolean;
+  instruction?: string;
+};
 export type RunReviewExecution = {
   enabled: boolean;
   trigger: ReviewExecutionTrigger;
@@ -512,6 +522,7 @@ export type AgentRun = {
   changeRequest?: {
     prompt: string;
     requestedAt: string;
+    selection?: ChangeRequestSelection;
   };
   headSha?: string;
   reviewUrl?: string;

--- a/src/ui/mock/local-agent-board-api.ts
+++ b/src/ui/mock/local-agent-board-api.ts
@@ -696,6 +696,16 @@ export class LocalAgentBoardApi implements AgentBoardApi {
       throw new Error(`Task ${run.taskId} not found.`);
     }
 
+    const selection = input.reviewSelection
+      ? {
+          mode: input.reviewSelection.mode,
+          requestedFindingIds: input.reviewSelection.findingIds,
+          selectedFindingIds: input.reviewSelection.findingIds ?? [],
+          includeReplies: input.reviewSelection.includeReplies,
+          instruction: input.reviewSelection.instruction?.trim()
+        }
+      : undefined;
+
     return this.simulator.createRun(
       {
         ...task,
@@ -707,7 +717,11 @@ export class LocalAgentBoardApi implements AgentBoardApi {
         prUrl: run.prUrl,
         prNumber: run.prNumber,
         baseRunId: run.runId,
-        changeRequest: { prompt: input.prompt, requestedAt: nowIso() }
+        changeRequest: {
+          prompt: input.prompt,
+          requestedAt: nowIso(),
+          ...(selection ? { selection } : {})
+        }
       }
     );
   }


### PR DESCRIPTION
Task: AR5 - Flexible Request-Changes Scope and Reply-Aware Context

Extend request-changes so operators can target all/some findings and include reply context.
Source ref: main

Acceptance criteria:
- Request-changes supports all/include/exclude/freeform selection modes.
- Legacy prompt-only request-changes path remains functional.
- Reply context is incorporated when requested.
- Run metadata records targeted findings for auditability.
- make sure that "yarn test" passes
- Before pushing the branch, run yarn typecheck and fix all issues.

Run ID: run_repo_abuiles_agents_kanban_mmbiv0c556cp