### PR TITLE
T5 - Decision-Gated Rerun State Machine

### DIFF
--- a/src/server/durable/repo-board.ts
+++ b/src/server/durable/repo-board.ts
@@ -1,6 +1,7 @@
 import type { CreateTaskInput, UpdateTaskInput } from '../../ui/domain/api';
 import type {
   AgentRun,
+  IntegrationLoopState,
   OperatorSession,
   Repo,
   RunCommand,
@@ -345,6 +346,7 @@ export class RepoBoardDO extends DurableObject<Env> {
 
     const now = new Date();
     const nextRun = createRealRun(task, createRunId(task.repoId), now, {
+      loopState: 'RERUN_QUEUED',
       branchName: existingRun.branchName,
       reviewUrl: existingRun.reviewUrl,
       reviewNumber: existingRun.reviewNumber,
@@ -512,6 +514,18 @@ export class RepoBoardDO extends DurableObject<Env> {
     if (isTerminalRunStatus(run.status) && patch.status && patch.status !== run.status) {
       return run;
     }
+    const nextStatus = patch.status ?? run.status;
+    const currentLoopState = run.loopState;
+    const nextLoopState = resolveLoopStateTransition(run.loopState, patch.loopState, nextStatus);
+    if (patch.loopState !== undefined && nextLoopState !== patch.loopState) {
+      patch = { ...patch, loopState: nextLoopState };
+    } else if (patch.loopState === undefined && nextLoopState !== currentLoopState) {
+      patch = { ...patch, loopState: nextLoopState };
+    }
+    const loopTransitionNote = buildLoopTransitionNote(currentLoopState, nextLoopState);
+    if (loopTransitionNote && patch.appendTimelineNote === undefined) {
+      patch = { ...patch, appendTimelineNote: loopTransitionNote };
+    }
     const nowIso = new Date().toISOString();
     const updated = applyRunTransition(run, patch, nowIso);
     const task = this.state.tasks.find((candidate) => candidate.taskId === updated.taskId);
@@ -525,7 +539,7 @@ export class RepoBoardDO extends DurableObject<Env> {
       runId: updated.runId,
       updatedAt: nowIso
     };
-    const events = nextStatusChanged(run, updated, patch.appendTimelineNote)
+    const events = nextStatusChanged(run, updated)
       ? [
           buildRunEvent(
             updated,
@@ -560,6 +574,26 @@ export class RepoBoardDO extends DurableObject<Env> {
       });
     }
     return updated;
+  }
+
+  async transitionRunFromLoopState(
+    runId: string,
+    expectedLoopState: IntegrationLoopState,
+    patch: RunTransitionPatch,
+    tenantId?: string
+  ): Promise<{ run: AgentRun; transitioned: boolean }> {
+    await this.ready;
+    const run = await this.getRun(runId, tenantId);
+    const current = normalizeLoopState(run.loopState);
+    if (current !== expectedLoopState) {
+      return { run, transitioned: false };
+    }
+
+    const next = await this.transitionRun(runId, patch, tenantId);
+    return {
+      run: next,
+      transitioned: normalizeLoopState(next.loopState) !== current
+    };
   }
 
   async markRunFailed(runId: string, error: RunError, tenantId?: string): Promise<AgentRun> {
@@ -1103,8 +1137,95 @@ function deriveTaskStatus(run: AgentRun, current: TaskStatus): TaskStatus {
   return current;
 }
 
-function nextStatusChanged(previous: AgentRun, next: AgentRun, note?: string) {
-  return previous.status !== next.status || Boolean(note);
+function buildLoopTransitionNote(previousLoopState: IntegrationLoopState | undefined, nextLoopState: IntegrationLoopState) {
+  if (previousLoopState === nextLoopState) {
+    return undefined;
+  }
+  if (previousLoopState === undefined) {
+    return `Loop state initialized as ${nextLoopState}.`;
+  }
+  return `Loop state changed from ${previousLoopState} to ${nextLoopState}.`;
+}
+
+function normalizeLoopState(value: IntegrationLoopState | undefined): IntegrationLoopState {
+  return value ?? 'QUEUED';
+}
+
+function isTerminalLoopState(state: IntegrationLoopState) {
+  return state === 'DONE' || state === 'FAILED' || state === 'PAUSED';
+}
+
+function canPersistLoopTransition(current: IntegrationLoopState, next: IntegrationLoopState) {
+  if (current === next) {
+    return true;
+  }
+  const transitions: Record<IntegrationLoopState, IntegrationLoopState[]> = {
+    QUEUED: ['RUNNING', 'PAUSED', 'FAILED'],
+    RUNNING: ['MR_OPEN', 'REVIEW_PENDING', 'FAILED', 'PAUSED'],
+    MR_OPEN: ['REVIEW_PENDING', 'FAILED', 'PAUSED'],
+    REVIEW_PENDING: ['DECISION_REQUIRED', 'FAILED', 'PAUSED'],
+    DECISION_REQUIRED: ['RERUN_QUEUED', 'FAILED', 'PAUSED'],
+    RERUN_QUEUED: ['RUNNING', 'FAILED', 'PAUSED'],
+    PAUSED: ['RERUN_QUEUED', 'RUNNING', 'DONE', 'FAILED'],
+    DONE: ['DONE'],
+    FAILED: ['FAILED']
+  };
+  return transitions[current]?.includes(next) ?? false;
+}
+
+function inferLoopStateFromStatus(nextStatus: AgentRun['status'], currentLoopState: IntegrationLoopState): IntegrationLoopState {
+  if (nextStatus === 'QUEUED') {
+    return currentLoopState === 'RERUN_QUEUED' ? 'RERUN_QUEUED' : 'QUEUED';
+  }
+  if (nextStatus === 'DONE') {
+    return 'DONE';
+  }
+  if (nextStatus === 'FAILED') {
+    return currentLoopState === 'PAUSED' ? 'PAUSED' : 'FAILED';
+  }
+  if (currentLoopState === 'REVIEW_PENDING' || currentLoopState === 'DECISION_REQUIRED') {
+    if (nextStatus === 'FAILED' || nextStatus === 'DONE') {
+      return nextStatus === 'DONE' ? 'DONE' : currentLoopState === 'PAUSED' ? 'PAUSED' : 'FAILED';
+    }
+    return currentLoopState;
+  }
+  if (['BOOTSTRAPPING', 'RUNNING_CODEX', 'OPERATOR_CONTROLLED', 'RUNNING_TESTS', 'PUSHING_BRANCH'].includes(nextStatus)) {
+    return 'RUNNING';
+  }
+  if (nextStatus === 'PR_OPEN' || nextStatus === 'WAITING_PREVIEW' || nextStatus === 'EVIDENCE_RUNNING') {
+    if (currentLoopState === 'REVIEW_PENDING' || currentLoopState === 'DECISION_REQUIRED') {
+      return currentLoopState;
+    }
+    if (currentLoopState === 'RERUN_QUEUED') {
+      return 'RUNNING';
+    }
+    return 'MR_OPEN';
+  }
+  return currentLoopState;
+}
+
+function resolveLoopStateTransition(
+  current: IntegrationLoopState | undefined,
+  requested: IntegrationLoopState | undefined,
+  nextStatus: AgentRun['status']
+): IntegrationLoopState {
+  const currentState = normalizeLoopState(current);
+  if (isTerminalLoopState(currentState) && requested !== currentState && requested !== undefined) {
+    return currentState;
+  }
+  const inferred = inferLoopStateFromStatus(nextStatus, currentState);
+  const target = requested ?? inferred;
+  if (requested && !canPersistLoopTransition(currentState, requested)) {
+    return currentState;
+  }
+  if (!requested && target === currentState) {
+    return currentState;
+  }
+  return target;
+}
+
+function nextStatusChanged(previous: AgentRun, next: AgentRun) {
+  return previous.status !== next.status;
 }
 
 function isTerminalRunStatus(status: AgentRun['status']) {

--- a/src/server/integrations/gitlab/handlers.test.ts
+++ b/src/server/integrations/gitlab/handlers.test.ts
@@ -3,6 +3,10 @@ import { describe, expect, it, vi } from 'vitest';
 vi.mock('../../tenant-auth-db', () => ({
   getPrimaryTenantId: vi.fn(async () => 'tenant_local')
 }));
+vi.mock('../slack/client', () => ({
+  listSlackThreadBindingsForTask: vi.fn(async () => []),
+  postSlackThreadMessage: vi.fn()
+}));
 
 import { handleGitlabWebhook } from './handlers';
 
@@ -18,19 +22,26 @@ class KvStore {
   }
 }
 
-function buildEnv(kv: KvStore): Env {
+function createRepoBoardStub(runs: Array<Record<string, unknown>>) {
+  return {
+    getBoardSlice: vi.fn(async () => ({ runs })),
+    transitionRun: vi.fn()
+  };
+}
+
+function buildEnv(kv: KvStore, boardRuns: Array<Record<string, unknown>>) {
   return {
     SECRETS_KV: kv as unknown as KVNamespace,
     BOARD_INDEX: {
       getByName: () => ({
-        listRepos: async () => []
+        listRepos: async () => [
+          { repoId: 'repo_1', tenantId: 'tenant_local', slug: 'repo-1' }
+        ]
       })
     },
     REPO_BOARD: {
-      getByName: () => ({
-        getBoardSlice: async () => ({ runs: [] })
-      })
-    },
+      getByName: () => createRepoBoardStub(boardRuns)
+    }
   } as unknown as Env;
 }
 
@@ -47,11 +58,90 @@ function gitlabReviewPendingPayload() {
   });
 }
 
+function gitlabReviewFeedbackPayload() {
+  return JSON.stringify({
+    object_kind: 'note',
+    project: { path_with_namespace: 'group/project' },
+    merge_request: { iid: 42, web_url: 'https://gitlab.example/group/project/-/merge_requests/42' },
+    user: { username: 'reviewer' },
+    object_attributes: {
+      id: 900,
+      note: 'Please add tests.',
+      noteable_type: 'MergeRequest',
+      system: false
+    }
+  });
+}
+
+function mappedRun() {
+  return {
+    runId: 'run_1',
+    taskId: 'task_1',
+    repoId: 'repo_1',
+    tenantId: 'tenant_local',
+    reviewNumber: 42,
+    status: 'PR_OPEN',
+    timeline: [],
+    startedAt: '2026-01-01T00:00:00.000Z'
+  };
+}
+
 describe('gitlab webhook handler', () => {
+  it('transitions run loop state to REVIEW_PENDING on review pending webhooks', async () => {
+    const kv = new KvStore();
+    kv.values.set('gitlab/webhook-secret', 'shared-token');
+    const board = createRepoBoardStub([mappedRun()]);
+    const env = {
+      ...buildEnv(kv, [mappedRun()]),
+      REPO_BOARD: { getByName: () => board }
+    } as unknown as Env;
+
+    const response = await handleGitlabWebhook(new Request('https://example.test/api/integrations/gitlab/webhook', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-gitlab-token': 'shared-token',
+        'x-gitlab-event-uuid': 'evt-456'
+      },
+      body: gitlabReviewPendingPayload()
+    }), env);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({ status: 'mirrored_review_pending', runId: 'run_1' });
+    expect(board.transitionRun).toHaveBeenCalledWith('run_1', { loopState: 'REVIEW_PENDING' });
+  });
+
+  it('transitions run loop state to DECISION_REQUIRED on review feedback webhooks', async () => {
+    const kv = new KvStore();
+    kv.values.set('gitlab/webhook-secret', 'shared-token');
+    const board = createRepoBoardStub([mappedRun()]);
+    const env = {
+      ...buildEnv(kv, [mappedRun()]),
+      REPO_BOARD: { getByName: () => board }
+    } as unknown as Env;
+
+    const response = await handleGitlabWebhook(new Request('https://example.test/api/integrations/gitlab/webhook', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-gitlab-token': 'shared-token',
+        'x-gitlab-event-uuid': 'evt-457'
+      },
+      body: gitlabReviewFeedbackPayload()
+    }), env);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({ status: 'mirrored_feedback', runId: 'run_1' });
+    expect(board.transitionRun).toHaveBeenCalledWith('run_1', { loopState: 'DECISION_REQUIRED' });
+  });
+
   it('dedupes repeated webhook deliveries by delivery id', async () => {
     const kv = new KvStore();
     kv.values.set('gitlab/webhook-secret', 'shared-token');
-    const env = buildEnv(kv);
+    const env = {
+      ...buildEnv(kv, []),
+      REPO_BOARD: { getByName: () => createRepoBoardStub([]) }
+    } as unknown as Env;
     const body = gitlabReviewPendingPayload();
 
     const first = await handleGitlabWebhook(new Request('https://example.test/api/integrations/gitlab/webhook', {
@@ -81,7 +171,10 @@ describe('gitlab webhook handler', () => {
   it('rejects invalid webhook secret', async () => {
     const kv = new KvStore();
     kv.values.set('gitlab/webhook-secret', 'shared-token');
-    const env = buildEnv(kv);
+    const env = {
+      ...buildEnv(kv, []),
+      REPO_BOARD: { getByName: () => createRepoBoardStub([]) }
+    } as unknown as Env;
 
     const response = await handleGitlabWebhook(new Request('https://example.test/api/integrations/gitlab/webhook', {
       method: 'POST',

--- a/src/server/integrations/gitlab/handlers.ts
+++ b/src/server/integrations/gitlab/handlers.ts
@@ -94,10 +94,16 @@ export async function handleGitlabWebhook(request: Request, env: Env): Promise<R
     }
 
     if (normalized.type === 'review_pending') {
+      await repoBoard.transitionRun(run.runId, {
+        loopState: 'REVIEW_PENDING'
+      });
       await mirrorRunLifecycleMilestone(env, run, 'review_pending', `${deliveryId}:review_pending`);
       return json({ ok: true, status: 'mirrored_review_pending', runId: run.runId });
     }
 
+    await repoBoard.transitionRun(run.runId, {
+      loopState: 'DECISION_REQUIRED'
+    });
     await mirrorRunLifecycleMilestone(env, run, 'review_pending', `${deliveryId}:review_pending`);
     const bindings = await listSlackThreadBindingsForTask(env, tenantId, run.taskId);
     const message = buildGitlabFeedbackSlackMessage({

--- a/src/server/integrations/slack/handlers.test.ts
+++ b/src/server/integrations/slack/handlers.test.ts
@@ -55,6 +55,18 @@ function taskBinding(taskId: string, channelId: string, threadTs: string) {
   };
 }
 
+function baseRunStub(taskId: string, runId: string) {
+  return {
+    runId,
+    taskId,
+    repoId: 'repo_alpha',
+    tenantId: 'tenant_local',
+    status: 'WAITING_PREVIEW',
+    timeline: [],
+    startedAt: '2026-01-01T00:00:00.000Z'
+  };
+}
+
 function makeRepoBoard(stub: { taskId: string; runId: string }) {
   return {
     createTask: vi.fn().mockResolvedValue({
@@ -65,14 +77,20 @@ function makeRepoBoard(stub: { taskId: string; runId: string }) {
       runId: stub.runId,
       taskId: stub.taskId
     }),
-    transitionRun: vi.fn()
+    transitionRun: vi.fn(),
+    transitionRunFromLoopState: vi.fn(async () => ({ run: baseRunStub(stub.taskId, stub.runId), transitioned: false })),
+    requestRunChanges: vi.fn(async () => baseRunStub(stub.taskId, `${stub.runId}_rerun`))
   };
 };
 
-function makeBoardIndex(repos: Array<{ repoId: string; slug: string }>) {
+function makeBoardIndex(
+  repos: Array<{ repoId: string; slug: string }>,
+  runToRepoId: Map<string, string> = new Map()
+) {
   return {
     getByName: vi.fn(() => ({
-      listRepos: vi.fn(async () => repos)
+      listRepos: vi.fn(async () => repos),
+      findRunRepoId: async (runId: string) => runToRepoId.get(runId)
     }))
   };
 }
@@ -367,35 +385,23 @@ describe('slack handlers', () => {
     });
   });
 
-  it('handles repo disambiguation and approve_rerun/pause actions in interactions', async () => {
-    const repoDisambiguationPayload = {
+  it('starts a rerun when approve_rerun is clicked in decision-required state', async () => {
+    const repoBoard = makeRepoBoard({ taskId: 'task_1', runId: 'run_1' });
+    repoBoard.transitionRunFromLoopState.mockResolvedValueOnce({
+      run: baseRunStub('task_1', 'run_1'),
+      transitioned: true
+    });
+    repoBoard.requestRunChanges.mockResolvedValueOnce(baseRunStub('task_1', 'run_2'));
+
+    const payload = {
       type: 'block_actions',
       user: { id: 'U1' },
       container: { channel_id: 'C123', thread_ts: '1672531200.1234' },
       actions: [
         {
-          action_id: 'repo_disambiguation',
-          value: JSON.stringify({
-            tenantId: 'tenant_local',
-            taskId: 'issue:ABC-100',
-            channelId: 'C123',
-            threadTs: '1672531200.1234',
-            issueKey: 'ABC-100',
-            issueTitle: 'Cannot login',
-            issueBody: 'Button fails',
-            issueUrl: 'https://jira.test.com/browse/ABC-100',
-            latestReviewRound: 1,
-            repoId: 'repo_alpha'
-          })
-        }
-      ]
-    };
-    const approvePayload = {
-      ...repoDisambiguationPayload,
-      actions: [
-        {
           action_id: 'approve_rerun',
           value: JSON.stringify({
+            tenantId: 'tenant_local',
             taskId: 'task_1',
             channelId: 'C123',
             threadTs: '1672531200.1234',
@@ -405,65 +411,139 @@ describe('slack handlers', () => {
         }
       ]
     };
-    const pausePayload = {
-      ...repoDisambiguationPayload,
+    const rawBody = new URLSearchParams({ payload: JSON.stringify(payload) }).toString();
+    const signature = await buildSlackSignature('secret', nowTs, rawBody);
+    const request = new Request('https://example.test/api/integrations/slack/interactions', {
+      method: 'POST',
+      headers: slackHeaders(nowTs, signature),
+      body: rawBody
+    });
+    const response = await handleSlackInteractions(
+      request,
+      makeEnv('secret', repoBoard, makeBoardIndex([], new Map([['run_1', 'repo_alpha']])),
+      {} as unknown as ExecutionContext<unknown>
+    );
+    expect(await response.json()).toMatchObject({ ok: true, action: 'approve_rerun' });
+    expect(repoBoard.transitionRunFromLoopState).toHaveBeenCalledWith(
+      'run_1',
+      'DECISION_REQUIRED',
+      { loopState: 'RERUN_QUEUED' },
+      'tenant_local'
+    );
+    expect(repoBoard.requestRunChanges).toHaveBeenCalledWith(
+      'run_1',
+      { prompt: 'Slack approved rerun for review round 3.' },
+      'tenant_local'
+    );
+    expect(runOrchestratorMocks.scheduleRunJob).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      {
+        tenantId: 'tenant_local',
+        repoId: 'repo_alpha',
+        taskId: 'task_1',
+        runId: 'run_2',
+        mode: 'full_run'
+      }
+    );
+    expect(repoBoard.transitionRun).toHaveBeenCalledWith('run_2', {
+      loopState: 'RERUN_QUEUED',
+      workflowInstanceId: 'workflow_1',
+      orchestrationMode: 'workflow'
+    });
+    expect(tenantAuthDbMocks.upsertSlackThreadBinding).toHaveBeenCalledWith(expect.anything(), {
+      tenantId: 'tenant_local',
+      taskId: 'task_1',
+      channelId: 'C123',
+      threadTs: '1672531200.1234',
+      currentRunId: 'run_2',
+      latestReviewRound: 3
+    });
+  });
+
+  it('does not start a duplicate rerun when approve_rerun is not in DECISION_REQUIRED', async () => {
+    const repoBoard = makeRepoBoard({ taskId: 'task_1', runId: 'run_1' });
+    repoBoard.transitionRunFromLoopState.mockResolvedValueOnce({
+      run: baseRunStub('task_1', 'run_1'),
+      transitioned: false
+    });
+
+    const payload = {
+      type: 'block_actions',
+      user: { id: 'U1' },
+      container: { channel_id: 'C123', thread_ts: '1672531200.1234' },
+      actions: [
+        {
+          action_id: 'approve_rerun',
+          value: JSON.stringify({
+            tenantId: 'tenant_local',
+            taskId: 'task_1',
+            channelId: 'C123',
+            threadTs: '1672531200.1234',
+            currentRunId: 'run_1',
+            latestReviewRound: 2
+          })
+        }
+      ]
+    };
+    const rawBody = new URLSearchParams({ payload: JSON.stringify(payload) }).toString();
+    const signature = await buildSlackSignature('secret', nowTs, rawBody);
+    const request = new Request('https://example.test/api/integrations/slack/interactions', {
+      method: 'POST',
+      headers: slackHeaders(nowTs, signature),
+      body: rawBody
+    });
+    const response = await handleSlackInteractions(
+      request,
+      makeEnv('secret', repoBoard, makeBoardIndex([], new Map([['run_1', 'repo_alpha']])),
+      {} as unknown as ExecutionContext<unknown>
+    );
+    expect(await response.json()).toMatchObject({ ok: true, action: 'approve_rerun' });
+    expect(repoBoard.requestRunChanges).not.toHaveBeenCalled();
+    expect(runOrchestratorMocks.scheduleRunJob).not.toHaveBeenCalled();
+    expect(repoBoard.transitionRun).not.toHaveBeenCalled();
+    expect(tenantAuthDbMocks.upsertSlackThreadBinding).not.toHaveBeenCalled();
+  });
+
+  it('pauses current run and preserves the Slack thread binding', async () => {
+    const repoBoard = makeRepoBoard({ taskId: 'task_1', runId: 'run_1' });
+    const payload = {
+      type: 'block_actions',
+      container: { channel_id: 'C123', thread_ts: '1672531200.1234' },
       actions: [
         {
           action_id: 'pause',
           value: JSON.stringify({
+            tenantId: 'tenant_local',
             taskId: 'task_1',
             channelId: 'C123',
             threadTs: '1672531200.1234',
+            currentRunId: 'run_1',
             latestReviewRound: 3
           })
         }
       ]
     };
-
-    const repoBody = new URLSearchParams({ payload: JSON.stringify(repoDisambiguationPayload) }).toString();
-    const repoSig = await buildSlackSignature('secret', nowTs, repoBody);
-
-    const repoRequest = new Request('https://example.test/api/integrations/slack/interactions', {
+    const rawBody = new URLSearchParams({ payload: JSON.stringify(payload) }).toString();
+    const signature = await buildSlackSignature('secret', nowTs, rawBody);
+    const request = new Request('https://example.test/api/integrations/slack/interactions', {
       method: 'POST',
-      headers: slackHeaders(nowTs, repoSig),
-      body: repoBody
+      headers: slackHeaders(nowTs, signature),
+      body: rawBody
     });
-    const repoResponse = await handleSlackInteractions(repoRequest, makeEnv('secret'), {} as unknown as ExecutionContext<unknown>);
-    expect(await repoResponse.json()).toMatchObject({ ok: true, action: 'repo_disambiguation' });
-
-    const approveBody = new URLSearchParams({ payload: JSON.stringify(approvePayload) }).toString();
-    const approveSig = await buildSlackSignature('secret', nowTs, approveBody);
-    const approveRequest = new Request('https://example.test/api/integrations/slack/interactions', {
-      method: 'POST',
-      headers: slackHeaders(nowTs, approveSig),
-      body: approveBody
-    });
-    const approveResponse = await handleSlackInteractions(approveRequest, makeEnv('secret'), {} as unknown as ExecutionContext<unknown>);
-    expect(await approveResponse.json()).toMatchObject({ ok: true, action: 'approve_rerun' });
-    expect(tenantAuthDbMocks.upsertSlackThreadBinding).toHaveBeenNthCalledWith(2, expect.anything(), {
+    const response = await handleSlackInteractions(
+      request,
+      makeEnv('secret', repoBoard, makeBoardIndex([], new Map([['run_1', 'repo_alpha']])),
+      {} as unknown as ExecutionContext<unknown>
+    );
+    expect(await response.json()).toMatchObject({ ok: true, action: 'pause' });
+    expect(repoBoard.transitionRun).toHaveBeenCalledWith('run_1', { loopState: 'PAUSED' }, 'tenant_local');
+    expect(tenantAuthDbMocks.upsertSlackThreadBinding).toHaveBeenCalledWith(expect.anything(), {
       tenantId: 'tenant_local',
       taskId: 'task_1',
       channelId: 'C123',
       threadTs: '1672531200.1234',
       currentRunId: 'run_1',
-      latestReviewRound: 3
-    });
-
-    const pauseBody = new URLSearchParams({ payload: JSON.stringify(pausePayload) }).toString();
-    const pauseSig = await buildSlackSignature('secret', nowTs, pauseBody);
-    const pauseRequest = new Request('https://example.test/api/integrations/slack/interactions', {
-      method: 'POST',
-      headers: slackHeaders(nowTs, pauseSig),
-      body: pauseBody
-    });
-    const pauseResponse = await handleSlackInteractions(pauseRequest, makeEnv('secret'), {} as unknown as ExecutionContext<unknown>);
-    expect(await pauseResponse.json()).toMatchObject({ ok: true, action: 'pause' });
-    expect(tenantAuthDbMocks.upsertSlackThreadBinding).toHaveBeenNthCalledWith(3, expect.anything(), {
-      tenantId: 'tenant_local',
-      taskId: 'task_1',
-      channelId: 'C123',
-      threadTs: '1672531200.1234',
-      currentRunId: undefined,
       latestReviewRound: 3
     });
   });

--- a/src/server/integrations/slack/handlers.ts
+++ b/src/server/integrations/slack/handlers.ts
@@ -225,6 +225,16 @@ async function resolveRepoCandidates(
   }
 }
 
+async function resolveRepoIdForRun(env: Env, runId: string): Promise<string | undefined> {
+  const boardIndex = env.BOARD_INDEX?.getByName(BOARD_OBJECT_NAME);
+  if (!boardIndex) {
+    return undefined;
+  }
+  return boardIndex.findRunRepoId
+    ? boardIndex.findRunRepoId(runId)
+    : undefined;
+}
+
 async function startRunForTask(
   env: Env,
   ctx: ExecutionContext<unknown> | undefined,
@@ -273,6 +283,78 @@ async function syncSlackBindingAfterRunStart(
     currentRunId: binding.runId,
     latestReviewRound: binding.latestReviewRound
   });
+}
+
+async function startSlackApprovedRerun(
+  env: Env,
+  ctx: ExecutionContext<unknown>,
+  tenantId: string,
+  interaction: ParsedSlackInteraction
+) {
+  const currentRunId = interaction.currentRunId?.trim();
+  if (!currentRunId) {
+    throw badRequest('Missing current run context for rerun approval.');
+  }
+
+  const repoId = await resolveRepoIdForRun(env, currentRunId);
+  if (!repoId) {
+    throw badRequest('Unable to resolve repository for the current run.');
+  }
+
+  const repoBoard = env.REPO_BOARD.getByName(repoId);
+  const nextReviewRound = normalizeLatestReviewRound(interaction.latestReviewRound) + 1;
+  const transition = await repoBoard.transitionRunFromLoopState(currentRunId, 'DECISION_REQUIRED', {
+    loopState: 'RERUN_QUEUED'
+  }, tenantId);
+  if (!transition.transitioned) {
+    return;
+  }
+
+  const run = await repoBoard.requestRunChanges(
+    currentRunId,
+    {
+      prompt: `Slack approved rerun for review round ${nextReviewRound}.`
+    },
+    tenantId
+  );
+
+  const workflow = await scheduleRunJob(env, executionContextOrNoop(ctx), {
+    tenantId,
+    repoId,
+    taskId: run.taskId,
+    runId: run.runId,
+    mode: 'full_run'
+  });
+
+  await repoBoard.transitionRun(run.runId, {
+    loopState: 'RERUN_QUEUED',
+    workflowInstanceId: workflow.id,
+    orchestrationMode: workflow.id.startsWith('local-alarm-') ? 'local_alarm' : 'workflow'
+  });
+
+  await tenantAuthDb.upsertSlackThreadBinding(env, {
+    tenantId,
+    taskId: interaction.taskId,
+    channelId: interaction.channelId,
+    threadTs: interaction.threadTs,
+    currentRunId: run.runId,
+    latestReviewRound: nextReviewRound
+  });
+}
+
+async function pauseSlackRun(
+  env: Env,
+  tenantId: string,
+  interaction: ParsedSlackInteraction,
+  repoId: string | undefined
+) {
+  if (!interaction.currentRunId?.trim() || !repoId) {
+    return;
+  }
+  const repoBoard = env.REPO_BOARD.getByName(repoId);
+  await repoBoard.transitionRun(interaction.currentRunId, {
+    loopState: 'PAUSED'
+  }, tenantId);
 }
 
 async function createThreadBindingForSlashCommand(
@@ -402,14 +484,7 @@ async function updateBindingForAction(
   }
 
   if (interaction.actionId === 'approve_rerun') {
-    return tenantAuthDb.upsertSlackThreadBinding(env, {
-      tenantId,
-      taskId: interaction.taskId,
-      channelId: interaction.channelId,
-      threadTs: interaction.threadTs,
-      currentRunId,
-      latestReviewRound: latestReviewRound + 1
-    });
+    return;
   }
 
   return tenantAuthDb.upsertSlackThreadBinding(env, {
@@ -542,6 +617,21 @@ export async function handleSlackInteractions(
     const tenantId = await resolveThreadTenantId(env, interaction.tenantId || interaction.teamId);
     if (interaction.actionId === 'repo_disambiguation') {
       return handleRepoDisambiguationAction(env, ctx, tenantId, interaction);
+    }
+    if (interaction.actionId === 'approve_rerun') {
+      await startSlackApprovedRerun(env, ctx, tenantId, interaction);
+      return json({
+        ok: true,
+        action: interaction.actionId,
+        taskId: interaction.taskId,
+        ...(interaction.repoId ? { repoId: interaction.repoId } : {})
+      });
+    }
+    if (interaction.actionId === 'pause') {
+      const repoId = interaction.currentRunId
+        ? await resolveRepoIdForRun(env, interaction.currentRunId)
+        : undefined;
+      await pauseSlackRun(env, tenantId, interaction, repoId);
     }
     await updateBindingForAction(env, tenantId, interaction);
     return json({

--- a/src/server/shared/real-run.ts
+++ b/src/server/shared/real-run.ts
@@ -1,4 +1,4 @@
-import type { ArtifactManifest, AgentRun, Repo, RunError, RunLogEntry, RunStatus, Task } from '../../ui/domain/types';
+import type { ArtifactManifest, AgentRun, IntegrationLoopState, Repo, RunError, RunLogEntry, RunStatus, Task } from '../../ui/domain/types';
 import { DEFAULT_SUPPORTS_RESUME_BY_ADAPTER, normalizeRunLlmState, normalizeTaskUiMeta } from '../../shared/llm';
 import { normalizeRunReviewMetadata } from '../../shared/scm';
 import { normalizeTenantId } from '../../shared/tenant';
@@ -15,6 +15,7 @@ export type RunJobParams = {
 
 export type RunTransitionPatch = {
   status?: RunStatus;
+  loopState?: IntegrationLoopState;
   branchName?: string;
   headSha?: string;
   reviewUrl?: string;
@@ -59,6 +60,7 @@ export type RunTransitionPatch = {
 };
 
 type CreateRealRunOptions = {
+  loopState?: IntegrationLoopState;
   branchName?: string;
   reviewUrl?: string;
   reviewNumber?: number;
@@ -84,6 +86,7 @@ export function createRealRun(task: Task, runId: string, now = new Date(), optio
     taskId: task.taskId,
     repoId: task.repoId,
     status: 'QUEUED',
+    loopState: options?.loopState ?? 'QUEUED',
     branchName: options?.branchName ?? `agent/${task.taskId}/${runId}`,
     baseRunId: options?.baseRunId,
     changeRequest: options?.changeRequest,
@@ -117,13 +120,16 @@ export function createRealRun(task: Task, runId: string, now = new Date(), optio
 
 export function applyRunTransition(run: AgentRun, patch: RunTransitionPatch, nowIso: string): AgentRun {
   const nextStatus = patch.status ?? run.status;
-  const timeline = nextStatus !== run.status || patch.appendTimelineNote
+  const nextLoopState = patch.loopState ?? run.loopState;
+  const loopStateChanged = nextLoopState !== run.loopState;
+  const timeline = (nextStatus !== run.status || loopStateChanged || patch.appendTimelineNote)
     ? [...run.timeline, { status: nextStatus, at: nowIso, note: patch.appendTimelineNote }]
     : run.timeline;
 
   return normalizeRunLlmState(normalizeRunReviewMetadata({
     ...run,
     ...patch,
+    loopState: nextLoopState,
     status: nextStatus,
     timeline,
     currentStepStartedAt: patch.currentStepStartedAt ?? (nextStatus !== run.status ? nowIso : run.currentStepStartedAt),


### PR DESCRIPTION
Task: T5 - Decision-Gated Rerun State Machine

Implement review-loop state machine with Slack-gated reruns and race-safe transitions.
Source ref: main

Acceptance criteria:
- Reruns are always explicit Slack-approved actions.
- At most one rerun starts for concurrent approval attempts.
- Loop states persist and progress deterministically across rounds.
- Late feedback is handled without unintended reruns.

Run ID: run_repo_abuiles_agents_kanban_mmc1qke5a916