### PR TITLE
C1 - Checkpoint Domain, Types, and Validation

### DIFF
--- a/src/server/checkpoint-config.test.ts
+++ b/src/server/checkpoint-config.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { DEFAULT_REPO_CHECKPOINT_CONFIG, normalizeRepoCheckpointConfig } from '../shared/checkpoint';
+
+describe('checkpoint config normalization', () => {
+  it('resolves deterministic defaults when checkpoint config is omitted', () => {
+    const normalized = normalizeRepoCheckpointConfig({});
+    expect(normalized.checkpointConfig).toEqual(DEFAULT_REPO_CHECKPOINT_CONFIG);
+  });
+
+  it('merges partial checkpoint config while preserving defaults', () => {
+    const normalized = normalizeRepoCheckpointConfig({
+      checkpointConfig: {
+        enabled: false,
+        contextNotes: {
+          filePath: ' .agentskanban/context/custom-notes.md '
+        },
+        reviewPrep: {
+          rewriteOnChangeRequestRerun: true
+        }
+      }
+    });
+
+    expect(normalized.checkpointConfig).toEqual({
+      ...DEFAULT_REPO_CHECKPOINT_CONFIG,
+      enabled: false,
+      contextNotes: {
+        ...DEFAULT_REPO_CHECKPOINT_CONFIG.contextNotes,
+        filePath: '.agentskanban/context/custom-notes.md'
+      },
+      reviewPrep: {
+        ...DEFAULT_REPO_CHECKPOINT_CONFIG.reviewPrep,
+        rewriteOnChangeRequestRerun: true
+      }
+    });
+  });
+});

--- a/src/server/durable/board-index.ts
+++ b/src/server/durable/board-index.ts
@@ -7,6 +7,7 @@ import type { BoardEvent } from '../shared/events';
 import { stringifyBoardEvent } from '../shared/events';
 import { buildBoardSnapshot, type BoardSyncResponse } from '../shared/state';
 import { buildRepoScmKey, getRepoHost, getRepoProjectPath, normalizeCredentialHost, normalizeRepo } from '../../shared/scm';
+import { DEFAULT_REPO_CHECKPOINT_CONFIG, normalizeRepoCheckpointConfig } from '../../shared/checkpoint';
 import { DEFAULT_REPO_SENTINEL_CONFIG, normalizeRepoSentinelConfig } from '../../shared/sentinel';
 import { DEFAULT_TENANT_ID, normalizeTenantId } from '../../shared/tenant';
 
@@ -759,6 +760,7 @@ export class BoardIndexDO extends DurableObject<Env> {
     const existing = await this.getRepo(repoId);
     const hasAutoReviewPatch = Object.prototype.hasOwnProperty.call(patch, 'autoReview');
     const hasSentinelConfigPatch = Object.prototype.hasOwnProperty.call(patch, 'sentinelConfig');
+    const hasCheckpointConfigPatch = Object.prototype.hasOwnProperty.call(patch, 'checkpointConfig');
     const mergedAutoReview = hasAutoReviewPatch
       ? {
           ...(existing.autoReview ?? { enabled: false, provider: 'gitlab', postInline: false }),
@@ -783,12 +785,27 @@ export class BoardIndexDO extends DurableObject<Env> {
           }
         }
       : existing.sentinelConfig;
+    const mergedCheckpointConfig = hasCheckpointConfigPatch
+      ? {
+          ...(existing.checkpointConfig ?? DEFAULT_REPO_CHECKPOINT_CONFIG),
+          ...patch.checkpointConfig,
+          contextNotes: {
+            ...(existing.checkpointConfig?.contextNotes ?? DEFAULT_REPO_CHECKPOINT_CONFIG.contextNotes),
+            ...(patch.checkpointConfig?.contextNotes ?? {})
+          },
+          reviewPrep: {
+            ...(existing.checkpointConfig?.reviewPrep ?? DEFAULT_REPO_CHECKPOINT_CONFIG.reviewPrep),
+            ...(patch.checkpointConfig?.reviewPrep ?? {})
+          }
+        }
+      : existing.checkpointConfig;
 
     const updated = buildRepoRecord({
       ...existing,
       ...patch,
       autoReview: mergedAutoReview,
       sentinelConfig: mergedSentinelConfig,
+      checkpointConfig: mergedCheckpointConfig,
       slug: patch.slug ?? patch.projectPath ?? existing.slug,
       projectPath: patch.projectPath ?? patch.slug ?? existing.projectPath,
       repoId: existing.repoId,
@@ -1217,6 +1234,20 @@ function buildRepoRecord(input: CreateRepoInput | Repo): Repo {
       }
     }
   }).sentinelConfig;
+  const normalizedCheckpointConfig = normalizeRepoCheckpointConfig({
+    checkpointConfig: {
+      ...DEFAULT_REPO_CHECKPOINT_CONFIG,
+      ...input.checkpointConfig,
+      contextNotes: {
+        ...DEFAULT_REPO_CHECKPOINT_CONFIG.contextNotes,
+        ...(input.checkpointConfig?.contextNotes ?? {})
+      },
+      reviewPrep: {
+        ...DEFAULT_REPO_CHECKPOINT_CONFIG.reviewPrep,
+        ...(input.checkpointConfig?.reviewPrep ?? {})
+      }
+    }
+  }).checkpointConfig;
 
   const normalized = normalizeRepo({
     ...input,
@@ -1226,6 +1257,7 @@ function buildRepoRecord(input: CreateRepoInput | Repo): Repo {
     enabled: input.enabled ?? true,
     autoReview: normalizedAutoReview,
     sentinelConfig: normalizedSentinelConfig,
+    checkpointConfig: normalizedCheckpointConfig,
     llmAdapter: input.llmAdapter,
     llmProfileId: input.llmProfileId,
     githubAuthMode: 'githubAuthMode' in input ? input.githubAuthMode : undefined,

--- a/src/server/durable/repo-board.ts
+++ b/src/server/durable/repo-board.ts
@@ -1286,6 +1286,9 @@ function cloneRepoBoardState(state: RepoBoardState): RepoBoardState {
       reviewFindingsSummary: run.reviewFindingsSummary ? { ...run.reviewFindingsSummary } : undefined,
       reviewArtifacts: run.reviewArtifacts ? { ...run.reviewArtifacts } : undefined,
       reviewPostState: run.reviewPostState ? { ...run.reviewPostState, errors: [...(run.reviewPostState.errors ?? [])] } : undefined,
+      checkpoints: cloneRunCheckpoints(run.checkpoints),
+      resumedFromCheckpointId: run.resumedFromCheckpointId,
+      resumedFromCommitSha: run.resumedFromCommitSha,
       artifacts: run.artifacts ? [...run.artifacts] : undefined,
       latestCodexResumeCommand: (run.llmAdapter ?? run.operatorSession?.llmAdapter ?? 'codex') === 'codex'
         ? (run.latestCodexResumeCommand ?? run.llmResumeCommand)
@@ -1360,7 +1363,10 @@ function normalizeRepoBoardState(state?: Partial<RepoBoardState> | null): RepoBo
       })),
       reviewFindingsSummary: run.reviewFindingsSummary ? { ...run.reviewFindingsSummary } : undefined,
       reviewArtifacts: run.reviewArtifacts ? { ...run.reviewArtifacts } : undefined,
-      reviewPostState: run.reviewPostState ? { ...run.reviewPostState, errors: [...(run.reviewPostState.errors ?? [])] } : undefined
+      reviewPostState: run.reviewPostState ? { ...run.reviewPostState, errors: [...(run.reviewPostState.errors ?? [])] } : undefined,
+      checkpoints: cloneRunCheckpoints(run.checkpoints),
+      resumedFromCheckpointId: run.resumedFromCheckpointId,
+      resumedFromCommitSha: run.resumedFromCommitSha
     };
   });
   const runTenantIds = new Map(normalizedRuns.map((run) => [run.runId, run.tenantId]));
@@ -1446,4 +1452,13 @@ function normalizeTaskTags(tags: Task['tags']) {
     normalized.push(trimmed);
   }
   return normalized.length ? normalized : undefined;
+}
+
+function cloneRunCheckpoints(checkpoints: AgentRun['checkpoints']) {
+  if (!Array.isArray(checkpoints)) {
+    return undefined;
+  }
+  return checkpoints
+    .filter((checkpoint) => checkpoint && typeof checkpoint === 'object')
+    .map((checkpoint) => ({ ...checkpoint }));
 }

--- a/src/server/http/validation.test.ts
+++ b/src/server/http/validation.test.ts
@@ -283,6 +283,61 @@ describe('repo validation', () => {
       postInline: false
     });
     expect(parsed.sentinelConfig).toEqual({});
+    expect(parsed.checkpointConfig).toEqual({});
+  });
+
+  it('parses nested checkpoint config updates', () => {
+    const parsed = parseUpdateRepoInput({
+      checkpointConfig: {
+        enabled: false,
+        triggerMode: 'phase_boundary',
+        contextNotes: {
+          enabled: true,
+          filePath: '.agentskanban/context/run-context.md',
+          cleanupBeforeReview: false
+        },
+        reviewPrep: {
+          squashBeforeFirstReviewOpen: true,
+          rewriteOnChangeRequestRerun: false
+        }
+      }
+    });
+
+    expect(parsed.checkpointConfig).toEqual({
+      enabled: false,
+      triggerMode: 'phase_boundary',
+      contextNotes: {
+        enabled: true,
+        filePath: '.agentskanban/context/run-context.md',
+        cleanupBeforeReview: false
+      },
+      reviewPrep: {
+        squashBeforeFirstReviewOpen: true,
+        rewriteOnChangeRequestRerun: false
+      }
+    });
+  });
+
+  it('rejects invalid checkpoint trigger modes', () => {
+    expect(() =>
+      parseUpdateRepoInput({
+        checkpointConfig: {
+          triggerMode: 'manual'
+        }
+      })
+    ).toThrow('Invalid checkpointConfig.triggerMode.');
+  });
+
+  it('rejects invalid checkpoint context notes payloads', () => {
+    expect(() =>
+      parseCreateRepoInput({
+        slug: 'abuiles/minions',
+        baselineUrl: 'https://example.com',
+        checkpointConfig: {
+          contextNotes: 'invalid'
+        }
+      })
+    ).toThrow('Invalid checkpointConfig.contextNotes.');
   });
 
   it('parses nested sentinel config updates', () => {

--- a/src/server/http/validation.ts
+++ b/src/server/http/validation.ts
@@ -18,6 +18,7 @@ const AUTO_REVIEW_MODES = new Set(['inherit', 'on', 'off'] as const);
 const AUTO_REVIEW_SELECTION_MODES = new Set(['all', 'include', 'exclude', 'freeform'] as const);
 const PREVIEW_ADAPTERS = new Set(['cloudflare_checks', 'prompt_recipe'] as const);
 const SENTINEL_MERGE_METHODS = new Set(['merge', 'squash', 'rebase'] as const);
+const CHECKPOINT_TRIGGER_MODES = new Set(['phase_boundary'] as const);
 const TENANT_MEMBER_ROLES = new Set(['owner', 'member'] as const);
 const TENANT_SEAT_STATES = new Set(['active', 'invited', 'revoked'] as const);
 
@@ -507,6 +508,61 @@ function readSentinelConfig(
   };
 }
 
+function readCheckpointConfig(
+  value: unknown,
+  field: string,
+  required = true
+): NonNullable<CreateRepoInput['checkpointConfig']> | undefined {
+  if (!required && typeof value === 'undefined') {
+    return undefined;
+  }
+  if (!isRecord(value)) {
+    throw badRequest(`Invalid ${field}.`);
+  }
+
+  const contextNotes = hasOwn(value, 'contextNotes')
+    ? (() => {
+        if (!isRecord(value.contextNotes)) {
+          throw badRequest(`Invalid ${field}.contextNotes.`);
+        }
+        return {
+          ...(hasOwn(value.contextNotes, 'enabled')
+            ? { enabled: readBoolean(value.contextNotes.enabled, `${field}.contextNotes.enabled`, false) }
+            : {}),
+          ...(hasOwn(value.contextNotes, 'filePath')
+            ? { filePath: readTrimmedString(value.contextNotes.filePath, `${field}.contextNotes.filePath`, false) }
+            : {}),
+          ...(hasOwn(value.contextNotes, 'cleanupBeforeReview')
+            ? { cleanupBeforeReview: readBoolean(value.contextNotes.cleanupBeforeReview, `${field}.contextNotes.cleanupBeforeReview`, false) }
+            : {})
+        };
+      })()
+    : undefined;
+
+  const reviewPrep = hasOwn(value, 'reviewPrep')
+    ? (() => {
+        if (!isRecord(value.reviewPrep)) {
+          throw badRequest(`Invalid ${field}.reviewPrep.`);
+        }
+        return {
+          ...(hasOwn(value.reviewPrep, 'squashBeforeFirstReviewOpen')
+            ? { squashBeforeFirstReviewOpen: readBoolean(value.reviewPrep.squashBeforeFirstReviewOpen, `${field}.reviewPrep.squashBeforeFirstReviewOpen`, false) }
+            : {}),
+          ...(hasOwn(value.reviewPrep, 'rewriteOnChangeRequestRerun')
+            ? { rewriteOnChangeRequestRerun: readBoolean(value.reviewPrep.rewriteOnChangeRequestRerun, `${field}.reviewPrep.rewriteOnChangeRequestRerun`, false) }
+            : {})
+        };
+      })()
+    : undefined;
+
+  return {
+    ...(hasOwn(value, 'enabled') ? { enabled: readBoolean(value.enabled, `${field}.enabled`, false) } : {}),
+    ...(hasOwn(value, 'triggerMode') ? { triggerMode: readEnumValue(value.triggerMode, `${field}.triggerMode`, CHECKPOINT_TRIGGER_MODES, false) } : {}),
+    ...(contextNotes ? { contextNotes } : {}),
+    ...(reviewPrep ? { reviewPrep } : {})
+  };
+}
+
 function normalizeRepoPreviewFields<T extends {
   previewMode?: CreateRepoInput['previewMode'];
   previewAdapter?: CreateRepoInput['previewAdapter'];
@@ -590,6 +646,9 @@ export function parseCreateRepoInput(body: unknown): CreateRepoInput {
     sentinelConfig: hasOwn(body, 'sentinelConfig')
       ? readSentinelConfig(body.sentinelConfig, 'sentinelConfig')
       : {},
+    checkpointConfig: hasOwn(body, 'checkpointConfig')
+      ? readCheckpointConfig(body.checkpointConfig, 'checkpointConfig')
+      : {},
     enabled: readBoolean(body.enabled, 'enabled', false),
     previewMode: readEnumValue(body.previewMode, 'previewMode', new Set(['auto', 'skip'] as const), false),
     evidenceMode: readEnumValue(body.evidenceMode, 'evidenceMode', new Set(['auto', 'skip'] as const), false),
@@ -635,6 +694,7 @@ export function parseUpdateRepoInput(body: unknown): UpdateRepoInput {
   if (hasOwn(body, 'previewCheckName')) patch.previewCheckName = readTrimmedString(body.previewCheckName, 'previewCheckName', false);
   if (hasOwn(body, 'autoReview')) patch.autoReview = readAutoReviewConfig(body.autoReview, 'autoReview', false);
   if (hasOwn(body, 'sentinelConfig')) patch.sentinelConfig = readSentinelConfig(body.sentinelConfig, 'sentinelConfig', false);
+  if (hasOwn(body, 'checkpointConfig')) patch.checkpointConfig = readCheckpointConfig(body.checkpointConfig, 'checkpointConfig', false);
   if (hasOwn(body, 'codexAuthBundleR2Key')) patch.codexAuthBundleR2Key = readTrimmedString(body.codexAuthBundleR2Key, 'codexAuthBundleR2Key', false);
 
   if (hasOwn(body, 'previewAdapter') || hasOwn(body, 'previewConfig') || hasOwn(body, 'previewProvider') || hasOwn(body, 'previewCheckName')) {

--- a/src/server/shared/real-run.test.ts
+++ b/src/server/shared/real-run.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import type { Task } from '../../ui/domain/types';
+import { applyRunTransition, createRealRun } from './real-run';
+
+function buildTask(overrides: Partial<Task> = {}): Task {
+  return {
+    tenantId: 'tenant_default',
+    taskId: 'task_repo_demo_1',
+    repoId: 'repo_demo',
+    title: 'Implement feature',
+    taskPrompt: 'Do the work',
+    acceptanceCriteria: ['Done'],
+    context: { links: [] },
+    status: 'INBOX',
+    createdAt: '2026-03-04T00:00:00.000Z',
+    updatedAt: '2026-03-04T00:00:00.000Z',
+    ...overrides
+  };
+}
+
+describe('real run checkpoint metadata compatibility', () => {
+  it('keeps checkpoint metadata optional for backward compatibility', () => {
+    const run = createRealRun(buildTask(), 'run_1', new Date('2026-03-04T00:00:00.000Z'));
+    expect(run.checkpoints).toBeUndefined();
+    expect(run.resumedFromCheckpointId).toBeUndefined();
+    expect(run.resumedFromCommitSha).toBeUndefined();
+  });
+
+  it('accepts checkpoint metadata when creating runs', () => {
+    const run = createRealRun(buildTask(), 'run_2', new Date('2026-03-04T00:00:00.000Z'), {
+      resumedFromCheckpointId: 'cp_1',
+      resumedFromCommitSha: 'a'.repeat(40),
+      checkpoints: [{
+        checkpointId: 'cp_1',
+        runId: 'run_2',
+        repoId: 'repo_demo',
+        taskId: 'task_repo_demo_1',
+        phase: 'codex',
+        commitSha: 'a'.repeat(40),
+        commitMessage: 'checkpoint: codex',
+        createdAt: '2026-03-04T00:00:00.000Z'
+      }]
+    });
+
+    expect(run.resumedFromCheckpointId).toBe('cp_1');
+    expect(run.resumedFromCommitSha).toBe('a'.repeat(40));
+    expect(run.checkpoints).toHaveLength(1);
+    expect(run.checkpoints?.[0]?.phase).toBe('codex');
+  });
+
+  it('preserves checkpoint metadata through run transitions', () => {
+    const initial = createRealRun(buildTask(), 'run_3', new Date('2026-03-04T00:00:00.000Z'));
+    const updated = applyRunTransition(initial, {
+      checkpoints: [{
+        checkpointId: 'cp_2',
+        runId: 'run_3',
+        repoId: 'repo_demo',
+        taskId: 'task_repo_demo_1',
+        phase: 'tests',
+        commitSha: 'b'.repeat(40),
+        commitMessage: 'checkpoint: tests',
+        createdAt: '2026-03-04T00:10:00.000Z'
+      }],
+      resumedFromCheckpointId: 'cp_1',
+      resumedFromCommitSha: 'a'.repeat(40)
+    }, '2026-03-04T00:10:00.000Z');
+
+    expect(updated.checkpoints).toHaveLength(1);
+    expect(updated.checkpoints?.[0]?.checkpointId).toBe('cp_2');
+    expect(updated.resumedFromCheckpointId).toBe('cp_1');
+    expect(updated.resumedFromCommitSha).toBe('a'.repeat(40));
+  });
+});

--- a/src/server/shared/real-run.ts
+++ b/src/server/shared/real-run.ts
@@ -54,6 +54,9 @@ export type RunTransitionPatch = {
   reviewFindingsSummary?: AgentRun['reviewFindingsSummary'];
   reviewArtifacts?: AgentRun['reviewArtifacts'];
   reviewPostState?: AgentRun['reviewPostState'];
+  checkpoints?: AgentRun['checkpoints'];
+  resumedFromCheckpointId?: AgentRun['resumedFromCheckpointId'];
+  resumedFromCommitSha?: AgentRun['resumedFromCommitSha'];
   endedAt?: string;
   currentStepStartedAt?: string;
   appendTimelineNote?: string;
@@ -74,6 +77,9 @@ type CreateRealRunOptions = {
   baseRunId?: string;
   changeRequest?: AgentRun['changeRequest'];
   dependencyContext?: AgentRun['dependencyContext'];
+  checkpoints?: AgentRun['checkpoints'];
+  resumedFromCheckpointId?: AgentRun['resumedFromCheckpointId'];
+  resumedFromCommitSha?: AgentRun['resumedFromCommitSha'];
 };
 
 export function createRealRun(task: Task, runId: string, now = new Date(), options?: CreateRealRunOptions): AgentRun {
@@ -100,6 +106,9 @@ export function createRealRun(task: Task, runId: string, now = new Date(), optio
     landedOnDefaultBranch: options?.landedOnDefaultBranch,
     landedOnDefaultBranchAt: options?.landedOnDefaultBranchAt,
     dependencyContext: options?.dependencyContext,
+    checkpoints: options?.checkpoints,
+    resumedFromCheckpointId: options?.resumedFromCheckpointId,
+    resumedFromCommitSha: options?.resumedFromCommitSha,
     errors: [],
     startedAt: nowIso,
     timeline: [{ status: 'QUEUED', at: nowIso, note: 'Run queued for real sandbox execution.' }],

--- a/src/shared/checkpoint.ts
+++ b/src/shared/checkpoint.ts
@@ -1,0 +1,54 @@
+import type { RepoCheckpointConfig } from '../ui/domain/types';
+
+export const DEFAULT_REPO_CHECKPOINT_CONFIG: RepoCheckpointConfig = {
+  enabled: true,
+  triggerMode: 'phase_boundary',
+  contextNotes: {
+    enabled: true,
+    filePath: '.agentskanban/context/run-context.md',
+    cleanupBeforeReview: true
+  },
+  reviewPrep: {
+    squashBeforeFirstReviewOpen: true,
+    rewriteOnChangeRequestRerun: false
+  }
+};
+
+type RepoCheckpointLike = {
+  checkpointConfig?: {
+    enabled?: boolean;
+    triggerMode?: RepoCheckpointConfig['triggerMode'];
+    contextNotes?: Partial<RepoCheckpointConfig['contextNotes']>;
+    reviewPrep?: Partial<RepoCheckpointConfig['reviewPrep']>;
+  };
+};
+
+export function normalizeRepoCheckpointConfig<T extends RepoCheckpointLike>(repo: T): T & { checkpointConfig: RepoCheckpointConfig } {
+  return {
+    ...repo,
+    checkpointConfig: {
+      enabled: repo.checkpointConfig?.enabled ?? DEFAULT_REPO_CHECKPOINT_CONFIG.enabled,
+      triggerMode: repo.checkpointConfig?.triggerMode ?? DEFAULT_REPO_CHECKPOINT_CONFIG.triggerMode,
+      contextNotes: {
+        enabled: repo.checkpointConfig?.contextNotes?.enabled ?? DEFAULT_REPO_CHECKPOINT_CONFIG.contextNotes.enabled,
+        filePath: normalizeCheckpointPath(repo.checkpointConfig?.contextNotes?.filePath),
+        cleanupBeforeReview: repo.checkpointConfig?.contextNotes?.cleanupBeforeReview
+          ?? DEFAULT_REPO_CHECKPOINT_CONFIG.contextNotes.cleanupBeforeReview
+      },
+      reviewPrep: {
+        squashBeforeFirstReviewOpen: repo.checkpointConfig?.reviewPrep?.squashBeforeFirstReviewOpen
+          ?? DEFAULT_REPO_CHECKPOINT_CONFIG.reviewPrep.squashBeforeFirstReviewOpen,
+        rewriteOnChangeRequestRerun: repo.checkpointConfig?.reviewPrep?.rewriteOnChangeRequestRerun
+          ?? DEFAULT_REPO_CHECKPOINT_CONFIG.reviewPrep.rewriteOnChangeRequestRerun
+      }
+    }
+  };
+}
+
+function normalizeCheckpointPath(value: string | undefined) {
+  if (typeof value !== 'string') {
+    return DEFAULT_REPO_CHECKPOINT_CONFIG.contextNotes.filePath;
+  }
+  const normalized = value.trim();
+  return normalized || DEFAULT_REPO_CHECKPOINT_CONFIG.contextNotes.filePath;
+}

--- a/src/shared/scm.ts
+++ b/src/shared/scm.ts
@@ -1,4 +1,5 @@
 import type { AgentRun, Repo, ScmProvider, TaskBranchSource } from '../ui/domain/types';
+import { normalizeRepoCheckpointConfig } from './checkpoint';
 import { normalizeRepoPreviewConfig } from './preview';
 import { normalizeRepoSentinelConfig } from './sentinel';
 import { normalizeTenantId } from './tenant';
@@ -64,18 +65,20 @@ export function normalizeRepo(repo: RepoScmLike & Omit<Repo, 'slug' | 'scmProvid
     messageExamples: messageExamples.length ? messageExamples : undefined
   };
 
-  return normalizeRepoSentinelConfig(
-    normalizeRepoPreviewConfig({
-      ...repo,
-      tenantId: normalizeTenantId(repo.tenantId),
-      slug: projectPath,
-      scmProvider,
-      scmBaseUrl: normalizeScmBaseUrl(scmProvider, repo.scmBaseUrl),
-      projectPath,
-      commitConfig: (commitConfig.messageTemplate || commitConfig.messageRegex || commitConfig.messageExamples)
-        ? commitConfig
-        : undefined
-    })
+  return normalizeRepoCheckpointConfig(
+    normalizeRepoSentinelConfig(
+      normalizeRepoPreviewConfig({
+        ...repo,
+        tenantId: normalizeTenantId(repo.tenantId),
+        slug: projectPath,
+        scmProvider,
+        scmBaseUrl: normalizeScmBaseUrl(scmProvider, repo.scmBaseUrl),
+        projectPath,
+        commitConfig: (commitConfig.messageTemplate || commitConfig.messageRegex || commitConfig.messageExamples)
+          ? commitConfig
+          : undefined
+      })
+    )
   );
 }
 

--- a/src/ui/domain/api.ts
+++ b/src/ui/domain/api.ts
@@ -8,6 +8,7 @@ import type {
   LlmAdapter,
   LlmReasoningEffort,
   Repo,
+  RepoCheckpointConfig,
   RepoSentinelConfig,
   SentinelEvent,
   SentinelRun,
@@ -38,6 +39,12 @@ export type RepoSentinelConfigInput = {
   reviewGate?: Partial<RepoSentinelConfig['reviewGate']>;
   mergePolicy?: Partial<RepoSentinelConfig['mergePolicy']>;
   conflictPolicy?: Partial<RepoSentinelConfig['conflictPolicy']>;
+};
+export type RepoCheckpointConfigInput = {
+  enabled?: boolean;
+  triggerMode?: RepoCheckpointConfig['triggerMode'];
+  contextNotes?: Partial<RepoCheckpointConfig['contextNotes']>;
+  reviewPrep?: Partial<RepoCheckpointConfig['reviewPrep']>;
 };
 
 export type RepoSentinelStartInput = {
@@ -82,6 +89,7 @@ export type CreateRepoInput = {
   enabled?: boolean;
   autoReview?: RepoAutoReviewInput;
   sentinelConfig?: RepoSentinelConfigInput;
+  checkpointConfig?: RepoCheckpointConfigInput;
   previewMode?: Repo['previewMode'];
   evidenceMode?: Repo['evidenceMode'];
   previewAdapter?: Repo['previewAdapter'];

--- a/src/ui/domain/types.ts
+++ b/src/ui/domain/types.ts
@@ -94,6 +94,19 @@ export type RepoSentinelConfig = {
     maxAttempts: number;
   };
 };
+export type RepoCheckpointConfig = {
+  enabled: boolean;
+  triggerMode: 'phase_boundary';
+  contextNotes: {
+    enabled: boolean;
+    filePath: string;
+    cleanupBeforeReview: boolean;
+  };
+  reviewPrep: {
+    squashBeforeFirstReviewOpen: boolean;
+    rewriteOnChangeRequestRerun: boolean;
+  };
+};
 export type SentinelScopeType = 'group' | 'global';
 export type SentinelRunStatus = 'running' | 'paused' | 'stopped' | 'failed' | 'completed';
 export type SentinelEventLevel = 'info' | 'warn' | 'error';
@@ -299,6 +312,7 @@ export type Repo = {
   codexAuthBundleR2Key?: string;
   autoReview?: RepoAutoReview;
   sentinelConfig?: RepoSentinelConfig;
+  checkpointConfig?: RepoCheckpointConfig;
   createdAt: string;
   updatedAt: string;
 };
@@ -511,6 +525,18 @@ export type ScheduledSimulationEvent = {
   note?: string;
 };
 
+export type RunCheckpoint = {
+  checkpointId: string;
+  runId: string;
+  repoId: string;
+  taskId: string;
+  phase: 'bootstrap' | 'codex' | 'tests' | 'push';
+  commitSha: string;
+  commitMessage: string;
+  contextNotesPath?: string;
+  createdAt: string;
+};
+
 export type AgentRun = {
   tenantId?: string;
   runId: string;
@@ -578,6 +604,9 @@ export type AgentRun = {
   reviewPostState?: RunReviewPostState;
   artifacts?: string[];
   artifactManifest?: ArtifactManifest;
+  checkpoints?: RunCheckpoint[];
+  resumedFromCheckpointId?: string;
+  resumedFromCommitSha?: string;
   errors: RunError[];
   startedAt: string;
   endedAt?: string;

--- a/src/ui/mock/local-agent-board-api.ts
+++ b/src/ui/mock/local-agent-board-api.ts
@@ -26,6 +26,7 @@ import { LocalBoardStore } from '../store/local-board-store';
 import { parseImportedBoard } from '../store/import-export';
 import { RunSimulator } from './run-simulator';
 import { normalizeOperatorSession, normalizeRunLlmState, normalizeTaskUiMeta } from '../../shared/llm';
+import { DEFAULT_REPO_CHECKPOINT_CONFIG, normalizeRepoCheckpointConfig } from '../../shared/checkpoint';
 import { normalizeCredentialHost, normalizeRepo } from '../../shared/scm';
 import { DEFAULT_REPO_SENTINEL_CONFIG, normalizeRepoSentinelConfig } from '../../shared/sentinel';
 
@@ -280,6 +281,7 @@ export class LocalAgentBoardApi implements AgentBoardApi {
 
         const hasAutoReviewPatch = Object.prototype.hasOwnProperty.call(patch, 'autoReview');
         const hasSentinelConfigPatch = Object.prototype.hasOwnProperty.call(patch, 'sentinelConfig');
+        const hasCheckpointConfigPatch = Object.prototype.hasOwnProperty.call(patch, 'checkpointConfig');
         const mergedAutoReview = hasAutoReviewPatch
           ? {
               ...(repo.autoReview ?? { enabled: false, provider: 'gitlab', postInline: false }),
@@ -322,12 +324,30 @@ export class LocalAgentBoardApi implements AgentBoardApi {
             }
           }
         }).sentinelConfig;
+        const mergedCheckpointConfig = hasCheckpointConfigPatch
+          ? {
+              ...(repo.checkpointConfig ?? DEFAULT_REPO_CHECKPOINT_CONFIG),
+              ...patch.checkpointConfig,
+              contextNotes: {
+                ...(repo.checkpointConfig?.contextNotes ?? DEFAULT_REPO_CHECKPOINT_CONFIG.contextNotes),
+                ...(patch.checkpointConfig?.contextNotes ?? {})
+              },
+              reviewPrep: {
+                ...(repo.checkpointConfig?.reviewPrep ?? DEFAULT_REPO_CHECKPOINT_CONFIG.reviewPrep),
+                ...(patch.checkpointConfig?.reviewPrep ?? {})
+              }
+            }
+          : repo.checkpointConfig;
+        const normalizedCheckpointConfig = normalizeRepoCheckpointConfig({
+          checkpointConfig: mergedCheckpointConfig
+        }).checkpointConfig;
 
         updatedRepo = normalizeRepo({
           ...repo,
           ...patch,
           autoReview: mergedAutoReview,
           sentinelConfig: normalizedSentinelConfig,
+          checkpointConfig: normalizedCheckpointConfig,
           slug: patch.slug ?? patch.projectPath ?? repo.slug,
           projectPath: patch.projectPath ?? patch.slug ?? repo.projectPath,
           updatedAt: nowIso()


### PR DESCRIPTION
Task: C1 - Checkpoint Domain, Types, and Validation

Add checkpoint config and run checkpoint metadata foundations with backward-compatible validation.
Source ref: main

Acceptance criteria:
- Repo checkpoint config is persisted with deterministic defaults.
- Run checkpoint metadata fields are available and backward compatible.
- Validation rejects malformed checkpoint config safely.

Run ID: run_repo_abuiles_agents_kanban_mmc5u6nkg8bb