### PR TITLE
C3 - Retry Recovery from Latest Checkpoint

### DIFF
--- a/src/server/durable/repo-board.ts
+++ b/src/server/durable/repo-board.ts
@@ -1,4 +1,4 @@
-import type { CreateTaskInput, UpdateTaskInput } from '../../ui/domain/api';
+import type { CreateTaskInput, RetryRunInput, UpdateTaskInput } from '../../ui/domain/api';
 import type {
   AgentRun,
   IntegrationLoopState,
@@ -28,6 +28,7 @@ import { normalizeOperatorSession, normalizeRunLlmState, normalizeTaskUiMeta } f
 import { hasRunReview, normalizeDependencyReviewMetadata, normalizeRunReviewMetadata, normalizeTaskBranchSourceReviewMetadata } from '../../shared/scm';
 import { DEFAULT_TENANT_ID, normalizeTenantId } from '../../shared/tenant';
 import { mapRunStatusToLifecycleMilestone, mirrorRunLifecycleMilestone } from '../integrations/slack/timeline';
+import { resolveRetryRecoveryDecision } from '../shared/retry-recovery';
 
 const STORAGE_KEY = 'repo-board-state';
 const LOCAL_JOBS_KEY = 'repo-board-local-jobs';
@@ -242,7 +243,15 @@ export class RepoBoardDO extends DurableObject<Env> {
 
   async startRun(
     taskId: string,
-    options?: { forceNew?: boolean; baseRunId?: string; dependencyAutoStart?: boolean; tenantId?: string }
+    options?: {
+      forceNew?: boolean;
+      baseRunId?: string;
+      dependencyAutoStart?: boolean;
+      tenantId?: string;
+      sourceRefOverride?: string;
+      resumedFromCheckpointId?: string;
+      resumedFromCommitSha?: string;
+    }
   ): Promise<AgentRun> {
     await this.ready;
     const task = this.state.tasks.find((candidate) => candidate.taskId === taskId);
@@ -271,7 +280,8 @@ export class RepoBoardDO extends DurableObject<Env> {
       tasks: this.state.tasks,
       runs: this.state.runs,
       defaultBranch: repo.defaultBranch,
-      resolvedAt: nowIso
+      resolvedAt: nowIso,
+      sourceRefOverride: options?.sourceRefOverride
     });
     const run = createRealRun(
       {
@@ -282,7 +292,9 @@ export class RepoBoardDO extends DurableObject<Env> {
       now,
       {
         baseRunId: options?.baseRunId,
-        dependencyContext: resolvedSource.dependencyContext
+        dependencyContext: resolvedSource.dependencyContext,
+        resumedFromCheckpointId: options?.resumedFromCheckpointId,
+        resumedFromCommitSha: options?.resumedFromCommitSha
       }
     );
 
@@ -326,10 +338,19 @@ export class RepoBoardDO extends DurableObject<Env> {
     return run;
   }
 
-  async retryRun(runId: string, tenantId?: string) {
+  async retryRun(runId: string, options?: RetryRunInput & { tenantId?: string }) {
     await this.ready;
-    const run = await this.getRun(runId, tenantId);
-    return this.startRun(run.taskId, { forceNew: true, baseRunId: run.runId, tenantId });
+    const run = await this.getRun(runId, options?.tenantId);
+    const recovery = resolveRetryRecoveryDecision(run, options);
+    const nextRun = await this.startRun(run.taskId, {
+      forceNew: true,
+      baseRunId: run.runId,
+      tenantId: options?.tenantId,
+      sourceRefOverride: recovery.strategy === 'checkpoint' ? recovery.resumedFromCommitSha : undefined,
+      resumedFromCheckpointId: recovery.strategy === 'checkpoint' ? recovery.resumedFromCheckpointId : undefined,
+      resumedFromCommitSha: recovery.strategy === 'checkpoint' ? recovery.resumedFromCommitSha : undefined
+    });
+    return this.transitionRun(nextRun.runId, { appendTimelineNote: recovery.timelineNote }, options?.tenantId);
   }
 
   async requestRunChanges(

--- a/src/server/http/validation.test.ts
+++ b/src/server/http/validation.test.ts
@@ -7,6 +7,7 @@ import {
   parseCreateTaskInput,
   parseCreateUserApiTokenInput,
   parseStartRepoSentinelInput,
+  parseRetryRunInput,
   parseRequestRunChangesInput,
   parseUpdateRepoSentinelConfigInput,
   parseUpdateRepoInput,
@@ -624,6 +625,29 @@ describe('request run validation', () => {
       mode: 'freeform',
       instruction: 'Address accessibility blockers first.'
     });
+  });
+
+  it('defaults retry payload to latest-checkpoint mode when empty', () => {
+    expect(parseRetryRunInput({})).toEqual({ recoveryMode: 'latest_checkpoint' });
+  });
+
+  it('parses retry payload with explicit checkpoint recovery', () => {
+    expect(parseRetryRunInput({
+      recoveryMode: 'latest_checkpoint',
+      checkpointId: 'run_1:cp:002:codex'
+    })).toEqual({
+      recoveryMode: 'latest_checkpoint',
+      checkpointId: 'run_1:cp:002:codex'
+    });
+  });
+
+  it('rejects checkpointId with fresh recovery mode', () => {
+    expect(() =>
+      parseRetryRunInput({
+        recoveryMode: 'fresh',
+        checkpointId: 'run_1:cp:002:codex'
+      })
+    ).toThrow('checkpointId cannot be provided when recoveryMode is fresh.');
   });
 });
 

--- a/src/server/http/validation.ts
+++ b/src/server/http/validation.ts
@@ -3,6 +3,7 @@ import type {
   CreateTaskInput,
   RepoSentinelConfigInput,
   RequestRunChangesInput,
+  RetryRunInput,
   UpdateRepoInput,
   UpdateTaskInput,
   UpsertScmCredentialInput
@@ -16,6 +17,7 @@ const LLM_ADAPTERS = new Set(['codex', 'cursor_cli'] as const);
 const AUTO_REVIEW_PROVIDERS = new Set(['gitlab', 'jira'] as const);
 const AUTO_REVIEW_MODES = new Set(['inherit', 'on', 'off'] as const);
 const AUTO_REVIEW_SELECTION_MODES = new Set(['all', 'include', 'exclude', 'freeform'] as const);
+const RETRY_RECOVERY_MODES = new Set(['latest_checkpoint', 'fresh'] as const);
 const PREVIEW_ADAPTERS = new Set(['cloudflare_checks', 'prompt_recipe'] as const);
 const SENTINEL_MERGE_METHODS = new Set(['merge', 'squash', 'rebase'] as const);
 const CHECKPOINT_TRIGGER_MODES = new Set(['phase_boundary'] as const);
@@ -808,6 +810,28 @@ export function parseRequestRunChangesInput(body: unknown): RequestRunChangesInp
     prompt,
     reviewSelection: readRequestRunChangesSelection(body.reviewSelection, 'reviewSelection')
   };
+}
+
+export function parseRetryRunInput(body: unknown): RetryRunInput {
+  if (!isRecord(body)) {
+    throw badRequest('Invalid retry payload.');
+  }
+
+  const retryInput: RetryRunInput = { recoveryMode: 'latest_checkpoint' };
+  if (hasOwn(body, 'recoveryMode')) {
+    retryInput.recoveryMode = readEnumValue(body.recoveryMode, 'recoveryMode', RETRY_RECOVERY_MODES, false);
+  }
+  if (hasOwn(body, 'checkpointId')) {
+    const checkpointId = readTrimmedString(body.checkpointId, 'checkpointId', false);
+    if (!checkpointId) {
+      throw badRequest('Invalid checkpointId.');
+    }
+    retryInput.checkpointId = checkpointId;
+  }
+  if (retryInput.recoveryMode === 'fresh' && retryInput.checkpointId) {
+    throw badRequest('checkpointId cannot be provided when recoveryMode is fresh.');
+  }
+  return retryInput;
 }
 
 export function parseUpdateRepoSentinelConfigInput(body: unknown): RepoSentinelConfigInput {

--- a/src/server/router.retry.test.ts
+++ b/src/server/router.retry.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const tenantAuthDbMocks = vi.hoisted(() => ({
+  resolveSessionByToken: vi.fn(),
+  hasActiveTenantAccess: vi.fn(),
+  getTenantMembership: vi.fn(),
+  resolveApiToken: vi.fn(),
+  listUserMemberships: vi.fn()
+}));
+
+const orchestratorMocks = vi.hoisted(() => ({
+  scheduleRunJob: vi.fn()
+}));
+
+vi.mock('./tenant-auth-db', () => tenantAuthDbMocks);
+vi.mock('./run-orchestrator', () => orchestratorMocks);
+
+import { handleRetryRun } from './router';
+
+function createEnv(): { env: Env; repoBoard: { retryRun: ReturnType<typeof vi.fn> } } {
+  let run = {
+    runId: 'run_retry_2',
+    taskId: 'task_1',
+    repoId: 'repo_1'
+  };
+
+  const repoBoard = {
+    retryRun: vi.fn(async (_runId: string, _input: Record<string, unknown>) => run),
+    transitionRun: vi.fn(async (_runId: string, patch: Record<string, unknown>) => {
+      run = { ...run, ...patch };
+      return run;
+    }),
+    getRun: vi.fn(async () => run)
+  };
+
+  const board = {
+    findRunRepoId: vi.fn(async () => 'repo_1'),
+    getRepo: vi.fn(async () => ({
+      repoId: 'repo_1',
+      tenantId: 'tenant_local',
+      scmProvider: 'github',
+      scmBaseUrl: 'https://github.com',
+      projectPath: 'acme/demo'
+    }))
+  };
+
+  const env = {
+    BOARD_INDEX: {
+      getByName: vi.fn(() => board)
+    },
+    REPO_BOARD: {
+      getByName: vi.fn(() => repoBoard)
+    }
+  } as unknown as Env;
+
+  return { env, repoBoard };
+}
+
+describe('handleRetryRun', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    tenantAuthDbMocks.resolveSessionByToken.mockResolvedValue({
+      user: { id: 'user_1' },
+      session: { id: 'sess_1', activeTenantId: 'tenant_local' }
+    });
+    tenantAuthDbMocks.hasActiveTenantAccess.mockResolvedValue(true);
+    orchestratorMocks.scheduleRunJob.mockResolvedValue({ id: 'wf_retry_1' });
+  });
+
+  it('defaults retry requests to latest_checkpoint recovery mode', async () => {
+    const { env, repoBoard } = createEnv();
+    const response = await handleRetryRun(
+      new Request('https://minions.example.test/api/runs/run_repo_1_demo/retry', {
+        method: 'POST',
+        headers: { 'x-session-token': 'session-token' }
+      }),
+      env,
+      { runId: 'run_repo_1_demo' },
+      {} as ExecutionContext<unknown>
+    );
+    expect(response.status).toBe(200);
+
+    expect(repoBoard.retryRun).toHaveBeenCalledWith('run_repo_1_demo', {
+      tenantId: 'tenant_local',
+      recoveryMode: 'latest_checkpoint'
+    });
+  });
+
+  it('forwards explicit checkpoint recovery options', async () => {
+    const { env, repoBoard } = createEnv();
+    const response = await handleRetryRun(
+      new Request('https://minions.example.test/api/runs/run_repo_1_demo/retry', {
+        method: 'POST',
+        headers: { 'x-session-token': 'session-token', 'content-type': 'application/json' },
+        body: JSON.stringify({
+          recoveryMode: 'latest_checkpoint',
+          checkpointId: 'run_repo_1_demo:cp:003:tests'
+        })
+      }),
+      env,
+      { runId: 'run_repo_1_demo' },
+      {} as ExecutionContext<unknown>
+    );
+    expect(response.status).toBe(200);
+
+    expect(repoBoard.retryRun).toHaveBeenCalledWith('run_repo_1_demo', {
+      tenantId: 'tenant_local',
+      recoveryMode: 'latest_checkpoint',
+      checkpointId: 'run_repo_1_demo:cp:003:tests'
+    });
+  });
+});

--- a/src/server/router.ts
+++ b/src/server/router.ts
@@ -19,6 +19,7 @@ import {
   parseCreateTenantMemberInput,
   parsePlatformAuthLoginInput,
   parsePlatformSupportAssumeTenantInput,
+  parseRetryRunInput,
   parseSetActiveTenantInput,
   parseRequestRunChangesInput,
   parseUpdateRepoSentinelConfigInput,
@@ -975,7 +976,11 @@ export async function handleRetryRun(request: Request, env: Env, params: RoutePa
     const runId = parsePathParam(params.runId);
     const repoId = await resolveRepoIdForRun(board, runId);
     await assertRepoAccess(env, board, requestContext, repoId);
-    const run = await env.REPO_BOARD.getByName(repoId).retryRun(runId, requestContext.activeTenantId);
+    const retryInput = parseRetryRunInput(await readJson(request).catch(() => ({})));
+    const run = await env.REPO_BOARD.getByName(repoId).retryRun(runId, {
+      tenantId: requestContext.activeTenantId,
+      ...retryInput
+    });
     const workflow = await scheduleRunJob(env, ctx as unknown as ExecutionContext, {
       tenantId: requestContext.activeTenantId,
       repoId,

--- a/src/server/shared/retry-recovery.test.ts
+++ b/src/server/shared/retry-recovery.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import type { AgentRun, RunCheckpoint } from '../../ui/domain/types';
+import { resolveRetryRecoveryDecision } from './retry-recovery';
+
+function buildCheckpoint(sequence: number, overrides: Partial<RunCheckpoint> = {}): RunCheckpoint {
+  const commitSha = `${sequence}`.repeat(40).slice(0, 40);
+  return {
+    checkpointId: `run_1:cp:${String(sequence).padStart(3, '0')}:codex`,
+    runId: 'run_1',
+    repoId: 'repo_1',
+    taskId: 'task_1',
+    phase: 'codex',
+    commitSha,
+    commitMessage: `checkpoint ${sequence}`,
+    createdAt: `2026-03-02T00:00:0${sequence}.000Z`,
+    ...overrides
+  };
+}
+
+function buildRun(checkpoints?: RunCheckpoint[]): Pick<AgentRun, 'checkpoints'> {
+  return { checkpoints };
+}
+
+describe('resolveRetryRecoveryDecision', () => {
+  it('defaults to latest checkpoint recovery when input is omitted', () => {
+    const decision = resolveRetryRecoveryDecision(buildRun([
+      buildCheckpoint(1),
+      buildCheckpoint(2)
+    ]));
+
+    expect(decision.strategy).toBe('checkpoint');
+    if (decision.strategy !== 'checkpoint') {
+      return;
+    }
+    expect(decision.resumedFromCheckpointId).toBe('run_1:cp:002:codex');
+    expect(decision.timelineNote).toContain('latest checkpoint run_1:cp:002:codex');
+  });
+
+  it('supports explicit checkpoint selection by checkpointId', () => {
+    const first = buildCheckpoint(1);
+    const second = buildCheckpoint(2);
+    const decision = resolveRetryRecoveryDecision(buildRun([first, second]), {
+      recoveryMode: 'latest_checkpoint',
+      checkpointId: first.checkpointId
+    });
+
+    expect(decision.strategy).toBe('checkpoint');
+    if (decision.strategy !== 'checkpoint') {
+      return;
+    }
+    expect(decision.resumedFromCheckpointId).toBe(first.checkpointId);
+    expect(decision.resumedFromCommitSha).toBe(first.commitSha);
+    expect(decision.timelineNote).toContain(first.checkpointId);
+  });
+
+  it('falls back to fresh mode with deterministic note when explicit checkpoint is missing', () => {
+    const decision = resolveRetryRecoveryDecision(buildRun([buildCheckpoint(1)]), {
+      recoveryMode: 'latest_checkpoint',
+      checkpointId: 'missing-checkpoint'
+    });
+
+    expect(decision).toMatchObject({
+      strategy: 'fresh',
+      timelineNote: 'Checkpoint recovery unavailable (reason=checkpoint_not_found, checkpointId=missing-checkpoint); falling back to fresh retry from standard source resolution.'
+    });
+  });
+
+  it('falls back to fresh mode with deterministic note when no checkpoints exist', () => {
+    const decision = resolveRetryRecoveryDecision(buildRun([]));
+
+    expect(decision).toMatchObject({
+      strategy: 'fresh',
+      timelineNote: 'Checkpoint recovery unavailable (reason=no_checkpoints); falling back to fresh retry from standard source resolution.'
+    });
+  });
+});

--- a/src/server/shared/retry-recovery.ts
+++ b/src/server/shared/retry-recovery.ts
@@ -1,0 +1,98 @@
+import type { RetryRunInput } from '../../ui/domain/api';
+import type { AgentRun, RunCheckpoint } from '../../ui/domain/types';
+
+export type RetryRecoveryDecision =
+  | {
+      strategy: 'checkpoint';
+      checkpoint: RunCheckpoint;
+      resumedFromCheckpointId: string;
+      resumedFromCommitSha: string;
+      timelineNote: string;
+    }
+  | {
+      strategy: 'fresh';
+      timelineNote: string;
+    };
+
+export function resolveRetryRecoveryDecision(
+  run: Pick<AgentRun, 'checkpoints'>,
+  input?: RetryRunInput
+): RetryRecoveryDecision {
+  const recoveryMode = input?.recoveryMode ?? 'latest_checkpoint';
+  if (recoveryMode === 'fresh') {
+    return {
+      strategy: 'fresh',
+      timelineNote: 'Retry mode set to fresh; starting from standard source resolution.'
+    };
+  }
+
+  const checkpoints = normalizeCheckpoints(run.checkpoints);
+  if (!checkpoints.length) {
+    return {
+      strategy: 'fresh',
+      timelineNote: 'Checkpoint recovery unavailable (reason=no_checkpoints); falling back to fresh retry from standard source resolution.'
+    };
+  }
+
+  if (input?.checkpointId) {
+    const explicit = checkpoints.find((checkpoint) => checkpoint.checkpointId === input.checkpointId);
+    if (!explicit) {
+      return {
+        strategy: 'fresh',
+        timelineNote: `Checkpoint recovery unavailable (reason=checkpoint_not_found, checkpointId=${input.checkpointId}); falling back to fresh retry from standard source resolution.`
+      };
+    }
+    return {
+      strategy: 'checkpoint',
+      checkpoint: explicit,
+      resumedFromCheckpointId: explicit.checkpointId,
+      resumedFromCommitSha: explicit.commitSha,
+      timelineNote: `Retry recovering from checkpoint ${explicit.checkpointId} at commit ${shortSha(explicit.commitSha)}.`
+    };
+  }
+
+  const latest = selectLatestCheckpoint(checkpoints);
+  if (!latest) {
+    return {
+      strategy: 'fresh',
+      timelineNote: 'Checkpoint recovery unavailable (reason=no_checkpoints); falling back to fresh retry from standard source resolution.'
+    };
+  }
+
+  return {
+    strategy: 'checkpoint',
+    checkpoint: latest,
+    resumedFromCheckpointId: latest.checkpointId,
+    resumedFromCommitSha: latest.commitSha,
+    timelineNote: `Retry recovering from latest checkpoint ${latest.checkpointId} at commit ${shortSha(latest.commitSha)}.`
+  };
+}
+
+function normalizeCheckpoints(checkpoints: AgentRun['checkpoints']) {
+  if (!Array.isArray(checkpoints)) {
+    return [];
+  }
+  return checkpoints.filter((checkpoint): checkpoint is RunCheckpoint => Boolean(checkpoint));
+}
+
+function selectLatestCheckpoint(checkpoints: RunCheckpoint[]) {
+  let latest: RunCheckpoint | undefined;
+  for (const checkpoint of checkpoints) {
+    if (!latest) {
+      latest = checkpoint;
+      continue;
+    }
+    if (checkpoint.createdAt > latest.createdAt) {
+      latest = checkpoint;
+      continue;
+    }
+    if (checkpoint.createdAt === latest.createdAt && checkpoint.checkpointId > latest.checkpointId) {
+      latest = checkpoint;
+    }
+  }
+  return latest;
+}
+
+function shortSha(commitSha: string) {
+  return commitSha.slice(0, 12);
+}

--- a/src/server/shared/run-source-resolution.test.ts
+++ b/src/server/shared/run-source-resolution.test.ts
@@ -59,6 +59,30 @@ describe('resolveRunSource', () => {
     expect(source.dependencyContext.sourceMode).toBe('explicit_source_ref');
   });
 
+  it('prefers explicit source override over task source ref and dependencies', () => {
+    const upstreamTask = buildTask('task_up', { status: 'REVIEW' });
+    const downstreamTask = buildTask('task_down', {
+      sourceRef: 'feature/task-source',
+      dependencies: [{ upstreamTaskId: 'task_up', mode: 'review_ready' }]
+    });
+    const upstreamRun = buildRun('task_up', 'WAITING_PREVIEW', { headSha: 'a'.repeat(40), prNumber: 11 });
+
+    const source = resolveRunSource({
+      task: downstreamTask,
+      tasks: [upstreamTask, downstreamTask],
+      runs: [upstreamRun],
+      defaultBranch: 'main',
+      resolvedAt,
+      sourceRefOverride: 'b'.repeat(40)
+    });
+
+    expect(source.branchSource).toMatchObject({
+      kind: 'explicit_source_ref',
+      resolvedRef: 'b'.repeat(40)
+    });
+    expect(source.dependencyContext.sourceMode).toBe('explicit_source_ref');
+  });
+
   it('uses dependency review head when no explicit source exists', () => {
     const upstreamTask = buildTask('task_up', { status: 'REVIEW' });
     const downstreamTask = buildTask('task_down', {

--- a/src/server/shared/run-source-resolution.ts
+++ b/src/server/shared/run-source-resolution.ts
@@ -8,6 +8,7 @@ type ResolveRunSourceInput = {
   runs: AgentRun[];
   defaultBranch: string;
   resolvedAt: string;
+  sourceRefOverride?: string;
 };
 
 type ResolvedRunSource = {
@@ -20,8 +21,23 @@ export function resolveRunSource({
   tasks,
   runs,
   defaultBranch,
-  resolvedAt
+  resolvedAt,
+  sourceRefOverride
 }: ResolveRunSourceInput): ResolvedRunSource {
+  const explicitSourceRefOverride = sourceRefOverride?.trim();
+  if (explicitSourceRefOverride) {
+    return {
+      branchSource: {
+        kind: 'explicit_source_ref',
+        resolvedRef: explicitSourceRefOverride,
+        resolvedAt
+      },
+      dependencyContext: {
+        sourceMode: 'explicit_source_ref'
+      }
+    };
+  }
+
   const explicitSourceRef = task.sourceRef?.trim();
   if (explicitSourceRef) {
     return {

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -229,7 +229,7 @@ export default function App({ api: providedApi }: { api?: AgentBoardApi }) {
   async function retryRun(runId: string) {
     const run = await api.retryRun(runId);
     await api.setSelectedTaskId(run.taskId);
-    setNotice('Started a fresh run.');
+    setNotice('Started retry run.');
   }
 
   async function rerunReview(runId: string) {

--- a/src/ui/api/http-agent-board-api.ts
+++ b/src/ui/api/http-agent-board-api.ts
@@ -15,6 +15,7 @@ import type {
   CreateUserApiTokenResult,
   InviteRecord,
   RequestRunChangesInput,
+  RetryRunInput,
   UpdateRepoInput,
   UpdateTaskInput,
   UserApiTokenRecord,
@@ -269,8 +270,11 @@ export class HttpAgentBoardApi implements AgentBoardApi {
     return run;
   }
 
-  async retryRun(runId: string) {
-    const run = await this.request<AgentRun>(`/api/runs/${encodeURIComponent(runId)}/retry`, { method: 'POST' });
+  async retryRun(runId: string, input?: RetryRunInput) {
+    const run = await this.request<AgentRun>(`/api/runs/${encodeURIComponent(runId)}/retry`, {
+      method: 'POST',
+      ...(input ? { body: JSON.stringify(input) } : {})
+    });
     await this.refresh();
     return run;
   }

--- a/src/ui/domain/api.ts
+++ b/src/ui/domain/api.ts
@@ -146,6 +146,11 @@ export type RequestRunChangesInput = {
   reviewSelection?: RequestRunChangesSelection;
 };
 
+export type RetryRunInput = {
+  recoveryMode?: 'latest_checkpoint' | 'fresh';
+  checkpointId?: string;
+};
+
 export type AuthSession = {
   user: User;
   memberships: TenantMember[];
@@ -243,7 +248,7 @@ export interface AgentBoardApi {
   updateTask(taskId: string, patch: UpdateTaskInput): Promise<Task>;
   startRun(taskId: string): Promise<AgentRun>;
   getRun(runId: string): Promise<AgentRun>;
-  retryRun(runId: string): Promise<AgentRun>;
+  retryRun(runId: string, input?: RetryRunInput): Promise<AgentRun>;
   rerunReview(runId: string): Promise<AgentRun>;
   requestRunChanges(runId: string, input: RequestRunChangesInput): Promise<AgentRun>;
   retryPreview(runId: string): Promise<AgentRun>;

--- a/src/ui/mock/local-agent-board-api.ts
+++ b/src/ui/mock/local-agent-board-api.ts
@@ -15,6 +15,7 @@ import type {
   CreateUserApiTokenResult,
   InviteRecord,
   RequestRunChangesInput,
+  RetryRunInput,
   UpdateRepoInput,
   UpdateTaskInput,
   UserApiTokenRecord,
@@ -658,7 +659,7 @@ export class LocalAgentBoardApi implements AgentBoardApi {
     return run;
   }
 
-  async retryRun(runId: string): Promise<AgentRun> {
+  async retryRun(runId: string, _input?: RetryRunInput): Promise<AgentRun> {
     const run = await this.getRun(runId);
     const task = this.store.getSnapshot().tasks.find((candidate) => candidate.taskId === run.taskId);
     if (!task) {


### PR DESCRIPTION
Task: C3 - Retry Recovery from Latest Checkpoint

Extend retry semantics to restore from latest checkpoint by default with explicit fallback behavior.
Source ref: main

Acceptance criteria:
- Retry defaults to latest checkpoint when available.
- Recovery provenance is stored on retried run.
- Fresh fallback path is deterministic and logged when checkpoint is unavailable.

Run ID: run_repo_abuiles_agents_kanban_mmc6bki5nn53