### PR TITLE
C4 - Review Prep Cleanup and First-Review Squash

### DIFF
--- a/src/server/run-orchestrator.llm.test.ts
+++ b/src/server/run-orchestrator.llm.test.ts
@@ -174,8 +174,23 @@ function buildSandbox(events: SandboxEvent[]): FakeSandbox {
       if (command.includes('git rev-parse origin/main')) {
         return { success: true, exitCode: 0, stdout: 'a'.repeat(40) };
       }
+      if (command.includes('git merge-base HEAD origin/main')) {
+        return { success: true, exitCode: 0, stdout: 'a'.repeat(40) };
+      }
       if (command.includes('git rev-parse HEAD')) {
         return { success: true, exitCode: 0, stdout: currentHead.value };
+      }
+      if (command.includes('git reset --soft')) {
+        currentHead.value = 'a'.repeat(40);
+        this.currentHead = currentHead.value;
+        return { success: true, exitCode: 0, stdout: '' };
+      }
+      if (command.includes('git cat-file -e HEAD:')) {
+        return {
+          success: false,
+          exitCode: 128,
+          stderr: 'fatal: path does not exist in HEAD'
+        };
       }
       if (command.includes('git add -A && git commit -m')) {
         currentHead.value = 'b'.repeat(40);
@@ -906,7 +921,7 @@ describe('executeRunJob LLM adapter coverage', () => {
     sandbox.exec = async (command) => {
       if (command.includes('git status --short')) {
         statusCall += 1;
-        if (statusCall === 2) {
+        if (statusCall === 2 || statusCall === 4) {
           return { success: true, exitCode: 0, stdout: 'M src/index.ts\n' };
         }
         return { success: true, exitCode: 0, stdout: '' };
@@ -926,8 +941,13 @@ describe('executeRunJob LLM adapter coverage', () => {
       contextNotesPath: '.agentskanban/context/run-context.md'
     });
     expect(harness.events.some((event) => event.eventType === 'run.checkpoint.created')).toBe(true);
+    expect(harness.events.some((event) => event.eventType === 'run.review_prep.context_cleaned')).toBe(true);
+    expect(harness.events.some((event) => event.eventType === 'run.review_prep.squashed')).toBe(true);
     expect(harness.getRun().timeline.some((entry) => entry.note?.includes('Checkpoint created (codex):'))).toBe(true);
-    expect(harness.commands.filter((command) => command.command.includes('git add -A && git commit -m')).length).toBe(1);
+    expect(harness.getRun().timeline.some((entry) => entry.note?.includes('Review prep removed checkpoint context notes'))).toBe(true);
+    expect(harness.getRun().timeline.some((entry) => entry.note?.includes('Review prep squashed 1 checkpoint commit'))).toBe(true);
+    expect(harness.commands.some((command) => command.command.includes('git reset --soft'))).toBe(true);
+    expect(harness.commands.filter((command) => command.command.includes('git add -A && git commit -m')).length).toBe(2);
     expect(sandbox.writes).toContainEqual({
       path: '/workspace/repo/.agentskanban/context/run-context.md',
       contents: [
@@ -1001,6 +1021,113 @@ describe('executeRunJob LLM adapter coverage', () => {
     expect(harness.events.some((event) => event.eventType === 'run.checkpoint.created')).toBe(false);
     expect(sandbox.writes.some((entry) => entry.path.includes('.agentskanban/context/run-context.md'))).toBe(false);
     expect(harness.commands.some((command) => command.command.includes('agentskanban checkpoint'))).toBe(false);
+  });
+
+  it('prepares first review push with context cleanup and checkpoint-history squash', async () => {
+    const task = buildTask();
+    const repo = buildRepo({
+      checkpointConfig: {
+        enabled: true,
+        triggerMode: 'phase_boundary',
+        contextNotes: {
+          enabled: true,
+          filePath: '.agentskanban/context/run-context.md',
+          cleanupBeforeReview: true
+        },
+        reviewPrep: {
+          squashBeforeFirstReviewOpen: true,
+          rewriteOnChangeRequestRerun: false
+        }
+      }
+    });
+    const harness = createHarness(task, repo);
+    const sandbox = buildSandbox([
+      { type: 'stdout', data: 'Applied fix.\n' },
+      { type: 'exit', exitCode: 0 }
+    ]);
+    const baseExec = sandbox.exec.bind(sandbox);
+    let statusCall = 0;
+    sandbox.exec = async (command) => {
+      if (command.includes('git status --short')) {
+        statusCall += 1;
+        if (statusCall === 2 || statusCall === 4) {
+          return { success: true, exitCode: 0, stdout: 'M src/index.ts\n' };
+        }
+        return { success: true, exitCode: 0, stdout: '' };
+      }
+      return baseExec(command);
+    };
+    sandboxState.current = sandbox;
+
+    await executeRunJob(harness.env, { tenantId: 'tenant_legacy', repoId: repo.repoId, taskId: task.taskId, runId: 'run_1', mode: 'full_run' }, async () => {});
+
+    expect(harness.getRun().status).toBe('DONE');
+    expect(harness.getRun().checkpoints).toHaveLength(1);
+    expect(harness.commands.some((command) => command.command.includes('git ls-files --error-unmatch .agentskanban/context/run-context.md'))).toBe(true);
+    expect(harness.commands.some((command) => command.command.includes('rm -f .agentskanban/context/run-context.md'))).toBe(true);
+    expect(harness.commands.some((command) => command.command.includes('git merge-base HEAD origin/main'))).toBe(true);
+    expect(harness.commands.some((command) => command.command.includes('git reset --soft'))).toBe(true);
+    expect(harness.commands.some((command) => command.command.includes('git cat-file -e HEAD:.agentskanban/context/run-context.md'))).toBe(true);
+    expect(harness.events.some((event) => event.eventType === 'run.review_prep.context_cleaned')).toBe(true);
+    expect(harness.events.some((event) => event.eventType === 'run.review_prep.squashed')).toBe(true);
+  });
+
+  it('preserves no-rewrite behavior for change-request reruns on existing review branches', async () => {
+    const task = buildTask();
+    const repo = buildRepo({
+      checkpointConfig: {
+        enabled: true,
+        triggerMode: 'phase_boundary',
+        contextNotes: {
+          enabled: true,
+          filePath: '.agentskanban/context/run-context.md',
+          cleanupBeforeReview: true
+        },
+        reviewPrep: {
+          squashBeforeFirstReviewOpen: true,
+          rewriteOnChangeRequestRerun: false
+        }
+      }
+    });
+    const harness = createHarness(task, repo);
+    await harness.repoBoard.transitionRun('run_1', {
+      reviewUrl: 'https://github.com/abuiles/minions/pull/17',
+      reviewNumber: 17,
+      reviewProvider: 'github',
+      changeRequest: {
+        prompt: 'Please revise this change.',
+        requestedAt: '2026-03-02T01:00:00.000Z'
+      }
+    });
+
+    const sandbox = buildSandbox([
+      { type: 'stdout', data: 'Applied fix.\n' },
+      { type: 'exit', exitCode: 0 }
+    ]);
+    const baseExec = sandbox.exec.bind(sandbox);
+    let statusCall = 0;
+    sandbox.exec = async (command) => {
+      if (command.includes('git status --short')) {
+        statusCall += 1;
+        if (statusCall === 2) {
+          return { success: true, exitCode: 0, stdout: 'M src/index.ts\n' };
+        }
+        return { success: true, exitCode: 0, stdout: '' };
+      }
+      return baseExec(command);
+    };
+    sandboxState.current = sandbox;
+
+    await executeRunJob(harness.env, { tenantId: 'tenant_legacy', repoId: repo.repoId, taskId: task.taskId, runId: 'run_1', mode: 'full_run' }, async () => {});
+
+    expect(harness.getRun().status).toBe('DONE');
+    expect(harness.commands.some((command) => command.command.includes('git reset --soft'))).toBe(false);
+    expect(harness.commands.some((command) => command.command.includes('rm -f .agentskanban/context/run-context.md'))).toBe(true);
+    expect(harness.events.some((event) => event.eventType === 'run.review_prep.context_cleaned')).toBe(true);
+    expect(harness.events.some((event) => event.eventType === 'run.review_prep.squashed')).toBe(false);
+    expect(
+      harness.getRun().timeline.some((entry) => entry.note?.includes('Review prep skipped checkpoint-history squash to preserve no-rewrite'))
+    ).toBe(true);
   });
 
   it('emits partial usage entries when the run fails', async () => {

--- a/src/server/run-orchestrator.ts
+++ b/src/server/run-orchestrator.ts
@@ -289,6 +289,13 @@ export async function executeRunJob(env: Env, params: RunJobParams, sleepFn: Sle
         ]);
       }
 
+      const reviewPrepResult = await prepareReviewBranchForFirstReview({
+        repoBoard,
+        runId: params.runId,
+        repo,
+        sandbox
+      });
+
       const statusResult = await emitCommandLifecycle(repoBoard, params.runId, 'push', 'cd /workspace/repo && git status --short', () =>
         sandbox.exec('cd /workspace/repo && git status --short')
       );
@@ -446,6 +453,15 @@ export async function executeRunJob(env: Env, params: RunJobParams, sleepFn: Sle
           buildRunLog(params.runId, `Detected an existing local commit from ${llmExecutorLabel}; pushing it without creating another commit.`, 'push')
         ]);
         effectiveBranchName = await pushWithAdaptiveRecovery();
+      }
+
+      if (reviewPrepResult.mustVerifyContextFileAbsent) {
+        await verifyContextFileAbsentFromHeadOrFail({
+          repoBoard,
+          runId: params.runId,
+          sandbox,
+          contextNotesPath: reviewPrepResult.contextNotesPath
+        });
       }
 
       const shaResult = await emitCommandLifecycle(repoBoard, params.runId, 'push', 'cd /workspace/repo && git rev-parse HEAD', () =>
@@ -1233,6 +1249,129 @@ async function createPhaseBoundaryCheckpoint(input: {
       }
     )
   ]);
+}
+
+async function prepareReviewBranchForFirstReview(input: {
+  repoBoard: DurableObjectStub<RepoBoardDO>;
+  runId: string;
+  repo: Repo;
+  sandbox: ReturnType<typeof getSandbox>;
+}) {
+  const currentRun = await input.repoBoard.getRun(input.runId);
+  const normalizedRepo = normalizeRepoCheckpointConfig(input.repo);
+  const checkpointConfig = normalizedRepo.checkpointConfig;
+  if (!checkpointConfig.enabled) {
+    return { mustVerifyContextFileAbsent: false, contextNotesPath: '' };
+  }
+
+  const contextNotesPath = checkpointConfig.contextNotes.filePath;
+  const hasExistingReview = Boolean(getRunReviewUrl(currentRun) && getRunReviewNumber(currentRun));
+  const isChangeRequestRerun = Boolean(currentRun.changeRequest?.prompt && hasExistingReview);
+  const allowsHistoryRewrite = !isChangeRequestRerun || checkpointConfig.reviewPrep.rewriteOnChangeRequestRerun;
+
+  if (checkpointConfig.contextNotes.enabled && checkpointConfig.contextNotes.cleanupBeforeReview) {
+    const trackedContextFile = await emitCommandLifecycle(
+      input.repoBoard,
+      input.runId,
+      'push',
+      `cd /workspace/repo && git ls-files --error-unmatch ${shellEscape(contextNotesPath)}`,
+      () => input.sandbox.exec(`cd /workspace/repo && git ls-files --error-unmatch ${shellEscape(contextNotesPath)}`)
+    );
+    if (trackedContextFile.success) {
+      const removeContextFile = await emitCommandLifecycle(
+        input.repoBoard,
+        input.runId,
+        'push',
+        `cd /workspace/repo && rm -f ${shellEscape(contextNotesPath)}`,
+        () => input.sandbox.exec(`cd /workspace/repo && rm -f ${shellEscape(contextNotesPath)}`)
+      );
+      if (!removeContextFile.success) {
+        throw new Error(removeContextFile.stderr || `Failed to remove checkpoint context notes file ${contextNotesPath} before review.`);
+      }
+      const runAfterCleanup = await input.repoBoard.transitionRun(input.runId, {
+        appendTimelineNote: `Review prep removed checkpoint context notes (${contextNotesPath}).`
+      });
+      await input.repoBoard.appendRunEvents(input.runId, [
+        buildRunEvent(
+          runAfterCleanup,
+          'workflow',
+          'run.review_prep.context_cleaned',
+          `Removed checkpoint context notes before review push: ${contextNotesPath}.`,
+          { contextNotesPath }
+        )
+      ]);
+    }
+  }
+
+  const shouldSquashForFirstReview = checkpointConfig.reviewPrep.squashBeforeFirstReviewOpen
+    && (hasExistingReview ? allowsHistoryRewrite : true);
+  const checkpointCount = currentRun.checkpoints?.length ?? 0;
+
+  if (shouldSquashForFirstReview && checkpointCount > 0) {
+    const mergeBase = await emitCommandLifecycle(
+      input.repoBoard,
+      input.runId,
+      'push',
+      `cd /workspace/repo && git merge-base HEAD origin/${shellEscape(input.repo.defaultBranch)}`,
+      () => input.sandbox.exec(`cd /workspace/repo && git merge-base HEAD origin/${shellEscape(input.repo.defaultBranch)}`)
+    );
+    if (!mergeBase.success) {
+      throw new Error(mergeBase.stderr || `Failed to resolve merge base for review prep squash against origin/${input.repo.defaultBranch}.`);
+    }
+    const baseSha = mergeBase.stdout.trim();
+    if (!baseSha) {
+      throw new Error(`Failed to resolve merge base for review prep squash against origin/${input.repo.defaultBranch}.`);
+    }
+    const squashResult = await emitCommandLifecycle(
+      input.repoBoard,
+      input.runId,
+      'push',
+      `cd /workspace/repo && git reset --soft ${shellEscape(baseSha)}`,
+      () => input.sandbox.exec(`cd /workspace/repo && git reset --soft ${shellEscape(baseSha)}`)
+    );
+    if (!squashResult.success) {
+      throw new Error(squashResult.stderr || 'Failed to squash checkpoint commits before first review push.');
+    }
+    const runAfterSquash = await input.repoBoard.transitionRun(input.runId, {
+      appendTimelineNote: `Review prep squashed ${checkpointCount} checkpoint commit${checkpointCount === 1 ? '' : 's'} before first review push.`
+    });
+    await input.repoBoard.appendRunEvents(input.runId, [
+      buildRunEvent(
+        runAfterSquash,
+        'workflow',
+        'run.review_prep.squashed',
+        `Squashed checkpoint history into a clean review-visible commit (${checkpointCount} checkpoint commit${checkpointCount === 1 ? '' : 's'}).`,
+        { checkpointCount, baseSha, hasExistingReview }
+      )
+    ]);
+  } else if (hasExistingReview && isChangeRequestRerun && checkpointConfig.reviewPrep.squashBeforeFirstReviewOpen && !allowsHistoryRewrite) {
+    await input.repoBoard.transitionRun(input.runId, {
+      appendTimelineNote: 'Review prep skipped checkpoint-history squash to preserve no-rewrite change-request rerun semantics.'
+    });
+  }
+
+  return {
+    mustVerifyContextFileAbsent: checkpointConfig.contextNotes.enabled && checkpointConfig.contextNotes.cleanupBeforeReview,
+    contextNotesPath
+  };
+}
+
+async function verifyContextFileAbsentFromHeadOrFail(input: {
+  repoBoard: DurableObjectStub<RepoBoardDO>;
+  runId: string;
+  sandbox: ReturnType<typeof getSandbox>;
+  contextNotesPath: string;
+}) {
+  const contextInHead = await emitCommandLifecycle(
+    input.repoBoard,
+    input.runId,
+    'push',
+    `cd /workspace/repo && git cat-file -e HEAD:${shellEscape(input.contextNotesPath)}`,
+    () => input.sandbox.exec(`cd /workspace/repo && git cat-file -e HEAD:${shellEscape(input.contextNotesPath)}`)
+  );
+  if (contextInHead.success) {
+    throw new Error(`Checkpoint context notes file ${input.contextNotesPath} must be absent from the review-visible HEAD commit.`);
+  }
 }
 
 function buildCheckpointId(runId: string, phase: 'bootstrap' | 'codex' | 'tests' | 'push', sequence: number) {

--- a/src/ui/domain/types.ts
+++ b/src/ui/domain/types.ts
@@ -227,6 +227,8 @@ export type RunPreviewResolution = {
 export type RunEventType =
   | 'run.status_changed'
   | 'run.checkpoint.created'
+  | 'run.review_prep.context_cleaned'
+  | 'run.review_prep.squashed'
   | 'command.started'
   | 'command.completed'
   | 'log.appended'


### PR DESCRIPTION
Task: C4 - Review Prep Cleanup and First-Review Squash

Clean context notes before review and squash checkpoint history for first review-open/update while preserving no-rewrite reruns.
Source ref: main

Acceptance criteria:
- First review open/update uses clean squashed commit history.
- Context notes file is not present in first review-visible commit.
- Change-request reruns do not rewrite history.

Run ID: run_repo_abuiles_agents_kanban_mmc6mbzbdwm8