### PR TITLE
C5 - Checkpoint APIs and UI Surfaces

### DIFF
--- a/.agentskanban/context/run-context.md
+++ b/.agentskanban/context/run-context.md
@@ -1,0 +1,27 @@
+# AgentsKanban Run Context
+
+runId: run_repo_abuiles_agents_kanban_mmc6uzihy649
+taskId: task_repo_abuiles_agents_kanban_fzuugonb
+repoId: repo_abuiles_agents_kanban
+repoSlug: abuiles/agents-kanban
+branchName: agent/task_repo_abuiles_agents_kanban_fzuugonb/run_repo_abuiles_agents_kanban_mmc6uzihy649
+checkpointSequence: 001
+checkpointPhase: codex
+contextNotesPath: .agentskanban/context/run-context.md
+
+Task:
+- title: C5 - Checkpoint APIs and UI Surfaces
+- prompt: Implement C5 from docs/plans/current/p8-checkpoint-recovery-and-context-notes.md.\n\nHard gates:\n- Start from main.\n- Do not begin until C4 is merged to main.\n\nRequired outcomes:\n1. Add GET /api/runs/:runId/checkpoints.\n2. Add GET /api/tasks/:taskId/checkpoints?latest=true.\n3. Add UI checkpoint list for run/task detail surfaces.\n4. Show resumed-from checkpoint indicators.\n5. Add tests for endpoint contracts and UI states.\n\nAdditional requirement:\n- Before pushing the branch, run `yarn typecheck` and fix all issues.
+
+Acceptance Criteria:
+- Operators can list checkpoints for runs and tasks.
+- UI clearly shows checkpoint and resumed-from metadata.
+- API responses are deterministic and backward compatible.
+
+Notes:
+- C chain is blocked on completion of current active batch: T6 + AR6 + S6 review-ready.
+
+Links:
+- P8 Plan: https://github.com/abuiles/agents-kanban/blob/main/docs/plans/current/p8-checkpoint-recovery-and-context-notes.md
+- P8 Task Pack: https://github.com/abuiles/agents-kanban/blob/main/docs/plans/current/p8-agentskanban-task-payloads.md
+- Run Orchestrator: https://github.com/abuiles/agents-kanban/blob/main/src/server/run-orchestrator.ts

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -19,6 +19,7 @@ import {
   handleDeleteTask,
   handleGetRepoSentinel,
   handleGetRun,
+  handleGetRunCheckpoints,
   handleGetRunArtifacts,
   handleGetRunCommands,
   handleGetRunEvents,
@@ -28,6 +29,7 @@ import {
   handleGetRunWs,
   handleGetScmCredential,
   handleGetTask,
+  handleGetTaskCheckpoints,
   handleListApiTokens,
   handleListInvites,
   handleListRepos,
@@ -143,6 +145,9 @@ apiRouter.get('/api/tenant-usage/runs', (c: Context) => handleTenantRunUsage(c.r
 apiRouter.get('/api/tasks/:taskId', (c: Context) =>
   handleGetTask(c.req.raw, c.env as Env, { taskId: c.req.param('taskId') })
 );
+apiRouter.get('/api/tasks/:taskId/checkpoints', (c: Context) =>
+  handleGetTaskCheckpoints(c.req.raw, c.env as Env, { taskId: c.req.param('taskId') })
+);
 apiRouter.patch('/api/tasks/:taskId', (c: Context) =>
   handleUpdateTask(c.req.raw, c.env as Env, { taskId: c.req.param('taskId') })
 );
@@ -155,6 +160,9 @@ apiRouter.post('/api/tasks/:taskId/run', (c: Context) =>
 
 apiRouter.get('/api/runs/:runId', (c: Context) =>
   handleGetRun(c.req.raw, c.env as Env, { runId: c.req.param('runId') })
+);
+apiRouter.get('/api/runs/:runId/checkpoints', (c: Context) =>
+  handleGetRunCheckpoints(c.req.raw, c.env as Env, { runId: c.req.param('runId') })
 );
 apiRouter.post('/api/runs/:runId/retry', (c: Context) =>
   handleRetryRun(c.req.raw, c.env as Env, { runId: c.req.param('runId') }, c.executionCtx as unknown as ExecutionContext<unknown>)

--- a/src/server/durable/repo-board.ts
+++ b/src/server/durable/repo-board.ts
@@ -4,6 +4,7 @@ import type {
   IntegrationLoopState,
   OperatorSession,
   Repo,
+  RunCheckpoint,
   RunCommand,
   RunError,
   RunEvent,
@@ -336,6 +337,38 @@ export class RepoBoardDO extends DurableObject<Env> {
     assertTenantMatch(run.tenantId, tenantId, 'Run', runId);
 
     return run;
+  }
+
+  async getRunCheckpoints(runId: string, tenantId?: string): Promise<RunCheckpoint[]> {
+    const run = await this.getRun(runId, tenantId);
+    return cloneRunCheckpoints(run.checkpoints) ?? [];
+  }
+
+  async getTaskCheckpoints(taskId: string, options?: { latest?: boolean; tenantId?: string }): Promise<RunCheckpoint[]> {
+    await this.ready;
+    const task = this.state.tasks.find((candidate) => candidate.taskId === taskId);
+    if (!task) {
+      throw notFound(`Task ${taskId} not found.`, { taskId });
+    }
+    assertTenantMatch(task.tenantId, options?.tenantId, 'Task', taskId);
+
+    const checkpoints = this.state.runs
+      .filter((run) => run.taskId === taskId)
+      .filter((run) => !options?.tenantId || normalizeTenantId(run.tenantId) === normalizeTenantId(options.tenantId))
+      .flatMap((run) => cloneRunCheckpoints(run.checkpoints) ?? [])
+      .sort((left, right) => {
+        const byCreatedAt = right.createdAt.localeCompare(left.createdAt);
+        if (byCreatedAt !== 0) {
+          return byCreatedAt;
+        }
+        return right.checkpointId.localeCompare(left.checkpointId);
+      });
+
+    if (options?.latest) {
+      return checkpoints.slice(0, 1);
+    }
+
+    return checkpoints;
   }
 
   async retryRun(runId: string, options?: RetryRunInput & { tenantId?: string }) {

--- a/src/server/router.checkpoints.test.ts
+++ b/src/server/router.checkpoints.test.ts
@@ -1,0 +1,115 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const tenantAuthDbMocks = vi.hoisted(() => ({
+  resolveSessionByToken: vi.fn(),
+  hasActiveTenantAccess: vi.fn(),
+  getTenantMembership: vi.fn(),
+  resolveApiToken: vi.fn(),
+  listUserMemberships: vi.fn()
+}));
+
+vi.mock('./tenant-auth-db', () => tenantAuthDbMocks);
+
+import { handleGetRunCheckpoints, handleGetTaskCheckpoints } from './router';
+
+function createEnv() {
+  const checkpoints = [{
+    checkpointId: 'run_repo_1_demo:cp:001:codex',
+    runId: 'run_repo_1_demo',
+    repoId: 'repo_1',
+    taskId: 'task_repo_1_demo',
+    phase: 'codex' as const,
+    commitSha: 'a'.repeat(40),
+    commitMessage: 'agentskanban checkpoint 001 (codex) [run_repo_1_demo]',
+    createdAt: '2026-03-03T12:00:00.000Z'
+  }];
+
+  const repoBoard = {
+    getRunCheckpoints: vi.fn(async () => checkpoints),
+    getTaskCheckpoints: vi.fn(async (_taskId: string, options?: { latest?: boolean }) => options?.latest ? [checkpoints[0]] : checkpoints)
+  };
+
+  const board = {
+    findRunRepoId: vi.fn(async () => 'repo_1'),
+    findTaskRepoId: vi.fn(async () => 'repo_1'),
+    getRepo: vi.fn(async () => ({
+      repoId: 'repo_1',
+      tenantId: 'tenant_local',
+      scmProvider: 'github',
+      scmBaseUrl: 'https://github.com',
+      projectPath: 'acme/demo'
+    }))
+  };
+
+  const env = {
+    BOARD_INDEX: {
+      getByName: vi.fn(() => board)
+    },
+    REPO_BOARD: {
+      getByName: vi.fn(() => repoBoard)
+    }
+  } as unknown as Env;
+
+  return { env, repoBoard };
+}
+
+describe('checkpoint read endpoints', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    tenantAuthDbMocks.resolveSessionByToken.mockResolvedValue({
+      user: { id: 'user_1' },
+      session: { id: 'sess_1', activeTenantId: 'tenant_local' }
+    });
+    tenantAuthDbMocks.hasActiveTenantAccess.mockResolvedValue(true);
+  });
+
+  it('returns run checkpoints for GET /api/runs/:runId/checkpoints', async () => {
+    const { env, repoBoard } = createEnv();
+    const response = await handleGetRunCheckpoints(
+      new Request('https://minions.example.test/api/runs/run_repo_1_demo/checkpoints', {
+        method: 'GET',
+        headers: { 'x-session-token': 'session-token' }
+      }),
+      env,
+      { runId: 'run_repo_1_demo' }
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json() as Array<{ checkpointId: string }>;
+    expect(body).toHaveLength(1);
+    expect(body[0]?.checkpointId).toBe('run_repo_1_demo:cp:001:codex');
+    expect(repoBoard.getRunCheckpoints).toHaveBeenCalledWith('run_repo_1_demo', 'tenant_local');
+  });
+
+  it('returns latest task checkpoint when latest=true', async () => {
+    const { env, repoBoard } = createEnv();
+    const response = await handleGetTaskCheckpoints(
+      new Request('https://minions.example.test/api/tasks/task_repo_1_demo/checkpoints?latest=true', {
+        method: 'GET',
+        headers: { 'x-session-token': 'session-token' }
+      }),
+      env,
+      { taskId: 'task_repo_1_demo' }
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json() as Array<{ checkpointId: string }>;
+    expect(body).toHaveLength(1);
+    expect(repoBoard.getTaskCheckpoints).toHaveBeenCalledWith('task_repo_1_demo', { latest: true, tenantId: 'tenant_local' });
+  });
+
+  it('returns full task checkpoint list when latest query is omitted', async () => {
+    const { env, repoBoard } = createEnv();
+    const response = await handleGetTaskCheckpoints(
+      new Request('https://minions.example.test/api/tasks/task_repo_1_demo/checkpoints', {
+        method: 'GET',
+        headers: { 'x-session-token': 'session-token' }
+      }),
+      env,
+      { taskId: 'task_repo_1_demo' }
+    );
+
+    expect(response.status).toBe(200);
+    expect(repoBoard.getTaskCheckpoints).toHaveBeenCalledWith('task_repo_1_demo', { latest: false, tenantId: 'tenant_local' });
+  });
+});

--- a/src/server/router.ts
+++ b/src/server/router.ts
@@ -913,6 +913,19 @@ export async function handleGetTask(request: Request, env: Env, params: RoutePar
   });
 }
 
+export async function handleGetTaskCheckpoints(request: Request, env: Env, params: RouteParams): Promise<Response> {
+  return withApiError(async () => {
+    const url = new URL(request.url);
+    const board = getBoard(env);
+    const requestContext = await resolveRequestTenantContext(env, board, request, { requireSession: true });
+    const taskId = parsePathParam(params.taskId);
+    const repoId = await resolveRepoIdForTask(board, taskId);
+    await assertRepoAccess(env, board, requestContext, repoId);
+    const latest = url.searchParams.get('latest') === 'true';
+    return json(await env.REPO_BOARD.getByName(repoId).getTaskCheckpoints(taskId, { latest, tenantId: requestContext.activeTenantId }));
+  });
+}
+
 export async function handleUpdateTask(request: Request, env: Env, params: RouteParams): Promise<Response> {
   return withApiError(async () => {
     const board = getBoard(env);
@@ -966,6 +979,17 @@ export async function handleGetRun(request: Request, env: Env, params: RoutePara
     const repoId = await resolveRepoIdForRun(board, runId);
     await assertRepoAccess(env, board, requestContext, repoId);
     return json(await env.REPO_BOARD.getByName(repoId).getRun(runId, requestContext.activeTenantId));
+  });
+}
+
+export async function handleGetRunCheckpoints(request: Request, env: Env, params: RouteParams): Promise<Response> {
+  return withApiError(async () => {
+    const board = getBoard(env);
+    const requestContext = await resolveRequestTenantContext(env, board, request, { requireSession: true });
+    const runId = parsePathParam(params.runId);
+    const repoId = await resolveRepoIdForRun(board, runId);
+    await assertRepoAccess(env, board, requestContext, repoId);
+    return json(await env.REPO_BOARD.getByName(repoId).getRunCheckpoints(runId, requestContext.activeTenantId));
   });
 }
 

--- a/src/ui/api/http-agent-board-api.ts
+++ b/src/ui/api/http-agent-board-api.ts
@@ -21,7 +21,7 @@ import type {
   UserApiTokenRecord,
   UpsertScmCredentialInput
 } from '../domain/api';
-import type { AgentRun, BoardSnapshotV1, OperatorSession, Repo, RunCommand, RunEvent, RunLogEntry, ScmCredential, Task, TaskDetail, TerminalBootstrap } from '../domain/types';
+import type { AgentRun, BoardSnapshotV1, OperatorSession, Repo, RunCheckpoint, RunCommand, RunEvent, RunLogEntry, ScmCredential, Task, TaskDetail, TerminalBootstrap } from '../domain/types';
 import { getTaskDetail } from '../domain/selectors';
 import { parseBoardSnapshot } from '../store/board-snapshot';
 import { UiPreferencesStore } from '../store/ui-preferences-store';
@@ -252,6 +252,11 @@ export class HttpAgentBoardApi implements AgentBoardApi {
     return detail;
   }
 
+  async getTaskCheckpoints(taskId: string, options?: { latest?: boolean }) {
+    const search = options?.latest ? '?latest=true' : '';
+    return this.request<RunCheckpoint[]>(`/api/tasks/${encodeURIComponent(taskId)}/checkpoints${search}`);
+  }
+
   async updateTask(taskId: string, patch: UpdateTaskInput) {
     const task = await this.request<Task>(`/api/tasks/${encodeURIComponent(taskId)}`, { method: 'PATCH', body: JSON.stringify(patch) });
     await this.refresh();
@@ -268,6 +273,10 @@ export class HttpAgentBoardApi implements AgentBoardApi {
     const run = await this.request<AgentRun>(`/api/runs/${encodeURIComponent(runId)}`);
     this.mergeRun(run);
     return run;
+  }
+
+  async getRunCheckpoints(runId: string) {
+    return this.request<RunCheckpoint[]>(`/api/runs/${encodeURIComponent(runId)}/checkpoints`);
   }
 
   async retryRun(runId: string, input?: RetryRunInput) {

--- a/src/ui/components/DetailPanel.test.tsx
+++ b/src/ui/components/DetailPanel.test.tsx
@@ -244,6 +244,54 @@ describe('DetailPanel', () => {
     expect(screen.getByText('Cursor CLI does not advertise resumable takeover for this run.')).toBeInTheDocument();
   });
 
+  it('renders checkpoint list and resumed-from indicator on latest run', () => {
+    const props = buildProps();
+    props.detail = {
+      ...props.detail,
+      runs: [{
+        ...props.detail.runs[0],
+        checkpoints: [{
+          checkpointId: 'run_demo:cp:001:codex',
+          runId: 'run_demo',
+          repoId: 'repo_demo',
+          taskId: 'task_demo',
+          phase: 'codex',
+          commitSha: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+          commitMessage: 'agentskanban checkpoint 001 (codex) [run_demo]',
+          createdAt: '2026-03-01T00:01:00.000Z'
+        }]
+      }],
+      latestRun: {
+        ...props.detail.latestRun!,
+        checkpoints: [{
+          checkpointId: 'run_demo:cp:001:codex',
+          runId: 'run_demo',
+          repoId: 'repo_demo',
+          taskId: 'task_demo',
+          phase: 'codex',
+          commitSha: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+          commitMessage: 'agentskanban checkpoint 001 (codex) [run_demo]',
+          createdAt: '2026-03-01T00:01:00.000Z'
+        }],
+        resumedFromCheckpointId: 'run_demo:cp:001:codex',
+        resumedFromCommitSha: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+      }
+    };
+
+    render(<DetailPanel {...props} />);
+
+    expect(screen.getByText('Resumed from checkpoint')).toBeInTheDocument();
+    expect(screen.getAllByText('resumed-from').length).toBeGreaterThan(0);
+    expect(screen.getByText(/run_demo:cp:001:codex · codex · aaaaaaaa/)).toBeInTheDocument();
+  });
+
+  it('renders empty checkpoint states when metadata is absent', () => {
+    render(<DetailPanel {...buildProps()} />);
+
+    expect(screen.getByText('No checkpoints recorded on this run.')).toBeInTheDocument();
+    expect(screen.getByText('No checkpoints recorded for this task yet.')).toBeInTheDocument();
+  });
+
   it('routes edit task clicks to the edit handler', async () => {
     const user = userEvent.setup();
     const onEditTask = vi.fn();

--- a/src/ui/components/DetailPanel.tsx
+++ b/src/ui/components/DetailPanel.tsx
@@ -34,6 +34,13 @@ function compactUrl(value: string) {
   }
 }
 
+function shortSha(value?: string) {
+  if (!value) {
+    return '—';
+  }
+  return value.slice(0, 8);
+}
+
 function statusTone(status: string) {
   if (status === 'FAILED') return 'border-rose-500/25 bg-rose-500/10 text-rose-100';
   if (status === 'DONE') return 'border-emerald-500/25 bg-emerald-500/10 text-emerald-100';
@@ -151,6 +158,17 @@ export function DetailPanel({
   const latestCommands = latestRun ? commands.filter((command) => command.runId === latestRun.runId) : [];
   const latestEvents = latestRun ? events.filter((event) => event.runId === latestRun.runId) : [];
   const currentCommand = latestRun?.currentCommandId ? latestCommands.find((command) => command.id === latestRun.currentCommandId) : undefined;
+  const latestRunCheckpoints = latestRun?.checkpoints ?? [];
+  const taskCheckpoints = detail.runs
+    .flatMap((run) => run.checkpoints ?? [])
+    .sort((left, right) => {
+      const byCreatedAt = right.createdAt.localeCompare(left.createdAt);
+      if (byCreatedAt !== 0) {
+        return byCreatedAt;
+      }
+      return right.checkpointId.localeCompare(left.checkpointId);
+    });
+  const latestTaskCheckpoint = taskCheckpoints[0];
 
   async function copyLogs() {
     if (!canCopyLogs) {
@@ -314,6 +332,13 @@ export function DetailPanel({
                 <div className="text-[11px] uppercase tracking-[0.16em] text-slate-500">Reasoning</div>
                 <code className="mt-1 block break-all text-xs text-slate-200">{latestRun.llmReasoningEffort ?? taskLlmReasoningEffort}</code>
               </div>
+              {latestRun.resumedFromCheckpointId || latestRun.resumedFromCommitSha ? (
+                <div className="rounded-lg border border-cyan-500/30 bg-cyan-500/10 px-3 py-2 sm:col-span-2">
+                  <div className="text-[11px] uppercase tracking-[0.16em] text-cyan-200">Resumed from checkpoint</div>
+                  <div className="mt-1 text-xs text-cyan-50">{latestRun.resumedFromCheckpointId ?? 'unknown checkpoint'}</div>
+                  <div className="mt-1 text-xs text-cyan-100/80">Commit {shortSha(latestRun.resumedFromCommitSha)}</div>
+                </div>
+              ) : null}
             </div>
             <div className="rounded-lg border border-slate-800 bg-slate-900/70 p-3">
               <div className="mb-2 flex items-center justify-between gap-3">
@@ -399,6 +424,28 @@ export function DetailPanel({
                   )}
                 </div>
               ) : null}
+            </div>
+
+            <div className="rounded-lg border border-slate-800 bg-slate-900/70 p-3">
+              <div className="mb-2 text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-500">Checkpoints</div>
+              <div className="space-y-2">
+                {latestRunCheckpoints.length ? latestRunCheckpoints.map((checkpoint) => (
+                  <div key={checkpoint.checkpointId} className="rounded-lg border border-slate-800 bg-slate-950/70 px-3 py-2">
+                    <div className="flex items-center justify-between gap-3 text-xs text-slate-400">
+                      <span>{checkpoint.phase}</span>
+                      <span title={formatTimestamp(checkpoint.createdAt)}>{formatRelativeTime(checkpoint.createdAt)}</span>
+                    </div>
+                    <div className="mt-2 flex flex-wrap items-center gap-2 text-xs">
+                      <code className="text-slate-200">{shortSha(checkpoint.commitSha)}</code>
+                      {latestRun.resumedFromCheckpointId === checkpoint.checkpointId ? (
+                        <span className="rounded-full border border-cyan-500/35 bg-cyan-500/15 px-2 py-0.5 text-[10px] uppercase tracking-[0.12em] text-cyan-100">
+                          resumed-from
+                        </span>
+                      ) : null}
+                    </div>
+                  </div>
+                )) : <p className="text-sm text-slate-500">No checkpoints recorded on this run.</p>}
+              </div>
             </div>
 
             <div className="rounded-lg border border-slate-800 bg-slate-900/70 p-3">
@@ -599,6 +646,25 @@ export function DetailPanel({
                 </div>
               </div>
             ) : null}
+          </PanelSection>
+
+          <PanelSection title="Task checkpoints">
+            {latestTaskCheckpoint ? (
+              <div className="space-y-2">
+                <div className="rounded-lg border border-slate-800 bg-slate-900/70 px-3 py-2">
+                  <div className="text-[11px] uppercase tracking-[0.16em] text-slate-500">Latest checkpoint</div>
+                  <div className="mt-1 text-xs text-slate-200">
+                    {latestTaskCheckpoint.checkpointId} · {latestTaskCheckpoint.phase} · {shortSha(latestTaskCheckpoint.commitSha)}
+                  </div>
+                  <div className="mt-1 text-xs text-slate-400">{formatTimestamp(latestTaskCheckpoint.createdAt)}</div>
+                </div>
+                <div className="text-xs text-slate-500">
+                  {taskCheckpoints.length} checkpoint{taskCheckpoints.length === 1 ? '' : 's'} across {detail.runs.length} run{detail.runs.length === 1 ? '' : 's'}.
+                </div>
+              </div>
+            ) : (
+              <p className="text-sm text-slate-500">No checkpoints recorded for this task yet.</p>
+            )}
           </PanelSection>
 
           <PanelSection title="Acceptance criteria">

--- a/src/ui/domain/api.ts
+++ b/src/ui/domain/api.ts
@@ -13,6 +13,7 @@ import type {
   SentinelEvent,
   SentinelRun,
   RunCommand,
+  RunCheckpoint,
   RunEvent,
   RunLogEntry,
   ScmCredential,
@@ -245,9 +246,11 @@ export interface AgentBoardApi {
   createTask(input: CreateTaskInput): Promise<Task>;
   listTasks(filter?: { repoId?: string; tags?: string[] }): Promise<Task[]>;
   getTask(taskId: string): Promise<TaskDetail>;
+  getTaskCheckpoints(taskId: string, options?: { latest?: boolean }): Promise<RunCheckpoint[]>;
   updateTask(taskId: string, patch: UpdateTaskInput): Promise<Task>;
   startRun(taskId: string): Promise<AgentRun>;
   getRun(runId: string): Promise<AgentRun>;
+  getRunCheckpoints(runId: string): Promise<RunCheckpoint[]>;
   retryRun(runId: string, input?: RetryRunInput): Promise<AgentRun>;
   rerunReview(runId: string): Promise<AgentRun>;
   requestRunChanges(runId: string, input: RequestRunChangesInput): Promise<AgentRun>;

--- a/src/ui/mock/local-agent-board-api.ts
+++ b/src/ui/mock/local-agent-board-api.ts
@@ -21,7 +21,7 @@ import type {
   UserApiTokenRecord,
   UpsertScmCredentialInput
 } from '../domain/api';
-import type { AgentRun, Repo, RunCommand, RunEvent, RunLogEntry, ScmCredential, Task, TaskDetail, TenantMember, TerminalBootstrap, User } from '../domain/types';
+import type { AgentRun, Repo, RunCheckpoint, RunCommand, RunEvent, RunLogEntry, ScmCredential, Task, TaskDetail, TenantMember, TerminalBootstrap, User } from '../domain/types';
 import { getTaskDetail, getTasksForRepo } from '../domain/selectors';
 import { LocalBoardStore } from '../store/local-board-store';
 import { parseImportedBoard } from '../store/import-export';
@@ -592,6 +592,20 @@ export class LocalAgentBoardApi implements AgentBoardApi {
     return detail;
   }
 
+  async getTaskCheckpoints(taskId: string, options?: { latest?: boolean }): Promise<RunCheckpoint[]> {
+    const detail = await this.getTask(taskId);
+    const checkpoints = detail.runs
+      .flatMap((run) => run.checkpoints ?? [])
+      .sort((left, right) => {
+        const byCreatedAt = right.createdAt.localeCompare(left.createdAt);
+        if (byCreatedAt !== 0) {
+          return byCreatedAt;
+        }
+        return right.checkpointId.localeCompare(left.checkpointId);
+      });
+    return options?.latest ? checkpoints.slice(0, 1) : checkpoints;
+  }
+
   async updateTask(taskId: string, patch: UpdateTaskInput): Promise<Task> {
     let updatedTask: Task | undefined;
     this.store.update((snapshot) => ({
@@ -657,6 +671,11 @@ export class LocalAgentBoardApi implements AgentBoardApi {
     }
 
     return run;
+  }
+
+  async getRunCheckpoints(runId: string): Promise<RunCheckpoint[]> {
+    const run = await this.getRun(runId);
+    return [...(run.checkpoints ?? [])];
   }
 
   async retryRun(runId: string, _input?: RetryRunInput): Promise<AgentRun> {


### PR DESCRIPTION
Task: C5 - Checkpoint APIs and UI Surfaces

Expose checkpoint visibility through APIs and run/task detail UI for operators.
Source ref: main

Acceptance criteria:
- Operators can list checkpoints for runs and tasks.
- UI clearly shows checkpoint and resumed-from metadata.
- API responses are deterministic and backward compatible.

Run ID: run_repo_abuiles_agents_kanban_mmc6uzihy649