### PR TITLE
G4 - GitHub Webhook Ingestion, Verification, and Dedupe

### DIFF
--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -57,7 +57,8 @@ import {
   handleSlackCommands,
   handleSlackEvents,
   handleSlackInteractions,
-  handleGitlabWebhook
+  handleGitlabWebhook,
+  handleGithubWebhook
 } from './router';
 import { json } from './http/response';
 
@@ -90,6 +91,9 @@ apiRouter.post('/api/integrations/slack/interactions', (c: Context) =>
 );
 apiRouter.post('/api/integrations/gitlab/webhook', (c: Context) =>
   handleGitlabWebhook(c.req.raw, c.env as Env)
+);
+apiRouter.post('/api/integrations/github/webhook', (c: Context) =>
+  handleGithubWebhook(c.req.raw, c.env as Env)
 );
 apiRouter.get('/api/board/ws', (c: Context) => handleBoardWs(c.req.raw, c.env as Env));
 apiRouter.get('/api/repos', (c: Context) => handleListRepos(c.req.raw, c.env as Env));

--- a/src/server/integrations/github/handlers.test.ts
+++ b/src/server/integrations/github/handlers.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it, vi } from 'vitest';
+import { buildReviewFindingMarker } from '../../review-posting/adapter';
+
+vi.mock('../../tenant-auth-db', () => ({
+  getPrimaryTenantId: vi.fn(async () => 'tenant_local')
+}));
+
+import { handleGithubWebhook } from './handlers';
+
+class KvStore {
+  values = new Map<string, string>();
+
+  async get(key: string) {
+    return this.values.get(key) ?? null;
+  }
+
+  async put(key: string, value: string) {
+    this.values.set(key, value);
+  }
+}
+
+async function signBody(secret: string, rawBody: string) {
+  const encoder = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    'raw',
+    encoder.encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign']
+  );
+  const signature = await crypto.subtle.sign('HMAC', key, encoder.encode(rawBody));
+  const hex = [...new Uint8Array(signature)].map((byte) => byte.toString(16).padStart(2, '0')).join('');
+  return `sha256=${hex}`;
+}
+
+async function makeRequest(input: {
+  secret: string;
+  body: string;
+  eventType?: string;
+  deliveryId?: string;
+  signature?: string;
+}) {
+  const signature = input.signature ?? await signBody(input.secret, input.body);
+  return new Request('https://example.test/api/integrations/github/webhook', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'x-github-event': input.eventType ?? 'pull_request_review_comment',
+      'x-github-delivery': input.deliveryId ?? 'delivery-1',
+      'x-hub-signature-256': signature
+    },
+    body: input.body
+  });
+}
+
+function buildEnv(kv: KvStore) {
+  return {
+    SECRETS_KV: kv as unknown as KVNamespace
+  } as Env;
+}
+
+describe('github webhook handler', () => {
+  it('ingests marker-bearing review replies and persists reply-context hints', async () => {
+    const kv = new KvStore();
+    kv.values.set('github/webhook-secret', 'shared-secret');
+    const marker = buildReviewFindingMarker('rf_1', 'run_1');
+    const body = JSON.stringify({
+      action: 'created',
+      repository: { full_name: 'acme/demo' },
+      pull_request: { number: 17 },
+      comment: { id: 901, body: `${marker} Please add a stronger nil check.` }
+    });
+
+    const response = await handleGithubWebhook(await makeRequest({
+      secret: 'shared-secret',
+      body,
+      deliveryId: 'delivery-101'
+    }), buildEnv(kv));
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      status: 'accepted',
+      hintsPersisted: 1,
+      reviewNumber: 17,
+      projectPath: 'acme/demo'
+    });
+
+    const storedKey = [...kv.values.keys()].find((key) => key.startsWith('github/reply-context:tenant_local'));
+    expect(storedKey).toBeDefined();
+    const persisted = JSON.parse(kv.values.get(storedKey as string) ?? '{}') as { hints?: Array<{ body?: string; findingId?: string }> };
+    expect(persisted.hints?.[0]).toMatchObject({
+      findingId: 'rf_1',
+      body: `${marker} Please add a stronger nil check.`
+    });
+  });
+
+  it('dedupes repeated deliveries deterministically', async () => {
+    const kv = new KvStore();
+    kv.values.set('github/webhook-secret', 'shared-secret');
+    const marker = buildReviewFindingMarker('rf_1', 'run_1');
+    const body = JSON.stringify({
+      action: 'created',
+      repository: { full_name: 'acme/demo' },
+      pull_request: { number: 17 },
+      comment: { id: 901, body: `${marker} Please add tests.` }
+    });
+    const env = buildEnv(kv);
+
+    const first = await handleGithubWebhook(await makeRequest({
+      secret: 'shared-secret',
+      body,
+      deliveryId: 'delivery-duplicate'
+    }), env);
+    const second = await handleGithubWebhook(await makeRequest({
+      secret: 'shared-secret',
+      body,
+      deliveryId: 'delivery-duplicate'
+    }), env);
+
+    expect(await first.json()).toMatchObject({ status: 'accepted' });
+    expect(await second.json()).toMatchObject({ status: 'duplicate_delivery' });
+  });
+
+  it('rejects invalid signatures', async () => {
+    const kv = new KvStore();
+    kv.values.set('github/webhook-secret', 'shared-secret');
+    const marker = buildReviewFindingMarker('rf_1', 'run_1');
+    const body = JSON.stringify({
+      action: 'created',
+      repository: { full_name: 'acme/demo' },
+      pull_request: { number: 17 },
+      comment: { id: 901, body: `${marker} Please add tests.` }
+    });
+
+    const response = await handleGithubWebhook(await makeRequest({
+      secret: 'shared-secret',
+      body,
+      signature: 'sha256=deadbeef',
+      deliveryId: 'delivery-invalid'
+    }), buildEnv(kv));
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toMatchObject({
+      code: 'UNAUTHORIZED',
+      message: 'Invalid GitHub webhook signature.'
+    });
+  });
+
+  it('returns ignored for non-marker events', async () => {
+    const kv = new KvStore();
+    kv.values.set('github/webhook-secret', 'shared-secret');
+    const body = JSON.stringify({
+      action: 'created',
+      repository: { full_name: 'acme/demo' },
+      pull_request: { number: 17 },
+      comment: { id: 901, body: 'Looks good to me.' }
+    });
+
+    const response = await handleGithubWebhook(await makeRequest({
+      secret: 'shared-secret',
+      body,
+      deliveryId: 'delivery-ignored'
+    }), buildEnv(kv));
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({ status: 'ignored' });
+  });
+});

--- a/src/server/integrations/github/handlers.ts
+++ b/src/server/integrations/github/handlers.ts
@@ -1,0 +1,94 @@
+import * as tenantAuthDb from '../../tenant-auth-db';
+import { badRequest } from '../../http/errors';
+import { handleError, json } from '../../http/response';
+import { buildIdempotencyKey } from '../idempotency';
+import { normalizeGithubReplyContextEvent } from './normalize';
+import { persistGithubReplyContextHints } from './reply-context-store';
+import { verifyGithubWebhookSignature } from './verification';
+
+const DEDUPE_TTL_SECONDS = 7 * 24 * 60 * 60;
+
+async function resolveTenantId(env: Env) {
+  return tenantAuthDb.getPrimaryTenantId(env);
+}
+
+async function shouldProcessDelivery(env: Env, key: string) {
+  const existing = await env.SECRETS_KV.get(key);
+  if (existing) {
+    return false;
+  }
+  await env.SECRETS_KV.put(key, '1', { expirationTtl: DEDUPE_TTL_SECONDS });
+  return true;
+}
+
+function hashText(value: string): string {
+  let hash = 0;
+  for (let i = 0; i < value.length; i += 1) {
+    hash = ((hash << 5) - hash) + value.charCodeAt(i);
+    hash |= 0;
+  }
+  return Math.abs(hash).toString(16);
+}
+
+function readDeliveryId(request: Request, rawBody: string, normalizedProviderEventId: string) {
+  const fromHeader = request.headers.get('x-github-delivery')?.trim();
+  if (fromHeader) {
+    return fromHeader;
+  }
+  return `${normalizedProviderEventId}:${hashText(rawBody)}`;
+}
+
+function parseGithubWebhookBody(rawBody: string): unknown {
+  try {
+    return JSON.parse(rawBody) as unknown;
+  } catch {
+    throw badRequest('Invalid GitHub webhook payload.');
+  }
+}
+
+export async function handleGithubWebhook(request: Request, env: Env): Promise<Response> {
+  try {
+    const tenantId = await resolveTenantId(env);
+    const rawBody = await request.text();
+    await verifyGithubWebhookSignature(env, tenantId, request, rawBody);
+
+    const payload = parseGithubWebhookBody(rawBody);
+    const eventType = request.headers.get('x-github-event');
+    const normalized = normalizeGithubReplyContextEvent(eventType, payload);
+    if (!normalized) {
+      return json({ ok: true, status: 'ignored' });
+    }
+
+    const deliveryId = readDeliveryId(request, rawBody, normalized.providerEventId);
+    const dedupeKey = buildIdempotencyKey({
+      provider: 'github',
+      tenantId,
+      eventType: 'webhook.delivery',
+      providerEventId: deliveryId,
+      subjectId: normalized.projectPath,
+      metadata: {
+        reviewNumber: normalized.reviewNumber
+      }
+    });
+    if (!(await shouldProcessDelivery(env, dedupeKey))) {
+      return json({ ok: true, status: 'duplicate_delivery' });
+    }
+
+    const hintsPersisted = await persistGithubReplyContextHints({
+      env,
+      tenantId,
+      deliveryId,
+      normalized
+    });
+
+    return json({
+      ok: true,
+      status: 'accepted',
+      hintsPersisted,
+      reviewNumber: normalized.reviewNumber,
+      projectPath: normalized.projectPath
+    });
+  } catch (error) {
+    return handleError(error);
+  }
+}

--- a/src/server/integrations/github/normalize.test.ts
+++ b/src/server/integrations/github/normalize.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { buildReviewFindingMarker } from '../../review-posting/adapter';
+import { normalizeGithubReplyContextEvent } from './normalize';
+
+describe('normalizeGithubReplyContextEvent', () => {
+  it('normalizes pull_request_review_comment events with markers', () => {
+    const marker = buildReviewFindingMarker('rf_1', 'run_1');
+    const normalized = normalizeGithubReplyContextEvent('pull_request_review_comment', {
+      action: 'created',
+      repository: { full_name: 'acme/demo' },
+      pull_request: { number: 42 },
+      comment: { id: 10, body: `${marker} Please adjust the API validation.` }
+    });
+
+    expect(normalized).toMatchObject({
+      providerEventId: 'pull_request_review_comment:10',
+      projectPath: 'acme/demo',
+      reviewNumber: 42,
+      hints: [{ findingId: 'rf_1', runId: 'run_1' }]
+    });
+  });
+
+  it('normalizes pull_request_review events with markers', () => {
+    const marker = buildReviewFindingMarker('rf_2', 'run_9');
+    const normalized = normalizeGithubReplyContextEvent('pull_request_review', {
+      action: 'submitted',
+      repository: { full_name: 'acme/demo' },
+      pull_request: { number: 12 },
+      review: { id: 88, body: `${marker} This should be split into two checks.` }
+    });
+
+    expect(normalized).toMatchObject({
+      providerEventId: 'pull_request_review:88',
+      projectPath: 'acme/demo',
+      reviewNumber: 12,
+      hints: [{ findingId: 'rf_2', runId: 'run_9' }]
+    });
+  });
+
+  it('normalizes issue_comment events on pull requests with markers', () => {
+    const marker = buildReviewFindingMarker('rf_3', 'run_3');
+    const normalized = normalizeGithubReplyContextEvent('issue_comment', {
+      action: 'created',
+      repository: { full_name: 'acme/demo' },
+      issue: { number: 12, pull_request: { url: 'https://api.github.com/repos/acme/demo/pulls/12' } },
+      comment: { id: 51, body: `${marker} Follow-up for summary thread.` }
+    });
+
+    expect(normalized).toMatchObject({
+      providerEventId: 'issue_comment:51',
+      projectPath: 'acme/demo',
+      reviewNumber: 12,
+      hints: [{ findingId: 'rf_3', runId: 'run_3' }]
+    });
+  });
+
+  it('ignores events without supported markers', () => {
+    const normalized = normalizeGithubReplyContextEvent('pull_request_review_comment', {
+      action: 'created',
+      repository: { full_name: 'acme/demo' },
+      pull_request: { number: 42 },
+      comment: { id: 10, body: 'No marker present here.' }
+    });
+
+    expect(normalized).toBeUndefined();
+  });
+});

--- a/src/server/integrations/github/normalize.ts
+++ b/src/server/integrations/github/normalize.ts
@@ -1,0 +1,204 @@
+import { extractFindingMarkersFromText } from '../../review-posting/adapter';
+
+export type GitHubReplyContextHint = {
+  findingId: string;
+  runId?: string;
+  body: string;
+};
+
+export type NormalizedGitHubReplyEvent = {
+  providerEventId: string;
+  projectPath: string;
+  reviewNumber: number;
+  hints: GitHubReplyContextHint[];
+};
+
+type GitHubRepository = {
+  full_name?: string;
+};
+
+type GitHubPullRequest = {
+  number?: number;
+};
+
+type GitHubIssue = {
+  number?: number;
+  pull_request?: Record<string, unknown>;
+};
+
+type GitHubComment = {
+  id?: number;
+  body?: string;
+};
+
+type GitHubReview = {
+  id?: number;
+  body?: string;
+};
+
+type GitHubWebhookPayload = {
+  action?: string;
+  repository?: GitHubRepository;
+  pull_request?: GitHubPullRequest;
+  issue?: GitHubIssue;
+  comment?: GitHubComment;
+  review?: GitHubReview;
+};
+
+const REVIEW_COMMENT_ACTIONS = new Set(['created', 'edited']);
+const REVIEW_ACTIONS = new Set(['submitted', 'edited']);
+const ISSUE_COMMENT_ACTIONS = new Set(['created', 'edited']);
+
+function normalizeProjectPath(raw: string | undefined) {
+  if (!raw) {
+    return undefined;
+  }
+  const value = raw.trim().replace(/^\/+|\/+$/g, '');
+  return value || undefined;
+}
+
+function normalizeBody(body: string | undefined) {
+  const value = body?.trim();
+  if (!value) {
+    return undefined;
+  }
+  return value.slice(0, 4000);
+}
+
+function hashText(value: string): string {
+  let hash = 0;
+  for (let i = 0; i < value.length; i += 1) {
+    hash = ((hash << 5) - hash) + value.charCodeAt(i);
+    hash |= 0;
+  }
+  return Math.abs(hash).toString(16);
+}
+
+function normalizeHints(body: string) {
+  const unique = new Map<string, GitHubReplyContextHint>();
+  for (const marker of extractFindingMarkersFromText(body)) {
+    const key = `${marker.findingId}:${marker.runId}`;
+    if (!unique.has(key)) {
+      unique.set(key, {
+        findingId: marker.findingId,
+        runId: marker.runId,
+        body
+      });
+    }
+  }
+  return [...unique.values()];
+}
+
+function normalizeReviewCommentEvent(payload: GitHubWebhookPayload): NormalizedGitHubReplyEvent | undefined {
+  const action = payload.action?.toLowerCase();
+  if (!action || !REVIEW_COMMENT_ACTIONS.has(action)) {
+    return undefined;
+  }
+
+  const projectPath = normalizeProjectPath(payload.repository?.full_name);
+  const reviewNumber = payload.pull_request?.number;
+  const body = normalizeBody(payload.comment?.body);
+  if (!projectPath || !reviewNumber || !body) {
+    return undefined;
+  }
+
+  const hints = normalizeHints(body);
+  if (hints.length === 0) {
+    return undefined;
+  }
+
+  const providerEventId = payload.comment?.id
+    ? `pull_request_review_comment:${payload.comment.id}`
+    : `pull_request_review_comment:${reviewNumber}:${hashText(body)}`;
+
+  return {
+    providerEventId,
+    projectPath,
+    reviewNumber,
+    hints
+  };
+}
+
+function normalizePullRequestReviewEvent(payload: GitHubWebhookPayload): NormalizedGitHubReplyEvent | undefined {
+  const action = payload.action?.toLowerCase();
+  if (!action || !REVIEW_ACTIONS.has(action)) {
+    return undefined;
+  }
+
+  const projectPath = normalizeProjectPath(payload.repository?.full_name);
+  const reviewNumber = payload.pull_request?.number;
+  const body = normalizeBody(payload.review?.body);
+  if (!projectPath || !reviewNumber || !body) {
+    return undefined;
+  }
+
+  const hints = normalizeHints(body);
+  if (hints.length === 0) {
+    return undefined;
+  }
+
+  const providerEventId = payload.review?.id
+    ? `pull_request_review:${payload.review.id}`
+    : `pull_request_review:${reviewNumber}:${hashText(body)}`;
+
+  return {
+    providerEventId,
+    projectPath,
+    reviewNumber,
+    hints
+  };
+}
+
+function normalizeIssueCommentEvent(payload: GitHubWebhookPayload): NormalizedGitHubReplyEvent | undefined {
+  const action = payload.action?.toLowerCase();
+  if (!action || !ISSUE_COMMENT_ACTIONS.has(action)) {
+    return undefined;
+  }
+
+  if (!payload.issue?.pull_request) {
+    return undefined;
+  }
+
+  const projectPath = normalizeProjectPath(payload.repository?.full_name);
+  const reviewNumber = payload.issue?.number;
+  const body = normalizeBody(payload.comment?.body);
+  if (!projectPath || !reviewNumber || !body) {
+    return undefined;
+  }
+
+  const hints = normalizeHints(body);
+  if (hints.length === 0) {
+    return undefined;
+  }
+
+  const providerEventId = payload.comment?.id
+    ? `issue_comment:${payload.comment.id}`
+    : `issue_comment:${reviewNumber}:${hashText(body)}`;
+
+  return {
+    providerEventId,
+    projectPath,
+    reviewNumber,
+    hints
+  };
+}
+
+export function normalizeGithubReplyContextEvent(eventType: string | null, payload: unknown): NormalizedGitHubReplyEvent | undefined {
+  if (!eventType || !payload || typeof payload !== 'object') {
+    return undefined;
+  }
+
+  const normalizedEventType = eventType.trim().toLowerCase();
+  const parsedPayload = payload as GitHubWebhookPayload;
+
+  if (normalizedEventType === 'pull_request_review_comment') {
+    return normalizeReviewCommentEvent(parsedPayload);
+  }
+  if (normalizedEventType === 'pull_request_review') {
+    return normalizePullRequestReviewEvent(parsedPayload);
+  }
+  if (normalizedEventType === 'issue_comment') {
+    return normalizeIssueCommentEvent(parsedPayload);
+  }
+  return undefined;
+}

--- a/src/server/integrations/github/reply-context-store.ts
+++ b/src/server/integrations/github/reply-context-store.ts
@@ -1,0 +1,161 @@
+import type { NormalizedGitHubReplyEvent } from './normalize';
+
+const REPLY_HINT_KEY_PREFIX = 'github/reply-context';
+const REPLY_HINT_TTL_SECONDS = 90 * 24 * 60 * 60;
+const MAX_HINTS_PER_FINDING = 50;
+
+export type GithubReplyContextHintRecord = {
+  findingId: string;
+  runId?: string;
+  body: string;
+  providerEventId: string;
+  deliveryId: string;
+  recordedAt: string;
+};
+
+type PersistedReplyHintRecord = {
+  findingId: string;
+  projectPath: string;
+  reviewNumber: number;
+  updatedAt: string;
+  hints: GithubReplyContextHintRecord[];
+};
+
+function buildReplyHintStorageKey(input: {
+  tenantId: string;
+  projectPath: string;
+  reviewNumber: number;
+  findingId: string;
+}) {
+  return [
+    REPLY_HINT_KEY_PREFIX,
+    input.tenantId,
+    encodeURIComponent(input.projectPath.toLowerCase()),
+    String(input.reviewNumber),
+    encodeURIComponent(input.findingId)
+  ].join(':');
+}
+
+function parseStoredRecord(raw: string | null): PersistedReplyHintRecord | undefined {
+  if (!raw) {
+    return undefined;
+  }
+  try {
+    const parsed = JSON.parse(raw) as Partial<PersistedReplyHintRecord>;
+    if (!parsed || typeof parsed !== 'object') {
+      return undefined;
+    }
+    if (!Array.isArray(parsed.hints) || typeof parsed.findingId !== 'string' || typeof parsed.projectPath !== 'string' || typeof parsed.reviewNumber !== 'number') {
+      return undefined;
+    }
+    return {
+      findingId: parsed.findingId,
+      projectPath: parsed.projectPath,
+      reviewNumber: parsed.reviewNumber,
+      updatedAt: typeof parsed.updatedAt === 'string' ? parsed.updatedAt : new Date(0).toISOString(),
+      hints: parsed.hints
+        .filter((hint): hint is GithubReplyContextHintRecord => (
+          Boolean(hint)
+          && typeof hint === 'object'
+          && typeof hint.findingId === 'string'
+          && typeof hint.body === 'string'
+          && typeof hint.providerEventId === 'string'
+          && typeof hint.deliveryId === 'string'
+          && typeof hint.recordedAt === 'string'
+        ))
+        .map((hint) => ({
+          findingId: hint.findingId,
+          body: hint.body,
+          providerEventId: hint.providerEventId,
+          deliveryId: hint.deliveryId,
+          recordedAt: hint.recordedAt,
+          runId: typeof hint.runId === 'string' ? hint.runId : undefined
+        }))
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+function buildHintDedupeKey(hint: GithubReplyContextHintRecord) {
+  return JSON.stringify({
+    findingId: hint.findingId,
+    runId: hint.runId ?? null,
+    body: hint.body
+  });
+}
+
+export async function persistGithubReplyContextHints(input: {
+  env: Env;
+  tenantId: string;
+  deliveryId: string;
+  normalized: NormalizedGitHubReplyEvent;
+}) {
+  const recordedAt = new Date().toISOString();
+  let persistedCount = 0;
+
+  await Promise.all(input.normalized.hints.map(async (hint) => {
+    const key = buildReplyHintStorageKey({
+      tenantId: input.tenantId,
+      projectPath: input.normalized.projectPath,
+      reviewNumber: input.normalized.reviewNumber,
+      findingId: hint.findingId
+    });
+
+    const stored = parseStoredRecord(await input.env.SECRETS_KV.get(key));
+    const nextHint: GithubReplyContextHintRecord = {
+      findingId: hint.findingId,
+      runId: hint.runId,
+      body: hint.body,
+      providerEventId: input.normalized.providerEventId,
+      deliveryId: input.deliveryId,
+      recordedAt
+    };
+    const dedupeKey = buildHintDedupeKey(nextHint);
+
+    const existingHints = stored?.hints ?? [];
+    if (existingHints.some((candidate) => buildHintDedupeKey(candidate) === dedupeKey)) {
+      return;
+    }
+
+    persistedCount += 1;
+    const nextRecord: PersistedReplyHintRecord = {
+      findingId: hint.findingId,
+      projectPath: input.normalized.projectPath,
+      reviewNumber: input.normalized.reviewNumber,
+      updatedAt: recordedAt,
+      hints: [...existingHints, nextHint].slice(-MAX_HINTS_PER_FINDING)
+    };
+
+    await input.env.SECRETS_KV.put(key, JSON.stringify(nextRecord), {
+      expirationTtl: REPLY_HINT_TTL_SECONDS
+    });
+  }));
+
+  return persistedCount;
+}
+
+export async function listGithubReplyContextHints(input: {
+  env: Env;
+  tenantId: string;
+  projectPath: string;
+  reviewNumber: number;
+  findingIds: string[];
+}) {
+  const entries = await Promise.all(input.findingIds.map(async (findingId) => {
+    const key = buildReplyHintStorageKey({
+      tenantId: input.tenantId,
+      projectPath: input.projectPath,
+      reviewNumber: input.reviewNumber,
+      findingId
+    });
+    return [findingId, parseStoredRecord(await input.env.SECRETS_KV.get(key))] as const;
+  }));
+
+  return entries.reduce<Record<string, GithubReplyContextHintRecord[]>>((output, [findingId, record]) => {
+    if (record?.hints.length) {
+      output[findingId] = [...record.hints];
+    }
+    return output;
+  }, {});
+}

--- a/src/server/integrations/github/verification.test.ts
+++ b/src/server/integrations/github/verification.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import { verifyGithubWebhookSignature } from './verification';
+
+class KvStore {
+  values = new Map<string, string>();
+
+  async get(key: string) {
+    return this.values.get(key) ?? null;
+  }
+}
+
+async function signBody(secret: string, rawBody: string) {
+  const encoder = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    'raw',
+    encoder.encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign']
+  );
+  const signature = await crypto.subtle.sign('HMAC', key, encoder.encode(rawBody));
+  const hex = [...new Uint8Array(signature)].map((byte) => byte.toString(16).padStart(2, '0')).join('');
+  return `sha256=${hex}`;
+}
+
+describe('verifyGithubWebhookSignature', () => {
+  it('accepts a valid signature', async () => {
+    const kv = new KvStore();
+    kv.values.set('github/webhook-secret', 'shared-secret');
+    const rawBody = JSON.stringify({ hello: 'world' });
+
+    const request = new Request('https://example.test/api/integrations/github/webhook', {
+      method: 'POST',
+      headers: {
+        'x-hub-signature-256': await signBody('shared-secret', rawBody)
+      },
+      body: rawBody
+    });
+
+    await expect(verifyGithubWebhookSignature({ SECRETS_KV: kv as unknown as KVNamespace } as Env, 'tenant_local', request, rawBody)).resolves.toBeUndefined();
+  });
+
+  it('rejects when the signature does not match', async () => {
+    const kv = new KvStore();
+    kv.values.set('github/webhook-secret', 'shared-secret');
+    const rawBody = JSON.stringify({ hello: 'world' });
+
+    const request = new Request('https://example.test/api/integrations/github/webhook', {
+      method: 'POST',
+      headers: {
+        'x-hub-signature-256': await signBody('wrong-secret', rawBody)
+      },
+      body: rawBody
+    });
+
+    await expect(
+      verifyGithubWebhookSignature({ SECRETS_KV: kv as unknown as KVNamespace } as Env, 'tenant_local', request, rawBody)
+    ).rejects.toThrow(/Invalid GitHub webhook signature/);
+  });
+});

--- a/src/server/integrations/github/verification.ts
+++ b/src/server/integrations/github/verification.ts
@@ -1,0 +1,62 @@
+import { unauthorized } from '../../http/errors';
+
+const DEFAULT_WEBHOOK_SECRET_KEY = 'github/webhook-secret';
+const TENANT_WEBHOOK_SECRET_PREFIX = 'github/webhook-secret';
+const SIGNATURE_PREFIX = 'sha256=';
+
+function timingSafeEqual(left: string, right: string): boolean {
+  if (left.length !== right.length) {
+    return false;
+  }
+  let diff = 0;
+  for (let index = 0; index < left.length; index += 1) {
+    diff |= left.charCodeAt(index) ^ right.charCodeAt(index);
+  }
+  return diff === 0;
+}
+
+function bytesToHex(value: ArrayBuffer) {
+  return [...new Uint8Array(value)].map((byte) => byte.toString(16).padStart(2, '0')).join('');
+}
+
+async function resolveWebhookSecret(env: Env, tenantId: string) {
+  const tenantScoped = await env.SECRETS_KV.get(`${TENANT_WEBHOOK_SECRET_PREFIX}:${tenantId}`);
+  if (tenantScoped?.trim()) {
+    return tenantScoped.trim();
+  }
+  const fallback = await env.SECRETS_KV.get(DEFAULT_WEBHOOK_SECRET_KEY);
+  return fallback?.trim() || undefined;
+}
+
+async function buildExpectedSignature(secret: string, rawBody: string) {
+  const encoder = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    'raw',
+    encoder.encode(secret),
+    {
+      name: 'HMAC',
+      hash: 'SHA-256'
+    },
+    false,
+    ['sign']
+  );
+  const signature = await crypto.subtle.sign('HMAC', key, encoder.encode(rawBody));
+  return `${SIGNATURE_PREFIX}${bytesToHex(signature)}`;
+}
+
+export async function verifyGithubWebhookSignature(env: Env, tenantId: string, request: Request, rawBody: string) {
+  const expectedSecret = await resolveWebhookSecret(env, tenantId);
+  if (!expectedSecret) {
+    throw unauthorized('Missing GitHub webhook secret.');
+  }
+
+  const actualSignature = request.headers.get('x-hub-signature-256')?.trim().toLowerCase();
+  if (!actualSignature || !actualSignature.startsWith(SIGNATURE_PREFIX)) {
+    throw unauthorized('Missing GitHub webhook signature.');
+  }
+
+  const expectedSignature = (await buildExpectedSignature(expectedSecret, rawBody)).toLowerCase();
+  if (!timingSafeEqual(actualSignature, expectedSignature)) {
+    throw unauthorized('Invalid GitHub webhook signature.');
+  }
+}

--- a/src/server/integrations/idempotency.ts
+++ b/src/server/integrations/idempotency.ts
@@ -1,5 +1,5 @@
 export type IdempotencyPayload = {
-  provider: 'slack' | 'gitlab';
+  provider: 'slack' | 'gitlab' | 'github';
   tenantId: string;
   eventType: string;
   providerEventId: string;

--- a/src/server/review-posting/adapter.ts
+++ b/src/server/review-posting/adapter.ts
@@ -94,13 +94,28 @@ export function buildReviewSummaryMarker(runId: string) {
   return `<!-- agentboard-review:summary:${runId} -->`;
 }
 
-export function extractFindingIdsFromText(text: string) {
-  const ids = new Set<string>();
+export function extractFindingMarkersFromText(text: string) {
+  const markers: Array<{ findingId: string; runId: string }> = [];
+  const seen = new Set<string>();
   const matcher = new RegExp(FINDING_MARKER_RE.source, 'gi');
   for (let match = matcher.exec(text); match; match = matcher.exec(text)) {
-    if (match[1]) {
-      ids.add(match[1]);
+    if (!match[1] || !match[2]) {
+      continue;
     }
+    const key = `${match[1]}:${match[2]}`;
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    markers.push({ findingId: match[1], runId: match[2] });
+  }
+  return markers;
+}
+
+export function extractFindingIdsFromText(text: string) {
+  const ids = new Set<string>();
+  for (const marker of extractFindingMarkersFromText(text)) {
+    ids.add(marker.findingId);
   }
   return [...ids];
 }

--- a/src/server/router.ts
+++ b/src/server/router.ts
@@ -45,6 +45,7 @@ import {
   handleSlackInteractions as handleSlackInteractionsHandler
 } from './integrations/slack/handlers';
 import { handleGitlabWebhook as handleGitlabWebhookHandler } from './integrations/gitlab/handlers';
+import { handleGithubWebhook as handleGithubWebhookHandler } from './integrations/github/handlers';
 import type { AutoReviewProvider, Repo, SentinelRun } from '../ui/domain/types';
 import { getScmAdapter } from './scm/registry';
 import { getReviewPostingAdapter } from './review-posting/registry';
@@ -113,6 +114,10 @@ export async function handleSlackInteractions(request: Request, env: Env, ctx: E
 
 export async function handleGitlabWebhook(request: Request, env: Env): Promise<Response> {
   return handleGitlabWebhookHandler(request, env);
+}
+
+export async function handleGithubWebhook(request: Request, env: Env): Promise<Response> {
+  return handleGithubWebhookHandler(request, env);
 }
 
 export async function handleAuthSignup(request: Request, env: Env): Promise<Response> {


### PR DESCRIPTION
Task: G4 - GitHub Webhook Ingestion, Verification, and Dedupe

Add GitHub webhook endpoint for reply-context ingestion with signature verification and idempotent delivery handling.
Source ref: main

Acceptance criteria:
- GitHub webhook endpoint verifies signature and rejects invalid requests.
- Duplicate deliveries are deduped deterministically.
- Normalized reply context hints are persisted for downstream use.
- PR description includes all required sections.

Run ID: run_repo_abuiles_agents_kanban_mmc7va37iqtq