### PR TITLE
G5 - Reply Context Merge, Request-Changes Enrichment, Docs, and Dogfood QA

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,10 @@ AgentsKanban helps you run AI-assisted software work the same way you already ma
 ### Auto Review and Selective Change Loop
 
 - Runs can auto-trigger review when `autoReview` is enabled and the run reaches review state.
-- Review findings are posted to GitLab or Jira with marker-based idempotency.
+- Review findings are posted to GitHub, GitLab, or Jira with marker-based idempotency.
 - Operators can request changes against all findings or a selected subset (`all`, `include`, `exclude`, `freeform`).
 - Replies from providers can be included in follow-up prompts when `reviewSelection.includeReplies = true`.
+- For GitHub, reply context is merged from webhook-ingested hints (`POST /api/integrations/github/webhook`) and on-demand provider fetch with deterministic dedupe.
 - Manual reruns are available via `POST /api/runs/:runId/review`.
 
 ### Native Sentinel Orchestration

--- a/docs/features-and-api.md
+++ b/docs/features-and-api.md
@@ -13,7 +13,7 @@
 | Tasks | 2, 3 | ✅ Implemented | `GET /api/tasks?repoId=all|<repoId>`; `POST /api/tasks`; `GET /api/tasks/:taskId`; `PATCH /api/tasks/:taskId`; `DELETE /api/tasks/:taskId` | _none_ | Full task lifecycle and mutation APIs are in place. |
 | Run execution | 3, 3.1, 3.5, 6 | ✅ Implemented | `POST /api/tasks/:taskId/run`; `GET /api/runs/:runId`; `POST /api/runs/:runId/retry`; `POST /api/runs/:runId/preview`; `POST /api/runs/:runId/evidence`; `POST /api/runs/:runId/request-changes`; `POST /api/runs/:runId/review` | `GET /api/runs/:runId/audit` *(Stage 5 target)* | Runtime includes auto review on review entry, manual review rerun endpoint, stable posting and retry metadata. |
 | Checkpoint recovery | P8/C1-C6 | ✅ Implemented | `GET /api/runs/:runId/checkpoints`; `GET /api/tasks/:taskId/checkpoints?latest=true`; `POST /api/runs/:runId/retry` with optional `{ recoveryMode, checkpointId }` body | _none_ | Retry defaults to `latest_checkpoint`, recovery metadata is persisted (`resumedFromCheckpointId`, `resumedFromCommitSha`), and selection/write paths are race/idempotency hardened. |
-| Slack/Jira/GitLab integrations | P5 | ✅ Implemented (MVP) | `POST /api/integrations/slack/commands`; `POST /api/integrations/slack/events`; `POST /api/integrations/slack/interactions`; `POST /api/integrations/gitlab/webhook` | _none in MVP scope_ | Slack ingress uses signature verification + replay protection. GitLab webhook ingress uses token verification + delivery idempotency. Slack thread binding remains the primary operator surface across reruns. |
+| Slack/Jira/GitLab/GitHub integrations | P5/P9 | ✅ Implemented | `POST /api/integrations/slack/commands`; `POST /api/integrations/slack/events`; `POST /api/integrations/slack/interactions`; `POST /api/integrations/gitlab/webhook`; `POST /api/integrations/github/webhook` | _none in MVP scope_ | Slack ingress uses signature verification + replay protection. GitLab and GitHub webhook ingress paths use verification + delivery idempotency. Slack thread binding remains the primary operator surface across reruns. |
 | Logs and artifacts | 3, 4 | ✅ Implemented | `GET /api/runs/:runId/logs`; `GET /api/runs/:runId/artifacts` | _none_ | Includes tailing behavior for logs and artifact listing per run. |
 | Operator observe | 4 | ✅ Implemented | `GET /api/runs/:runId/events`; `GET /api/runs/:runId/commands` | _none_ | Runtime event and structured command history are exposed. |
 | Operator attach | 4 | ✅ Implemented | `GET /api/runs/:runId/terminal`; `GET /api/runs/:runId/ws` | _none_ | Websocket attach endpoint requires `Upgrade: websocket`. |
@@ -59,7 +59,7 @@
   - `POST /api/runs/:runId/review` for manual review rerun (`review_only` orchestration mode).
 - Enhanced request-changes input:
   - `reviewSelection.mode`: `all` / `include` / `exclude` / `freeform`.
-  - Optional provider-reply stitching via `includeReplies`.
+  - Optional provider-reply stitching via `includeReplies` (GitHub merges webhook-ingested and on-demand replies with deterministic dedupe).
 
 ## Slack/Jira/GitLab MVP flow states
 

--- a/docs/integrations/auto-review-change-loop.md
+++ b/docs/integrations/auto-review-change-loop.md
@@ -5,7 +5,7 @@
 This guide captures the end-to-end flow for Stage 6 hardening and operation handoff:
 
 - automatic review execution after run lifecycle review entry
-- provider posting to GitLab/Jira with retry-safe, idempotent behavior
+- provider posting to GitHub/GitLab/Jira with retry-safe, idempotent behavior
 - selective follow-up request-changes
 - manual review-only reruns
 
@@ -14,8 +14,9 @@ This guide captures the end-to-end flow for Stage 6 hardening and operation hand
 1. Enable auto-review in repo config (and optional task override):
 
    - `repo.autoReview.enabled = true`
-   - `repo.autoReview.provider = 'gitlab' | 'jira'`
+   - `repo.autoReview.provider = 'github' | 'gitlab' | 'jira'`
    - `repo.autoReview.postInline = true` for GitLab inline notes
+   - for GitHub repos, provider defaults to `github` when omitted and `autoReview.enabled=true`
 
 2. Trigger a normal run:
 
@@ -53,6 +54,26 @@ This guide captures the end-to-end flow for Stage 6 hardening and operation hand
    - `POST /api/runs/:runId/review`
    - confirm timeline contains `Manual review started (round N).`
 
+## GitHub dogfood setup and QA
+
+1. Runtime secrets:
+   - set `GITHUB_TOKEN` in Worker secrets (write access to PR comments/reviews).
+2. Webhook verification secret:
+   - set `github/webhook-secret` in `SECRETS_KV`.
+3. GitHub webhook subscription:
+   - endpoint: `POST /api/integrations/github/webhook`
+   - events: `Pull request review comments`, `Pull request reviews`, `Issue comments`
+4. Dry run one PR flow in AgentsKanban repo:
+   - run task with `sourceRef=main`
+   - confirm findings post to PR with marker comments
+   - reply to at least one marker-bearing finding comment on GitHub
+5. Trigger selective request-changes with replies:
+   - send `POST /api/runs/:runId/request-changes` and set:
+   - `{ "reviewSelection": { "mode": "include", "findingIds": ["<id>"], "includeReplies": true } }`
+6. Verify merged context:
+   - prompt includes deduped reply lines from both webhook-ingested hints and on-demand fetch
+   - ordering is deterministic (source-priority + stable lexical sort)
+
 ## Execution handoff pack (for next phase)
 
 1. Repo/task state
@@ -73,14 +94,21 @@ This guide captures the end-to-end flow for Stage 6 hardening and operation hand
 - `reviewExecution.trigger` remains `auto_on_review` but `round` is still `0`
   - check repo auto-review setting and task override mode resolution
 - postings never happen
-  - confirm provider credential secret exists (`GITLAB_TOKEN` or `JIRA_TOKEN`)
+  - confirm provider credential secret exists (`GITHUB_TOKEN`, `GITLAB_TOKEN`, or `JIRA_TOKEN`)
 - duplicate findings comments appearing
   - verify stable marker IDs in provider comments and idempotent mapping behavior
 - request-changes prompt missing selection context
-  - confirm `reviewSelection` payload is valid JSON and provider replies are enabled only for gitlab/jira
+  - confirm `reviewSelection` payload is valid JSON and provider replies are enabled for github/gitlab/jira
+- GitHub replies missing from request-changes context
+  - verify webhook secret is configured in KV as `github/webhook-secret`
+  - verify webhook deliveries return `status: accepted` (not signature errors)
+  - verify review number/project path in webhook payload matches the run review metadata
 
 ## Known limitations / deferred work
 
+- GitHub webhook ingestion only stores marker-bearing comment/review content; non-marker conversational context is ignored.
+- Reply merge currently dedupes by normalized body text and source order; richer thread semantics (author/timestamp weighting) are deferred.
+- Webhook ingestion is tenant-primary; multi-tenant, per-repo GitHub app installation mapping is deferred.
 - Jira comment threading is treated as marker-based dedupe only; cross-page/reply threading is not deeply normalized.
 - GitLab inline posting recovery after transient network failures depends on re-fetching discussion state before retries.
 - Cross-provider review-provider migration for a run is not yet available; changing provider requires a new run cycle.

--- a/docs/local-testing.md
+++ b/docs/local-testing.md
@@ -14,7 +14,7 @@ Use this flow to verify:
 - Stage 6 auto-review/change-loop behavior:
   - run reaches review state
   - review auto-posting executes and writes review artifacts
-  - selective request-changes with provider-reply context
+  - selective request-changes with merged provider-reply context (webhook + on-demand for GitHub)
   - manual review rerun keeps execution metadata updated
 - Stage 7 native sentinel behavior:
   - start/pause/resume/stop control actions
@@ -52,6 +52,12 @@ npx wrangler secret put OPENAI_API_KEY
 ```
 
 Set only the providers you use (`GITHUB_TOKEN` for GitHub repos, `GITLAB_TOKEN` for GitLab repos, `JIRA_TOKEN` when review provider is Jira).
+
+Set GitHub webhook verification secret in KV when validating GitHub reply-context ingestion:
+
+```bash
+npx wrangler kv key put --binding SECRETS_KV github/webhook-secret "<shared-webhook-secret>"
+```
 
 ## 3) Required infrastructure bindings
 
@@ -197,6 +203,11 @@ You can continue to use `npx wrangler dev` for Worker-only execution on the lega
    - `GET /api/runs/:runId` (verify `reviewExecution` fields and round count)
    - `GET /api/runs/:runId/artifacts` (verify `reviewFindingsJson` and `reviewMarkdown` review pointers)
    - `POST /api/runs/:runId/request-changes` with `reviewSelection` payload
+   - for GitHub dogfood:
+     - ensure webhook target is configured: `POST /api/integrations/github/webhook`
+     - reply to a marker-bearing PR finding comment
+     - confirm webhook delivery status is `accepted`
+     - rerun `POST /api/runs/:runId/request-changes` with `includeReplies=true` and verify merged reply context in prompt
    - `POST /api/runs/:runId/review` to execute manual review-only rerun
 6.6 Validate native sentinel orchestration
    - `PATCH /api/repos/:repoId/sentinel/config` with `{ "enabled": true }` plus desired scope/gate/policy

--- a/src/server/request-changes.test.ts
+++ b/src/server/request-changes.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { ReviewFinding } from '../ui/domain/types';
-import { buildRequestChangesPrompt, resolveRequestRunChangesSelection } from './request-changes';
+import { buildRequestChangesPrompt, mergeReviewReplyContext, resolveRequestRunChangesSelection } from './request-changes';
 
 const findings: ReviewFinding[] = [
   {
@@ -131,5 +131,28 @@ describe('buildRequestChangesPrompt', () => {
     expect(prompt).toContain('Selected finding context:');
     expect(prompt).toContain('Provider replies for finding_1:');
     expect(prompt).toContain('Reviewer said this spacing change will break 4k layouts.');
+  });
+});
+
+describe('mergeReviewReplyContext', () => {
+  it('dedupes replies and keeps deterministic ordering by source + body', () => {
+    const merged = mergeReviewReplyContext({
+      findingIds: ['finding_1', 'finding_3'],
+      sources: [
+        {
+          finding_1: ['  Reply B  ', 'Reply A', 'Reply B'],
+          finding_3: ['Store only reply']
+        },
+        {
+          finding_1: ['Reply A', 'Reply C', 'Reply  C  '],
+          finding_3: ['Store only reply', 'On-demand only reply']
+        }
+      ]
+    });
+
+    expect(merged).toEqual({
+      finding_1: ['Reply A', 'Reply B', 'Reply  C', 'Reply C'],
+      finding_3: ['Store only reply', 'On-demand only reply']
+    });
   });
 });

--- a/src/server/request-changes.ts
+++ b/src/server/request-changes.ts
@@ -110,6 +110,41 @@ function formatReplyContext(id: string, replyContext?: ReviewReplyContext) {
   ];
 }
 
+function normalizeReplyBody(value: string) {
+  return value.replace(/\r\n/g, '\n').trim();
+}
+
+export function mergeReviewReplyContext(input: {
+  findingIds: string[];
+  sources: Array<ReviewReplyContext | undefined>;
+}): ReviewReplyContext {
+  const merged: ReviewReplyContext = {};
+
+  for (const findingId of input.findingIds) {
+    const dedupedByBody = new Map<string, { body: string; sourceIndex: number }>();
+    for (let sourceIndex = 0; sourceIndex < input.sources.length; sourceIndex += 1) {
+      const source = input.sources[sourceIndex];
+      const replies = source?.[findingId] ?? [];
+      for (const reply of replies) {
+        const normalized = normalizeReplyBody(reply);
+        if (!normalized || dedupedByBody.has(normalized)) {
+          continue;
+        }
+        dedupedByBody.set(normalized, { body: normalized, sourceIndex });
+      }
+    }
+
+    const entries = [...dedupedByBody.values()]
+      .sort((a, b) => a.sourceIndex - b.sourceIndex || a.body.localeCompare(b.body))
+      .map((entry) => entry.body);
+    if (entries.length) {
+      merged[findingId] = entries;
+    }
+  }
+
+  return merged;
+}
+
 export function buildRequestChangesPrompt(input: {
   operatorPrompt: string;
   selection?: ChangeRequestSelection;

--- a/src/server/router.review.test.ts
+++ b/src/server/router.review.test.ts
@@ -39,7 +39,25 @@ const reviewFindings: ReviewFinding[] = [
   }
 ];
 
-function createEnv(runOverrides: Record<string, unknown> = {}): Env {
+class KvStore {
+  values = new Map<string, string>();
+
+  async get(key: string) {
+    return this.values.get(key) ?? null;
+  }
+
+  async put(key: string, value: string) {
+    this.values.set(key, value);
+  }
+}
+
+function createEnv(
+  runOverrides: Record<string, unknown> = {},
+  options: {
+    repoOverrides?: Record<string, unknown>;
+    kv?: KvStore;
+  } = {}
+): Env {
   let run = {
     runId: 'run_repo_1_demo',
     repoId: 'repo_1',
@@ -94,12 +112,14 @@ function createEnv(runOverrides: Record<string, unknown> = {}): Env {
       tenantId: 'tenant_local',
       scmProvider: 'github',
       scmBaseUrl: 'https://github.com',
-      projectPath: 'acme/demo'
+      projectPath: 'acme/demo',
+      ...options.repoOverrides
     })),
     getScmCredentialSecret: vi.fn(async () => 'SCM_TOKEN')
   };
 
   return {
+    SECRETS_KV: (options.kv ?? new KvStore()) as unknown as KVNamespace,
     BOARD_INDEX: {
       getByName: vi.fn(() => board)
     },
@@ -173,6 +193,97 @@ describe('handleRequestChanges', () => {
     expect(body.changeRequest?.prompt).toContain('Requested findings: rf_1, rf_unknown');
     expect(body.changeRequest?.prompt).toContain('Unknown findings: rf_unknown');
     expect(body.changeRequest?.prompt).toContain('Provider replies for rf_1:');
+  });
+
+  it('merges persisted webhook hints with on-demand github replies for selective request-changes', async () => {
+    const markerA = '<!-- agentboard-review:finding:rf_1:run_repo_1_demo -->';
+    const kv = new KvStore();
+    kv.values.set(
+      'github/reply-context:tenant_local:acme%2Fdemo:7:rf_1',
+      JSON.stringify({
+        findingId: 'rf_1',
+        projectPath: 'acme/demo',
+        reviewNumber: 7,
+        updatedAt: '2026-03-03T10:00:00.000Z',
+        hints: [
+          {
+            findingId: 'rf_1',
+            runId: 'run_repo_1_demo',
+            body: `${markerA} Persisted advice B`,
+            providerEventId: 'pull_request_review_comment:501',
+            deliveryId: 'delivery-501',
+            recordedAt: '2026-03-03T10:00:00.000Z'
+          },
+          {
+            findingId: 'rf_1',
+            runId: 'run_repo_1_demo',
+            body: `${markerA} Persisted advice A`,
+            providerEventId: 'pull_request_review_comment:502',
+            deliveryId: 'delivery-502',
+            recordedAt: '2026-03-03T10:01:00.000Z'
+          }
+        ]
+      })
+    );
+
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/repos/acme/demo/pulls/7/comments')) {
+        return new Response(JSON.stringify([
+          {
+            id: 100,
+            body: `${markerA} Root comment`
+          },
+          {
+            id: 101,
+            in_reply_to_id: 100,
+            body: `${markerA} Persisted advice B`
+          },
+          {
+            id: 102,
+            in_reply_to_id: 100,
+            body: `${markerA} On-demand advice C`
+          }
+        ]), { status: 200 });
+      }
+      if (url.includes('/repos/acme/demo/issues/7/comments')) {
+        return new Response(JSON.stringify([]), { status: 200 });
+      }
+      throw new Error(`Unexpected fetch URL: ${url}`);
+    }));
+
+    const response = await handleRequestChanges(
+      new Request('https://minions.example.test/api/runs/run_repo_1_demo/request-changes', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', 'x-session-token': 'session-token' },
+        body: JSON.stringify({
+          prompt: 'Use merged provider context.',
+          reviewSelection: {
+            mode: 'include',
+            findingIds: ['rf_1'],
+            includeReplies: true
+          }
+        })
+      }),
+      createEnv({
+        reviewProvider: 'github',
+        reviewUrl: 'https://github.com/acme/demo/pull/7',
+        reviewNumber: 7,
+        reviewFindings
+      } as Record<string, unknown>, { kv }),
+      { runId: 'run_repo_1_demo' },
+      {} as ExecutionContext<unknown>
+    );
+
+    const body = await response.json() as { changeRequest?: { prompt?: string; selection?: Record<string, unknown> } };
+
+    expect(response.status).toBe(200);
+    expect((body.changeRequest?.selection as Record<string, unknown> | undefined)?.selectedFindingIds).toEqual(['rf_1']);
+    expect(body.changeRequest?.prompt).toContain('Provider replies for rf_1:');
+    expect(body.changeRequest?.prompt).toContain('- <!-- agentboard-review:finding:rf_1:run_repo_1_demo --> On-demand advice C');
+    expect(body.changeRequest?.prompt).toContain('- <!-- agentboard-review:finding:rf_1:run_repo_1_demo --> Persisted advice A');
+    expect(body.changeRequest?.prompt).toContain('- <!-- agentboard-review:finding:rf_1:run_repo_1_demo --> Persisted advice B');
+    expect(body.changeRequest?.prompt).not.toContain('Persisted advice B\n- <!-- agentboard-review:finding:rf_1:run_repo_1_demo --> Persisted advice B');
   });
 });
 

--- a/src/server/router.ts
+++ b/src/server/router.ts
@@ -34,11 +34,11 @@ import { parseBoardSnapshot } from '../ui/store/board-snapshot';
 import { scheduleRunJob } from './run-orchestrator';
 import { getRunUsage, getTenantRunUsage, getTenantUsageSummary } from './usage-reporting';
 import { normalizeTenantId, normalizeTenantIdStrict } from '../shared/tenant';
-import { getRepoHost, getRunReviewProvider, hasRunReview } from '../shared/scm';
+import { getRepoHost, getRepoProjectPath, getRunReviewProvider, hasRunReview } from '../shared/scm';
 import * as tenantAuthDb from './tenant-auth-db';
 import { DEFAULT_REPO_SENTINEL_CONFIG } from '../shared/sentinel';
 import { SentinelController } from './sentinel';
-import { buildRequestChangesPrompt, resolveRequestRunChangesSelection } from './request-changes';
+import { buildRequestChangesPrompt, mergeReviewReplyContext, resolveRequestRunChangesSelection } from './request-changes';
 import {
   handleSlackCommands as handleSlackCommandsHandler,
   handleSlackEvents as handleSlackEventsHandler,
@@ -46,9 +46,11 @@ import {
 } from './integrations/slack/handlers';
 import { handleGitlabWebhook as handleGitlabWebhookHandler } from './integrations/gitlab/handlers';
 import { handleGithubWebhook as handleGithubWebhookHandler } from './integrations/github/handlers';
+import { listGithubReplyContextHints } from './integrations/github/reply-context-store';
 import type { AutoReviewProvider, Repo, SentinelRun } from '../ui/domain/types';
 import { getScmAdapter } from './scm/registry';
 import { getReviewPostingAdapter } from './review-posting/registry';
+import type { ReviewReplyContext } from './review-posting/adapter';
 
 const BOARD_OBJECT_NAME = 'agentboard';
 
@@ -1099,7 +1101,7 @@ export async function handleRequestChanges(request: Request, env: Env, params: R
     let replyContext;
     if (selection?.includeReplies && selectedFindings.length) {
       const reviewProvider = getRunReviewProvider(existingRun) as AutoReviewProvider | undefined;
-      if (reviewProvider !== 'gitlab' && reviewProvider !== 'jira') {
+      if (reviewProvider !== 'github' && reviewProvider !== 'gitlab' && reviewProvider !== 'jira') {
         throw badRequest('Cannot include replies for this review provider.');
       }
       if (!repo.scmProvider) {
@@ -1110,13 +1112,42 @@ export async function handleRequestChanges(request: Request, env: Env, params: R
         throw badRequest(`No SCM credential found for ${repo.scmProvider} host ${getRepoHost(repo)}.`);
       }
       const taskDetail = await repoBoard.getTask(existingRun.taskId, requestContext.activeTenantId);
-      replyContext = await getReviewPostingAdapter(reviewProvider).fetchReplyContext({
+      const fetchedReplyContext = await getReviewPostingAdapter(reviewProvider).fetchReplyContext({
         repo,
         task: taskDetail.task,
         run: existingRun,
         credential: { token },
         findingIds: selection.selectedFindingIds
       });
+
+      if (reviewProvider === 'github') {
+        const reviewNumber = existingRun.reviewNumber ?? existingRun.prNumber;
+        const storedHints = reviewNumber
+          ? await listGithubReplyContextHints({
+            env,
+            tenantId: requestContext.activeTenantId,
+            projectPath: getRepoProjectPath(repo),
+            reviewNumber,
+            findingIds: selection.selectedFindingIds
+          })
+          : {};
+        const persistedReplyContext = Object.entries(storedHints).reduce<ReviewReplyContext>((output, [findingId, hints]) => {
+          const bodies = hints.map((hint) => hint.body.trim()).filter(Boolean);
+          if (bodies.length) {
+            output[findingId] = bodies;
+          }
+          return output;
+        }, {});
+        replyContext = mergeReviewReplyContext({
+          findingIds: selection.selectedFindingIds,
+          sources: [persistedReplyContext, fetchedReplyContext]
+        });
+      } else {
+        replyContext = mergeReviewReplyContext({
+          findingIds: selection.selectedFindingIds,
+          sources: [fetchedReplyContext]
+        });
+      }
     }
 
     const prompt = buildRequestChangesPrompt({


### PR DESCRIPTION
Task: G5 - Reply Context Merge, Request-Changes Enrichment, Docs, and Dogfood QA

Merge webhook and on-demand GitHub replies into request-changes context and complete documentation plus dogfood QA guidance.
Source ref: main

Acceptance criteria:
- Request-changes includes merged GitHub reply context when requested.
- Reply merge logic is deterministic and deduped.
- Docs include setup and manual QA instructions for GitHub auto-review dogfooding.
- PR description includes all required sections.

Run ID: run_repo_abuiles_agents_kanban_mmc83og3pork