### PR TITLE
S10: Slack free-text intent intake + clarification loop

### DIFF
--- a/docs/features-and-api.md
+++ b/docs/features-and-api.md
@@ -79,10 +79,15 @@ Operational notes:
 
 - `POST /api/integrations/slack/commands`
   - Verified with Slack signing secret and replay window checks.
-  - Accepts `/kanvy fix <JIRA_KEY>`.
+  - Accepts `/kanvy fix <JIRA_KEY>` and free-text `/kanvy <intent>`.
   - Acknowledges immediately and continues Jira/repo/run processing asynchronously.
+- Free-text intake behavior:
+  - Deterministic Jira fast-path remains unchanged for `fix <JIRA_KEY>`.
+  - Non-fast-path requests run through strict-JSON intent parsing with scoped model defaults.
+  - Thread-scoped clarification sessions persist in KV and continue through Slack thread replies.
+  - Auto-create starts task/run when intent confidence is high and required fields are complete.
 - `POST /api/integrations/slack/interactions`
-  - Supports actions: `repo_disambiguation`, `approve_rerun`, `pause`, `close`.
+  - Supports actions: `repo_disambiguation`, `intent_repo_select`, `approve_rerun`, `pause`, `close`.
   - Uses thread binding context (`taskId`, `channelId`, `threadTs`, `currentRunId`, `latestReviewRound`) to keep decisions in one thread.
 - `POST /api/integrations/gitlab/webhook`
   - Verified with GitLab webhook token.

--- a/docs/integrations/slack-jira-gitlab-mvp.md
+++ b/docs/integrations/slack-jira-gitlab-mvp.md
@@ -7,6 +7,7 @@ This document is the operator and agent handoff artifact for the P5 MVP vertical
 In scope (MVP):
 
 - Slack-triggered task start from Jira key (`/kanvy fix <JIRA_KEY>`)
+- Slack free-text intake (`/kanvy <intent>`) with clarification loop
 - Jira issue load and repo resolution (mapping and disambiguation)
 - Task/run start from `main`
 - GitLab MR lifecycle and feedback mirrored to Slack thread
@@ -38,8 +39,10 @@ Out of scope (this phase):
 
 ## Operator day-to-day flow (no dashboard required)
 
-1. In Slack, run `/kanvy fix ABC-123`.
-2. If multiple repo mappings are available, click a repo disambiguation button.
+1. In Slack, run either:
+   - `/kanvy fix ABC-123` (deterministic Jira fast-path), or
+   - `/kanvy <free-text request>` (intent intake path).
+2. If disambiguation is needed, click the repo selection button or reply with repo context in-thread.
 3. Monitor status and MR feedback in the same Slack thread.
 4. When feedback arrives and run enters `DECISION_REQUIRED`, click `Approve rerun`.
 5. Continue the thread loop until `DONE`, `PAUSED`, or `FAILED`.
@@ -120,5 +123,5 @@ Execution sequencing for task pack remains strict:
 Model config standard for task creation:
 
 - `codex`
-- `gpt-5.3-codex-spark`
-- `high`
+- `gpt-5.1-codex-mini`
+- `high` for Jira fast-path, `medium` for free-text intake-created tasks

--- a/docs/local-testing.md
+++ b/docs/local-testing.md
@@ -280,17 +280,23 @@ Use this when validating day-to-day operator flow without dashboard actions.
 2. Configure Jira project -> repo mapping for the tenant.
 3. Trigger slash command:
    - `/kanvy fix ABC-123`
+   - `/kanvy draft rollout plan for retry safety`
 4. Confirm slash command ack is immediate and async processing posts one of:
    - run start confirmation
    - repo disambiguation buttons
+   - clarification follow-up question for incomplete free-text intent
    - failure message (for example Jira read failure)
-5. Confirm run thread binding stores:
+5. For free-text intake sessions, reply in the same Slack thread until the parser has:
+   - repository target
+   - task objective/prompt
+   - enough confidence to auto-create task/run
+6. Confirm run thread binding stores:
    - `taskId`, `channelId`, `threadTs`, `currentRunId`, `latestReviewRound`
-6. Simulate or receive GitLab webhook events:
+7. Simulate or receive GitLab webhook events:
    - MR open/update -> `REVIEW_PENDING`
    - MR note feedback -> `DECISION_REQUIRED`
-7. Click `Approve rerun` in the same Slack thread.
-8. Confirm exactly one rerun is queued and thread binding updates to the new `currentRunId`.
+8. Click `Approve rerun` in the same Slack thread.
+9. Confirm exactly one rerun is queued and thread binding updates to the new `currentRunId`.
 
 Ingress/idempotency checks to verify in local logs:
 

--- a/docs/plans/current/p10-slack-intent-intake-one-shot.md
+++ b/docs/plans/current/p10-slack-intent-intake-one-shot.md
@@ -1,6 +1,6 @@
 # Stage: Slack Free-Text Intent Intake + Model-Selectable Parser (One-Shot Execution)
 
-**Status:** Planned
+**Status:** Implemented
 
 ## Goal
 

--- a/src/server/integrations/slack/handlers.test.ts
+++ b/src/server/integrations/slack/handlers.test.ts
@@ -5,6 +5,7 @@ import { handleSlackCommands, handleSlackEvents, handleSlackInteractions } from 
 const tenantAuthDbMocks = vi.hoisted(() => ({
   deleteSlackThreadBinding: vi.fn(),
   getPrimaryTenantId: vi.fn(),
+  listIntegrationConfigs: vi.fn(),
   listJiraProjectRepoMappingsByProject: vi.fn(),
   upsertSlackThreadBinding: vi.fn()
 }));
@@ -118,6 +119,7 @@ describe('slack handlers', () => {
     fetchSpy.mockReset();
     fetchSpy.mockResolvedValue(new Response('{}', { status: 200 }));
     tenantAuthDbMocks.getPrimaryTenantId.mockResolvedValue('tenant_local');
+    tenantAuthDbMocks.listIntegrationConfigs.mockResolvedValue([]);
     tenantAuthDbMocks.upsertSlackThreadBinding.mockImplementation(async (input: {
       taskId: string;
       channelId: string;
@@ -167,7 +169,7 @@ describe('slack handlers', () => {
       repoId: 'repo_alpha',
       sourceRef: 'main',
       llmAdapter: 'codex',
-      codexModel: 'gpt-5.3-codex-spark',
+      codexModel: 'gpt-5.1-codex-mini',
       codexReasoningEffort: 'high'
     }));
     expect(repoBoard.startRun).toHaveBeenCalledWith('task_single', { tenantId: 'team_one' });
@@ -706,5 +708,110 @@ describe('slack handlers', () => {
     const response = await handleSlackEvents(request, makeEnv('secret'));
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual({ challenge: 'challenge-123' });
+  });
+
+  it('accepts free-text /kanvy commands and starts task/run when a single repo is available', async () => {
+    const boardIndex = makeBoardIndex([
+      { repoId: 'repo_alpha', slug: 'abuiles/agents-kanban' }
+    ]);
+    const repoBoard = makeRepoBoard({ taskId: 'task_intake', runId: 'run_intake' });
+    const rawBody = new URLSearchParams({
+      command: '/kanvy',
+      text: 'draft a rollout plan for retry safety and checkpoint cleanup',
+      channel_id: 'C123',
+      thread_ts: '1672531200.5678',
+      team_id: 'team_one',
+      user_id: 'U1',
+      response_url: 'https://hooks.slack.com/commands/intent'
+    }).toString();
+    const timestamp = nowTs;
+    const signature = await buildSlackSignature('secret', timestamp, rawBody);
+    const request = new Request('https://example.test/api/integrations/slack/commands', {
+      method: 'POST',
+      headers: slackHeaders(timestamp, signature),
+      body: rawBody
+    });
+    const waitUntilTasks: Array<Promise<unknown>> = [];
+    const waitUntil = vi.fn((task: Promise<unknown>) => {
+      waitUntilTasks.push(task);
+    });
+
+    const response = await handleSlackCommands(
+      request,
+      makeEnv('secret', repoBoard, boardIndex),
+      { waitUntil } as unknown as ExecutionContext<unknown>
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      ok: true,
+      text: 'Accepted /kanvy free-text intake command.'
+    });
+    await waitUntilTasks[0];
+    expect(repoBoard.createTask).toHaveBeenCalledWith(expect.objectContaining({
+      repoId: 'repo_alpha',
+      sourceRef: 'main',
+      llmAdapter: 'codex',
+      codexModel: 'gpt-5.1-codex-mini',
+      codexReasoningEffort: 'medium'
+    }));
+    expect(repoBoard.startRun).toHaveBeenCalledWith('task_intake', { tenantId: 'team_one' });
+  });
+
+  it('continues intake sessions from Slack thread replies', async () => {
+    const boardIndex = makeBoardIndex([
+      { repoId: 'repo_alpha', slug: 'abuiles/agents-kanban' }
+    ]);
+    const repoBoard = makeRepoBoard({ taskId: 'task_event_intake', runId: 'run_event_intake' });
+
+    const slashBody = new URLSearchParams({
+      command: '/kanvy',
+      text: 'help',
+      channel_id: 'C123',
+      thread_ts: '1672531200.9999',
+      team_id: 'team_one',
+      user_id: 'U1',
+      response_url: 'https://hooks.slack.com/commands/intent-followup'
+    }).toString();
+    const slashTimestamp = nowTs;
+    const slashSignature = await buildSlackSignature('secret', slashTimestamp, slashBody);
+    const slashRequest = new Request('https://example.test/api/integrations/slack/commands', {
+      method: 'POST',
+      headers: slackHeaders(slashTimestamp, slashSignature),
+      body: slashBody
+    });
+    const waitUntilTasks: Array<Promise<unknown>> = [];
+    await handleSlackCommands(
+      slashRequest,
+      makeEnv('secret', repoBoard, boardIndex),
+      { waitUntil: (task: Promise<unknown>) => waitUntilTasks.push(task) } as unknown as ExecutionContext<unknown>
+    );
+    await waitUntilTasks[0];
+    expect(repoBoard.createTask).not.toHaveBeenCalled();
+
+    const eventBody = JSON.stringify({
+      type: 'event_callback',
+      event_id: 'Ev123',
+      team_id: 'team_one',
+      event: {
+        type: 'message',
+        user: 'U1',
+        channel: 'C123',
+        thread_ts: '1672531200.9999',
+        text: 'Create a task to implement retry logs and acceptance criteria'
+      }
+    });
+    const eventTs = (Number(nowTs) + 1).toString();
+    const eventSig = await buildSlackSignature('secret', eventTs, eventBody);
+    const eventRequest = new Request('https://example.test/api/integrations/slack/events', {
+      method: 'POST',
+      headers: slackHeaders(eventTs, eventSig),
+      body: eventBody
+    });
+    const eventResponse = await handleSlackEvents(eventRequest, makeEnv('secret', repoBoard, boardIndex));
+
+    expect(eventResponse.status).toBe(200);
+    expect(repoBoard.createTask).toHaveBeenCalledTimes(1);
+    expect(repoBoard.startRun).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/server/integrations/slack/handlers.ts
+++ b/src/server/integrations/slack/handlers.ts
@@ -6,6 +6,7 @@ import * as tenantAuthDb from '../../tenant-auth-db';
 import { createJiraIssueSourceIntegrationFromEnv } from '../jira/client';
 import { scheduleRunJob } from '../../run-orchestrator';
 import { buildIdempotencyKey } from '../idempotency';
+import { resolveIntegrationConfig } from '../config-resolution';
 import {
   parseSlackEventBody,
   parseSlackInteractionBody,
@@ -14,14 +15,30 @@ import {
 } from './payload';
 import { resolveThreadTenant, verifySlackRequest } from './verification';
 import { mirrorRunLifecycleMilestone } from './timeline';
+import { postSlackThreadMessage } from './client';
+import {
+  buildClarificationQuestion,
+  buildSlackIntakeSessionKey,
+  defaultSlackIntentSettings,
+  getSlackIntakeSession,
+  isIntentComplete,
+  mergeIntentState,
+  parseSlackIntentText,
+  putSlackIntakeSession,
+  type SlackIntakeSession,
+  type SlackIntentSettings
+} from './intent';
 
 const DEFAULT_TASK_ID_PREFIX = 'issue';
 const DEFAULT_REVIEW_ROUND = 0;
 const BOARD_OBJECT_NAME = 'agentboard';
 const SOURCE_REF = 'main';
 const JIRA_LLM_ADAPTER: CreateTaskInput['llmAdapter'] = 'codex';
-const JIRA_LLM_MODEL: CreateTaskInput['codexModel'] = 'gpt-5.3-codex-spark';
+const JIRA_LLM_MODEL: CreateTaskInput['codexModel'] = 'gpt-5.1-codex-mini';
 const JIRA_LLM_REASONING_EFFORT: CreateTaskInput['codexReasoningEffort'] = 'high';
+const INTAKE_TASK_ID_PREFIX = 'slack-intake';
+const DEFAULT_INTAKE_TASK_MODEL: CreateTaskInput['codexModel'] = 'gpt-5.1-codex-mini';
+const DEFAULT_INTAKE_TASK_REASONING: CreateTaskInput['codexReasoningEffort'] = 'medium';
 const FALLBACK_DISAMBIGUATION_WARNING = 'No matching repository was auto-selected for this issue.';
 const DISAMBIGUATION_MULTIPLE_MAPPINGS_MESSAGE = 'Multiple repositories are mapped for Jira project';
 const DISAMBIGUATION_NO_MAPPING_MESSAGE = 'No active mapping exists for project';
@@ -201,6 +218,166 @@ function normalizeJiraIssueFromInteraction(values: {
     title: values.issueTitle || values.issueKey,
     body: values.issueBody || 'No description provided.',
     url: values.issueUrl
+  };
+}
+
+function normalizeSettingBoolean(value: unknown, fallback: boolean) {
+  return typeof value === 'boolean' ? value : fallback;
+}
+
+function normalizeSettingString(value: unknown) {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
+function normalizeSettingReasoning(value: unknown, fallback: SlackIntentSettings['intentReasoningEffort']) {
+  if (value === 'low' || value === 'medium' || value === 'high') {
+    return value;
+  }
+  return fallback;
+}
+
+function normalizeSettingTurns(value: unknown, fallback: number) {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return fallback;
+  }
+  return Math.max(1, Math.min(8, Math.trunc(value)));
+}
+
+function buildIntakeTaskId(channelId: string, threadTs: string) {
+  return `${INTAKE_TASK_ID_PREFIX}:${channelId}:${threadTs}`;
+}
+
+async function resolveSlackIntentSettings(
+  env: Env,
+  tenantId: string,
+  target: { channelId?: string; repoId?: string }
+): Promise<SlackIntentSettings> {
+  const defaults = defaultSlackIntentSettings();
+  const configs = await tenantAuthDb.listIntegrationConfigs(env, tenantId, {
+    pluginKind: 'slack',
+    enabledOnly: true
+  });
+  const config = resolveIntegrationConfig(configs, {
+    tenantId,
+    pluginKind: 'slack',
+    channelId: target.channelId,
+    repoId: target.repoId
+  });
+  if (!config) {
+    return defaults;
+  }
+  return {
+    intentEnabled: normalizeSettingBoolean(config.settings.intentEnabled, defaults.intentEnabled),
+    intentModel: normalizeSettingString(config.settings.intentModel) ?? defaults.intentModel,
+    intentReasoningEffort: normalizeSettingReasoning(config.settings.intentReasoningEffort, defaults.intentReasoningEffort),
+    intentAutoCreate: normalizeSettingBoolean(config.settings.intentAutoCreate, defaults.intentAutoCreate),
+    intentClarifyMaxTurns: normalizeSettingTurns(config.settings.intentClarifyMaxTurns, defaults.intentClarifyMaxTurns),
+    defaultRepoId: normalizeSettingString(config.settings.defaultRepoId)
+  };
+}
+
+function normalizeIntakeCodexModel(model: string | undefined): CreateTaskInput['codexModel'] {
+  if (model === 'gpt-5.3-codex' || model === 'gpt-5.3-codex-spark' || model === 'gpt-5.1-codex-mini') {
+    return model;
+  }
+  return DEFAULT_INTAKE_TASK_MODEL;
+}
+
+async function listTenantRepoCandidates(env: Env, tenantId: string): Promise<RepoDisambiguationChoice[]> {
+  const boardIndex = env.BOARD_INDEX?.getByName(BOARD_OBJECT_NAME);
+  if (!boardIndex) {
+    return [];
+  }
+  try {
+    const repos = await boardIndex.listRepos(tenantId);
+    return repos
+      .filter((repo) => repo.repoId)
+      .map((repo) => ({ repoId: repo.repoId, label: `${repo.slug} (${repo.repoId})` }));
+  } catch {
+    return [];
+  }
+}
+
+function resolveRepoFromHint(options: RepoDisambiguationChoice[], hint: string | undefined): RepoDisambiguationChoice | undefined {
+  if (!hint) {
+    return undefined;
+  }
+  const lowered = hint.toLowerCase();
+  return options.find((option) => option.repoId.toLowerCase() === lowered || option.label.toLowerCase().includes(lowered));
+}
+
+function buildIntentRepoChoiceValue(value: {
+  tenantId: string;
+  channelId: string;
+  threadTs: string;
+  sessionKey: string;
+  repoId: string;
+  taskId: string;
+}) {
+  return JSON.stringify(value);
+}
+
+function buildIntentRepoDisambiguationResponse(message: string, options: RepoDisambiguationChoice[], context: {
+  tenantId: string;
+  channelId: string;
+  threadTs: string;
+  sessionKey: string;
+  taskId: string;
+}) {
+  return {
+    response_type: 'ephemeral' as const,
+    replace_original: false,
+    text: message,
+    blocks: [
+      {
+        type: 'section' as const,
+        text: { type: 'mrkdwn' as const, text: message }
+      },
+      {
+        type: 'actions' as const,
+        elements: options.map((option) => ({
+          type: 'button' as const,
+          text: { type: 'plain_text' as const, text: option.label },
+          action_id: 'intent_repo_select',
+          value: buildIntentRepoChoiceValue({
+            tenantId: context.tenantId,
+            channelId: context.channelId,
+            threadTs: context.threadTs,
+            sessionKey: context.sessionKey,
+            repoId: option.repoId,
+            taskId: context.taskId
+          })
+        }))
+      }
+    ]
+  };
+}
+
+function buildTaskPayloadFromIntent(
+  repoId: string,
+  intent: {
+    taskTitle?: string;
+    taskPrompt?: string;
+    acceptanceCriteria: string[];
+  },
+  settings: SlackIntentSettings
+): CreateTaskInput {
+  return {
+    repoId,
+    title: (intent.taskTitle || 'Slack intake task').trim(),
+    description: intent.taskPrompt,
+    sourceRef: SOURCE_REF,
+    taskPrompt: intent.taskPrompt || intent.taskTitle || 'Slack intake task',
+    acceptanceCriteria: intent.acceptanceCriteria.length > 0
+      ? intent.acceptanceCriteria
+      : ['Complete the requested Slack intake change.'],
+    context: {
+      links: [],
+      notes: 'Created from Slack free-text intake.'
+    },
+    llmAdapter: JIRA_LLM_ADAPTER,
+    codexModel: normalizeIntakeCodexModel(settings.intentModel),
+    codexReasoningEffort: DEFAULT_INTAKE_TASK_REASONING
   };
 }
 
@@ -508,36 +685,248 @@ async function updateBindingForAction(
   });
 }
 
+async function resolveRepoForIntent(
+  env: Env,
+  tenantId: string,
+  options: {
+    explicitRepoId?: string;
+    repoHint?: string;
+    defaultRepoId?: string;
+  }
+) {
+  const candidates = await listTenantRepoCandidates(env, tenantId);
+  const directRepoId = options.explicitRepoId?.trim();
+  if (directRepoId) {
+    return { repoId: directRepoId, candidates };
+  }
+  const defaultRepoId = options.defaultRepoId?.trim();
+  if (defaultRepoId) {
+    return { repoId: defaultRepoId, candidates };
+  }
+  const hinted = resolveRepoFromHint(candidates, options.repoHint);
+  if (hinted) {
+    return { repoId: hinted.repoId, candidates };
+  }
+  if (candidates.length === 1) {
+    return { repoId: candidates[0]!.repoId, candidates };
+  }
+  return { repoId: undefined, candidates };
+}
+
+async function postThreadMessage(
+  env: Env,
+  input: {
+    tenantId: string;
+    channelId: string;
+    threadTs: string;
+    repoId?: string;
+    text: string;
+  }
+) {
+  await postSlackThreadMessage(env, {
+    tenantId: input.tenantId,
+    repoId: input.repoId ?? 'repo_unknown',
+    channelId: input.channelId,
+    threadTs: input.threadTs,
+    text: input.text
+  }).catch(() => {});
+}
+
+async function attemptCreateTaskFromIntakeSession(
+  env: Env,
+  ctx: ExecutionContext<unknown> | undefined,
+  session: SlackIntakeSession,
+  settings: SlackIntentSettings,
+  responseUrl?: string
+) {
+  const resolution = await resolveRepoForIntent(env, session.tenantId, {
+    explicitRepoId: session.parse.repoId,
+    repoHint: session.parse.repoHint,
+    defaultRepoId: settings.defaultRepoId
+  });
+  if (!resolution.repoId) {
+    const question = resolution.candidates.length > 1
+      ? 'I found multiple repositories. Pick one to continue.'
+      : 'I could not resolve a repository. Reply with the repository slug or repoId.';
+    if (responseUrl && resolution.candidates.length > 1) {
+      await postSlackResponse(
+        responseUrl,
+        buildIntentRepoDisambiguationResponse(question, resolution.candidates, {
+          tenantId: session.tenantId,
+          channelId: session.channelId,
+          threadTs: session.threadTs,
+          sessionKey: session.key,
+          taskId: buildIntakeTaskId(session.channelId, session.threadTs)
+        })
+      );
+    } else {
+      await postThreadMessage(env, {
+        tenantId: session.tenantId,
+        channelId: session.channelId,
+        threadTs: session.threadTs,
+        text: question
+      });
+    }
+    return;
+  }
+
+  const payload = buildTaskPayloadFromIntent(resolution.repoId, session.parse, settings);
+  const started = await startRunForTask(env, ctx, session.tenantId, resolution.repoId, payload);
+  await tenantAuthDb.upsertSlackThreadBinding(env, {
+    tenantId: session.tenantId,
+    taskId: started.taskId,
+    channelId: session.channelId,
+    threadTs: session.threadTs,
+    currentRunId: started.runId,
+    latestReviewRound: 0
+  });
+  session.status = 'completed';
+  session.updatedAt = new Date().toISOString();
+  await putSlackIntakeSession(env, session);
+  const text = `Started task ${started.taskId} and run ${started.runId} for your request in repo ${resolution.repoId}.`;
+  if (responseUrl) {
+    await postSlackResponse(responseUrl, { response_type: 'ephemeral', text });
+  } else {
+    await postThreadMessage(env, {
+      tenantId: session.tenantId,
+      channelId: session.channelId,
+      threadTs: session.threadTs,
+      repoId: resolution.repoId,
+      text
+    });
+  }
+}
+
+async function processSlackIntentMessage(
+  env: Env,
+  ctx: ExecutionContext<unknown> | undefined,
+  input: {
+    tenantId: string;
+    channelId: string;
+    threadTs: string;
+    text: string;
+    responseUrl?: string;
+    existingSession?: SlackIntakeSession;
+  }
+) {
+  const settings = await resolveSlackIntentSettings(env, input.tenantId, { channelId: input.channelId });
+  if (!settings.intentEnabled) {
+    if (input.responseUrl) {
+      await postSlackResponse(input.responseUrl, {
+        response_type: 'ephemeral',
+        text: 'Slack free-text intake is disabled for this scope.'
+      });
+    }
+    return;
+  }
+
+  const parse = await parseSlackIntentText(env, input.text, settings);
+  const sessionKey = buildSlackIntakeSessionKey(input.tenantId, input.channelId, input.threadTs);
+  const now = new Date().toISOString();
+  const session: SlackIntakeSession = input.existingSession
+    ? {
+      ...input.existingSession,
+      parse: mergeIntentState(input.existingSession.parse, parse),
+      turnCount: input.existingSession.turnCount + 1,
+      updatedAt: now,
+      lastUserMessage: input.text
+    }
+    : {
+      key: sessionKey,
+      tenantId: input.tenantId,
+      channelId: input.channelId,
+      threadTs: input.threadTs,
+      status: 'active',
+      turnCount: 0,
+      maxTurns: settings.intentClarifyMaxTurns,
+      updatedAt: now,
+      createdAt: now,
+      lastUserMessage: input.text,
+      parse
+    };
+
+  if (session.parse.intent === 'create_task' && settings.intentAutoCreate && isIntentComplete(session.parse)) {
+    await attemptCreateTaskFromIntakeSession(env, ctx, session, settings, input.responseUrl);
+    return;
+  }
+
+  if (session.turnCount >= session.maxTurns) {
+    session.status = 'handoff';
+    await putSlackIntakeSession(env, session);
+    const handoff = 'I still need more detail. Please provide: repository, objective, and acceptance criteria in one message.';
+    if (input.responseUrl) {
+      await postSlackResponse(input.responseUrl, { response_type: 'ephemeral', text: handoff });
+    } else {
+      await postThreadMessage(env, {
+        tenantId: input.tenantId,
+        channelId: input.channelId,
+        threadTs: input.threadTs,
+        text: handoff
+      });
+    }
+    return;
+  }
+
+  session.status = 'active';
+  await putSlackIntakeSession(env, session);
+  const question = buildClarificationQuestion(session.parse);
+  if (input.responseUrl) {
+    await postSlackResponse(input.responseUrl, {
+      response_type: 'ephemeral',
+      text: question
+    });
+  } else {
+    await postThreadMessage(env, {
+      tenantId: input.tenantId,
+      channelId: input.channelId,
+      threadTs: input.threadTs,
+      text: question
+    });
+  }
+}
+
 async function runSlackCommandAsync(
   env: Env,
   payload: ReturnType<typeof parseSlackSlashCommandBody>,
   ctx?: ExecutionContext<unknown>
 ) {
   const tenantId = await resolveThreadTenantId(env, payload.teamId);
+  const threadTs = payload.threadTs?.trim() || `${Date.now() / 1000}`;
+  const fastPathIssueKey = payload.issueKey?.trim();
   const slashDedupeKey = buildIdempotencyKey({
     provider: 'slack',
     tenantId,
-    eventType: 'slash_command.fix',
-    providerEventId: payload.responseUrl ?? `${payload.teamId ?? 'team:default'}:${payload.channelId}:${payload.issueKey}`,
-    subjectId: `${payload.channelId}:${payload.threadTs ?? 'root'}`,
+    eventType: fastPathIssueKey ? 'slash_command.fix' : 'slash_command.intent',
+    providerEventId: payload.responseUrl ?? `${payload.teamId ?? 'team:default'}:${payload.channelId}:${payload.text}`,
+    subjectId: `${payload.channelId}:${threadTs}`,
     metadata: {
-      issueKey: payload.issueKey,
+      issueKey: fastPathIssueKey,
       userId: payload.userId
     }
   });
   if (!(await markIngressDeliveryIfNew(env, slashDedupeKey))) {
     await postSlackResponse(payload.responseUrl, {
       response_type: 'ephemeral',
-      text: `Duplicate /kanvy command ignored for ${payload.issueKey}.`
+      text: `Duplicate /kanvy command ignored${fastPathIssueKey ? ` for ${fastPathIssueKey}` : ''}.`
+    });
+    return;
+  }
+  if (!fastPathIssueKey) {
+    await processSlackIntentMessage(env, ctx, {
+      tenantId,
+      channelId: payload.channelId,
+      threadTs,
+      text: payload.text.trim(),
+      responseUrl: payload.responseUrl
     });
     return;
   }
   const bindingTaskId = payload.threadTs
-    ? await createThreadBindingForSlashCommand(env, tenantId, payload.issueKey, payload.channelId, payload.threadTs)
-    : buildTaskIdFromIssue(payload.issueKey);
+    ? await createThreadBindingForSlashCommand(env, tenantId, fastPathIssueKey, payload.channelId, payload.threadTs)
+    : buildTaskIdFromIssue(fastPathIssueKey);
 
   try {
-    const issue = await resolveTenantAndJiraIssue(env, tenantId, payload.issueKey);
+    const issue = await resolveTenantAndJiraIssue(env, tenantId, fastPathIssueKey);
     await processJiraIssueFlow(env, ctx, tenantId, issue, {
       taskId: bindingTaskId,
       channelId: payload.channelId,
@@ -547,7 +936,7 @@ async function runSlackCommandAsync(
   } catch (error) {
     await postSlackResponse(payload.responseUrl, {
       response_type: 'ephemeral',
-      text: `Failed to process /kanvy command for ${payload.issueKey}: ${toReadableErrorMessage(error)}`
+      text: `Failed to process /kanvy command for ${fastPathIssueKey}: ${toReadableErrorMessage(error)}`
     });
   }
 }
@@ -613,7 +1002,9 @@ export async function handleSlackCommands(
     }
     return json({
       ok: true,
-      text: `Accepted /kanvy command for ${payload.issueKey}.`
+      text: payload.issueKey
+        ? `Accepted /kanvy command for ${payload.issueKey}.`
+        : 'Accepted /kanvy free-text intake command.'
     });
   } catch (error) {
     return handleError(error);
@@ -627,6 +1018,47 @@ export async function handleSlackEvents(request: Request, env: Env): Promise<Res
     const payload = parseSlackEventBody(rawBody);
     if (payload.type === 'url_verification' && payload.challenge) {
       return json({ challenge: payload.challenge });
+    }
+    if (payload.type === 'event_callback' && payload.eventType === 'message') {
+      const tenantId = await resolveThreadTenantId(env, payload.teamId);
+      const channelId = payload.channelId?.trim();
+      const threadTs = payload.threadTs?.trim();
+      const text = payload.text?.trim();
+      if (channelId && threadTs && text && !payload.botId) {
+        const eventDedupeKey = buildIdempotencyKey({
+          provider: 'slack',
+          tenantId,
+          eventType: 'event.message',
+          providerEventId: payload.eventId ?? `${channelId}:${threadTs}:${text}`,
+          subjectId: `${channelId}:${threadTs}`,
+          metadata: { userId: payload.userId ?? 'unknown' }
+        });
+        if (await markIngressDeliveryIfNew(env, eventDedupeKey)) {
+          const sessionKey = buildSlackIntakeSessionKey(tenantId, channelId, threadTs);
+          const session = await getSlackIntakeSession(env, sessionKey);
+          if (session?.status === 'active') {
+            if (text.toLowerCase() === 'cancel') {
+              session.status = 'cancelled';
+              session.updatedAt = new Date().toISOString();
+              await putSlackIntakeSession(env, session);
+              await postThreadMessage(env, {
+                tenantId,
+                channelId,
+                threadTs,
+                text: 'Slack intake cancelled for this thread.'
+              });
+            } else {
+              await processSlackIntentMessage(env, undefined, {
+                tenantId,
+                channelId,
+                threadTs,
+                text,
+                existingSession: session
+              });
+            }
+          }
+        }
+      }
     }
     return json({ ok: true, status: 'accepted' });
   } catch (error) {
@@ -648,10 +1080,10 @@ export async function handleSlackInteractions(
       provider: 'slack',
       tenantId,
       eventType: `interaction.${interaction.actionId}`,
-      providerEventId: `${interaction.actionId}:${interaction.currentRunId ?? interaction.issueKey ?? interaction.taskId}`,
+      providerEventId: `${interaction.actionId}:${interaction.currentRunId ?? interaction.issueKey ?? interaction.taskId ?? interaction.sessionKey ?? interaction.repoId ?? 'unknown'}`,
       subjectId: `${interaction.channelId}:${interaction.threadTs || 'root'}`,
       metadata: {
-        taskId: interaction.taskId,
+        taskId: interaction.taskId || null,
         repoId: interaction.repoId ?? null,
         latestReviewRound: interaction.latestReviewRound ?? -1
       }
@@ -666,6 +1098,49 @@ export async function handleSlackInteractions(
     }
     if (interaction.actionId === 'repo_disambiguation') {
       return handleRepoDisambiguationAction(env, ctx, tenantId, interaction);
+    }
+    if (interaction.actionId === 'intent_repo_select') {
+      const sessionKey = interaction.sessionKey
+        || buildSlackIntakeSessionKey(tenantId, interaction.channelId, interaction.threadTs);
+      const session = await getSlackIntakeSession(env, sessionKey);
+      if (!session || session.status !== 'active') {
+        return json({ ok: true, status: 'intake_session_missing', action: interaction.actionId });
+      }
+      session.parse.repoId = interaction.repoId ?? session.parse.repoId;
+      session.updatedAt = new Date().toISOString();
+      await putSlackIntakeSession(env, session);
+      const settings = await resolveSlackIntentSettings(env, tenantId, {
+        channelId: interaction.channelId,
+        repoId: session.parse.repoId
+      });
+      await attemptCreateTaskFromIntakeSession(env, ctx, session, settings);
+      return json({
+        ok: true,
+        action: interaction.actionId,
+        taskId: interaction.taskId || buildIntakeTaskId(interaction.channelId, interaction.threadTs)
+      });
+    }
+    if (interaction.actionId === 'intent_cancel') {
+      const sessionKey = interaction.sessionKey
+        || buildSlackIntakeSessionKey(tenantId, interaction.channelId, interaction.threadTs);
+      const session = await getSlackIntakeSession(env, sessionKey);
+      if (session) {
+        session.status = 'cancelled';
+        session.updatedAt = new Date().toISOString();
+        await putSlackIntakeSession(env, session);
+      }
+      return json({
+        ok: true,
+        action: interaction.actionId,
+        status: 'cancelled'
+      });
+    }
+    if (interaction.actionId === 'intent_confirm_create') {
+      return json({
+        ok: true,
+        action: interaction.actionId,
+        status: 'noop'
+      });
     }
     if (interaction.actionId === 'approve_rerun') {
       await startSlackApprovedRerun(env, ctx, tenantId, interaction);

--- a/src/server/integrations/slack/intent.ts
+++ b/src/server/integrations/slack/intent.ts
@@ -1,0 +1,345 @@
+const DEFAULT_MODEL = 'gpt-5.1-codex-mini';
+const DEFAULT_REASONING_EFFORT = 'low';
+const DEFAULT_AUTO_CREATE = true;
+const DEFAULT_CLARIFY_MAX_TURNS = 4;
+const DEFAULT_SESSION_TTL_SECONDS = 24 * 60 * 60;
+const INTENT_CONFIDENCE_THRESHOLD = 0.8;
+const ISSUE_KEY_PATTERN = /^[A-Z][A-Z0-9_]*-\d+$/i;
+
+export type SlackIntentType = 'fix_jira' | 'create_task' | 'unknown';
+
+export type SlackIntentSettings = {
+  intentEnabled: boolean;
+  intentModel: string;
+  intentReasoningEffort: 'low' | 'medium' | 'high';
+  intentAutoCreate: boolean;
+  intentClarifyMaxTurns: number;
+  defaultRepoId?: string;
+};
+
+export type SlackIntentParseResult = {
+  intent: SlackIntentType;
+  confidence: number;
+  jiraKey?: string;
+  repoId?: string;
+  repoHint?: string;
+  taskTitle?: string;
+  taskPrompt?: string;
+  acceptanceCriteria: string[];
+  missingFields: string[];
+  clarifyingQuestion?: string;
+};
+
+export type SlackIntakeSessionStatus = 'active' | 'completed' | 'cancelled' | 'handoff';
+
+export type SlackIntakeSession = {
+  key: string;
+  tenantId: string;
+  channelId: string;
+  threadTs: string;
+  status: SlackIntakeSessionStatus;
+  turnCount: number;
+  maxTurns: number;
+  updatedAt: string;
+  createdAt: string;
+  lastUserMessage: string;
+  parse: SlackIntentParseResult;
+};
+
+function clampConfidence(value: unknown) {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return 0;
+  }
+  return Math.max(0, Math.min(1, value));
+}
+
+function normalizeIntent(value: unknown): SlackIntentType {
+  if (value === 'fix_jira' || value === 'create_task') {
+    return value;
+  }
+  return 'unknown';
+}
+
+function normalizeString(value: unknown) {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function normalizeCriteria(value: unknown) {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value
+    .map((entry) => (typeof entry === 'string' ? entry.trim() : ''))
+    .filter((entry) => Boolean(entry));
+}
+
+function normalizeMissingFields(value: unknown) {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value
+    .map((entry) => (typeof entry === 'string' ? entry.trim() : ''))
+    .filter((entry) => Boolean(entry));
+}
+
+function deriveTaskTitleFromText(text: string) {
+  const sanitized = text.replace(/\s+/g, ' ').trim();
+  if (!sanitized) {
+    return 'Slack intake task';
+  }
+  const sentence = sanitized.split(/[.!?]/, 1)[0] ?? sanitized;
+  return sentence.length > 80 ? `${sentence.slice(0, 77)}...` : sentence;
+}
+
+function parseFallbackIntent(text: string): SlackIntentParseResult {
+  const trimmed = text.trim();
+  const jiraMatch = /^fix\s+([A-Z][A-Z0-9_]*-\d+)\s*$/i.exec(trimmed);
+  if (jiraMatch?.[1]) {
+    return {
+      intent: 'fix_jira',
+      confidence: 1,
+      jiraKey: jiraMatch[1].toUpperCase(),
+      acceptanceCriteria: [],
+      missingFields: []
+    };
+  }
+
+  const hasRepoHint = /(?:repo|repository|in)\s+([a-z0-9_.-]+\/[a-z0-9_.-]+)/i.exec(trimmed)?.[1];
+  const prompt = trimmed;
+  const title = deriveTaskTitleFromText(trimmed);
+  const confidence = prompt.length >= 15 ? 0.85 : 0.55;
+  const missingFields = [];
+  if (!prompt) {
+    missingFields.push('taskPrompt');
+  }
+
+  return {
+    intent: prompt ? 'create_task' : 'unknown',
+    confidence,
+    repoHint: hasRepoHint,
+    taskTitle: prompt ? title : undefined,
+    taskPrompt: prompt || undefined,
+    acceptanceCriteria: [],
+    missingFields,
+    clarifyingQuestion: prompt
+      ? 'Which repository should this run against?'
+      : 'What task should I create? Please describe the goal and expected result.'
+  };
+}
+
+function parseModelOutput(raw: unknown): SlackIntentParseResult | undefined {
+  if (!raw || typeof raw !== 'object') {
+    return undefined;
+  }
+  const obj = raw as Record<string, unknown>;
+  const jiraKey = normalizeString(obj.jiraKey);
+  const normalizedJiraKey = jiraKey && ISSUE_KEY_PATTERN.test(jiraKey) ? jiraKey.toUpperCase() : undefined;
+  return {
+    intent: normalizeIntent(obj.intent),
+    confidence: clampConfidence(obj.confidence),
+    jiraKey: normalizedJiraKey,
+    repoId: normalizeString(obj.repoId),
+    repoHint: normalizeString(obj.repoHint),
+    taskTitle: normalizeString(obj.taskTitle),
+    taskPrompt: normalizeString(obj.taskPrompt),
+    acceptanceCriteria: normalizeCriteria(obj.acceptanceCriteria),
+    missingFields: normalizeMissingFields(obj.missingFields),
+    clarifyingQuestion: normalizeString(obj.clarifyingQuestion)
+  };
+}
+
+function extractResponseText(payload: Record<string, unknown>) {
+  if (typeof payload.output_text === 'string' && payload.output_text.trim()) {
+    return payload.output_text.trim();
+  }
+  const output = Array.isArray(payload.output) ? payload.output : [];
+  for (const item of output) {
+    if (!item || typeof item !== 'object') {
+      continue;
+    }
+    const content = (item as Record<string, unknown>).content;
+    if (!Array.isArray(content)) {
+      continue;
+    }
+    for (const fragment of content) {
+      if (!fragment || typeof fragment !== 'object') {
+        continue;
+      }
+      const text = (fragment as Record<string, unknown>).text;
+      if (typeof text === 'string' && text.trim()) {
+        return text.trim();
+      }
+    }
+  }
+  return undefined;
+}
+
+async function parseWithModel(
+  env: Env,
+  text: string,
+  settings: SlackIntentSettings
+): Promise<SlackIntentParseResult | undefined> {
+  const apiKey = await env.SECRETS_KV.get('openai/api-key');
+  if (!apiKey?.trim()) {
+    return undefined;
+  }
+
+  const schema = {
+    type: 'object',
+    additionalProperties: false,
+    properties: {
+      intent: { type: 'string', enum: ['fix_jira', 'create_task', 'unknown'] },
+      confidence: { type: 'number' },
+      jiraKey: { type: 'string' },
+      repoId: { type: 'string' },
+      repoHint: { type: 'string' },
+      taskTitle: { type: 'string' },
+      taskPrompt: { type: 'string' },
+      acceptanceCriteria: { type: 'array', items: { type: 'string' } },
+      missingFields: { type: 'array', items: { type: 'string' } },
+      clarifyingQuestion: { type: 'string' }
+    },
+    required: ['intent', 'confidence', 'acceptanceCriteria', 'missingFields']
+  };
+
+  const response = await fetch('https://api.openai.com/v1/responses', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${apiKey.trim()}`,
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      model: settings.intentModel || DEFAULT_MODEL,
+      reasoning: { effort: settings.intentReasoningEffort || DEFAULT_REASONING_EFFORT },
+      input: [
+        {
+          role: 'system',
+          content: [
+            {
+              type: 'input_text',
+              text: 'Parse Slack command intent. Return only valid JSON.'
+            }
+          ]
+        },
+        {
+          role: 'user',
+          content: [{ type: 'input_text', text }]
+        }
+      ],
+      text: {
+        format: {
+          type: 'json_schema',
+          name: 'slack_intake_intent',
+          schema,
+          strict: true
+        }
+      }
+    })
+  });
+  if (!response.ok) {
+    return undefined;
+  }
+  const payload = await response.json().catch(() => undefined) as Record<string, unknown> | undefined;
+  if (!payload) {
+    return undefined;
+  }
+  const responseText = extractResponseText(payload);
+  if (!responseText) {
+    return undefined;
+  }
+  const parsed = JSON.parse(responseText) as unknown;
+  return parseModelOutput(parsed);
+}
+
+export async function parseSlackIntentText(
+  env: Env,
+  text: string,
+  settings: SlackIntentSettings
+): Promise<SlackIntentParseResult> {
+  try {
+    const modelResult = await parseWithModel(env, text, settings);
+    if (modelResult) {
+      return modelResult;
+    }
+  } catch {
+    // Fallback stays deterministic.
+  }
+  return parseFallbackIntent(text);
+}
+
+export function buildSlackIntakeSessionKey(tenantId: string, channelId: string, threadTs: string) {
+  return `slack:intake:${tenantId}:${channelId}:${threadTs}`;
+}
+
+export async function getSlackIntakeSession(env: Env, key: string): Promise<SlackIntakeSession | undefined> {
+  const stored = await env.SECRETS_KV.get(key);
+  if (!stored) {
+    return undefined;
+  }
+  try {
+    const parsed = JSON.parse(stored) as SlackIntakeSession;
+    if (!parsed || typeof parsed !== 'object') {
+      return undefined;
+    }
+    return parsed;
+  } catch {
+    return undefined;
+  }
+}
+
+export async function putSlackIntakeSession(env: Env, session: SlackIntakeSession): Promise<void> {
+  await env.SECRETS_KV.put(session.key, JSON.stringify(session), {
+    expirationTtl: DEFAULT_SESSION_TTL_SECONDS
+  });
+}
+
+export function mergeIntentState(
+  previous: SlackIntentParseResult,
+  next: SlackIntentParseResult
+): SlackIntentParseResult {
+  return {
+    intent: next.intent !== 'unknown' ? next.intent : previous.intent,
+    confidence: Math.max(previous.confidence, next.confidence),
+    jiraKey: next.jiraKey ?? previous.jiraKey,
+    repoId: next.repoId ?? previous.repoId,
+    repoHint: next.repoHint ?? previous.repoHint,
+    taskTitle: next.taskTitle ?? previous.taskTitle,
+    taskPrompt: next.taskPrompt ?? previous.taskPrompt,
+    acceptanceCriteria: next.acceptanceCriteria.length > 0 ? next.acceptanceCriteria : previous.acceptanceCriteria,
+    missingFields: next.missingFields.length > 0 ? next.missingFields : previous.missingFields,
+    clarifyingQuestion: next.clarifyingQuestion ?? previous.clarifyingQuestion
+  };
+}
+
+export function isIntentComplete(parse: SlackIntentParseResult) {
+  if (parse.intent !== 'create_task') {
+    return false;
+  }
+  if (parse.confidence < INTENT_CONFIDENCE_THRESHOLD) {
+    return false;
+  }
+  if (!parse.taskTitle || !parse.taskPrompt) {
+    return false;
+  }
+  return true;
+}
+
+export function buildClarificationQuestion(parse: SlackIntentParseResult) {
+  return parse.clarifyingQuestion
+    ?? 'Please clarify repository, objective, and acceptance criteria.';
+}
+
+export function defaultSlackIntentSettings(): SlackIntentSettings {
+  return {
+    intentEnabled: true,
+    intentModel: DEFAULT_MODEL,
+    intentReasoningEffort: DEFAULT_REASONING_EFFORT,
+    intentAutoCreate: DEFAULT_AUTO_CREATE,
+    intentClarifyMaxTurns: DEFAULT_CLARIFY_MAX_TURNS
+  };
+}
+

--- a/src/server/integrations/slack/payload.ts
+++ b/src/server/integrations/slack/payload.ts
@@ -3,7 +3,7 @@ import { badRequest } from '../../http/errors';
 export type SlackSlashCommandPayload = {
   command: string;
   text: string;
-  issueKey: string;
+  issueKey?: string;
   teamId: string | undefined;
   channelId: string;
   threadTs: string | undefined;
@@ -11,7 +11,14 @@ export type SlackSlashCommandPayload = {
   responseUrl: string | undefined;
 };
 
-export type SlackInteractionAction = 'repo_disambiguation' | 'approve_rerun' | 'pause' | 'close';
+export type SlackInteractionAction =
+  | 'repo_disambiguation'
+  | 'approve_rerun'
+  | 'pause'
+  | 'close'
+  | 'intent_repo_select'
+  | 'intent_confirm_create'
+  | 'intent_cancel';
 
 export type SlackInteractionValue = {
   tenantId?: string;
@@ -25,6 +32,7 @@ export type SlackInteractionValue = {
   issueTitle?: string;
   issueBody?: string;
   issueUrl?: string;
+  sessionKey?: string;
 };
 
 export type ParsedSlackInteraction = {
@@ -41,12 +49,20 @@ export type ParsedSlackInteraction = {
   issueTitle?: string;
   issueBody?: string;
   issueUrl?: string;
+  sessionKey?: string;
 };
 
 type SlackEventPayload = {
   type: string;
   challenge?: string;
   teamId?: string;
+  eventId?: string;
+  eventType?: string;
+  channelId?: string;
+  threadTs?: string;
+  text?: string;
+  userId?: string;
+  botId?: string;
 };
 
 const ISSUE_KEY_PATTERN = /^[A-Z][A-Z0-9_]*-\d+$/i;
@@ -56,7 +72,10 @@ const SUPPORTED_ACTION_IDS: Set<string> = new Set([
   'repo_disambiguation',
   'approve_rerun',
   'pause',
-  'close'
+  'close',
+  'intent_repo_select',
+  'intent_confirm_create',
+  'intent_cancel'
 ]);
 
 function readFormValue(params: URLSearchParams, key: string, required: true): string;
@@ -120,18 +139,18 @@ export function parseSlackSlashCommandBody(rawBody: string): SlackSlashCommandPa
   }
   const text = readFormValue(params, 'text', false) ?? '';
   const match = FIX_COMMAND_PATTERN.exec(text);
-  if (!match || !match[1]) {
-    throw badRequest('Invalid slash command format. Expected: /kanvy fix <JIRA_KEY>.');
-  }
-  const issueKey = match[1].toUpperCase();
-  if (!ISSUE_KEY_PATTERN.test(issueKey)) {
-    throw badRequest('Invalid issue key.');
+  let issueKey: string | undefined;
+  if (match?.[1]) {
+    issueKey = match[1].toUpperCase();
+    if (!ISSUE_KEY_PATTERN.test(issueKey)) {
+      throw badRequest('Invalid issue key.');
+    }
   }
 
   return {
     command,
     text,
-    issueKey,
+    ...(issueKey ? { issueKey } : {}),
     teamId: readFormValue(params, 'team_id', false),
     channelId: readFormValue(params, 'channel_id', true),
     threadTs: readFormValue(params, 'thread_ts', false),
@@ -174,15 +193,20 @@ export function parseSlackInteractionBody(rawBody: string): ParsedSlackInteracti
   const team = payload.team as Record<string, unknown> | undefined;
   const tenantId = (value.tenantId ?? undefined) as string | undefined;
 
+  const parsedTaskId = typeof value.taskId === 'string' && value.taskId.trim()
+    ? value.taskId.trim()
+    : typeof payload.callback_id === 'string' && payload.callback_id.trim()
+      ? payload.callback_id.trim()
+      : '';
+  if (!parsedTaskId && !actionId.startsWith('intent_')) {
+    throw badRequest('Missing Slack interaction task id.');
+  }
+
   return {
     actionId,
     teamId: typeof team?.id === 'string' && team.id.trim() ? team.id.trim() : undefined,
     tenantId,
-    taskId: typeof value.taskId === 'string' && value.taskId.trim()
-      ? value.taskId.trim()
-      : typeof payload.callback_id === 'string' && payload.callback_id.trim()
-        ? payload.callback_id.trim()
-        : undefined!,
+    taskId: parsedTaskId,
     channelId: typeof value.channelId === 'string' && value.channelId.trim()
       ? value.channelId.trim()
       : typeof (container?.channel_id) === 'string' && container?.channel_id.trim()
@@ -199,7 +223,8 @@ export function parseSlackInteractionBody(rawBody: string): ParsedSlackInteracti
     issueKey: readOptionalString(value.issueKey, 'issueKey'),
     issueTitle: readOptionalString(value.issueTitle, 'issueTitle'),
     issueBody: readOptionalString(value.issueBody, 'issueBody'),
-    issueUrl: readOptionalString(value.issueUrl, 'issueUrl')
+    issueUrl: readOptionalString(value.issueUrl, 'issueUrl'),
+    sessionKey: readOptionalString(value.sessionKey, 'sessionKey')
   };
 }
 
@@ -213,9 +238,11 @@ export function parseSlackEventBody(rawBody: string): SlackEventPayload {
   if (!payload || typeof payload.type !== 'string') {
     throw badRequest('Invalid Slack event payload.');
   }
+  const event = payload.event as Record<string, unknown> | undefined;
   return {
     type: payload.type,
     challenge: typeof payload.challenge === 'string' ? payload.challenge : undefined,
+    eventId: typeof payload.event_id === 'string' ? payload.event_id : undefined,
     teamId: (() => {
       const event = payload as Record<string, unknown>;
       if (typeof event.team_id === 'string' && event.team_id.trim()) {
@@ -223,6 +250,16 @@ export function parseSlackEventBody(rawBody: string): SlackEventPayload {
       }
       const team = event.team as Record<string, unknown> | undefined;
       return typeof team?.id === 'string' && team.id.trim() ? team.id.trim() : undefined;
-    })()
+    })(),
+    eventType: typeof event?.type === 'string' ? event.type : undefined,
+    channelId: typeof event?.channel === 'string' ? event.channel : undefined,
+    threadTs: typeof event?.thread_ts === 'string'
+      ? event.thread_ts
+      : typeof event?.ts === 'string'
+        ? event.ts
+        : undefined,
+    text: typeof event?.text === 'string' ? event.text : undefined,
+    userId: typeof event?.user === 'string' ? event.user : undefined,
+    botId: typeof event?.bot_id === 'string' ? event.bot_id : undefined
   };
 }


### PR DESCRIPTION
## Objective
Implement P10 one-shot Slack intake so `/kanvy` accepts free text, preserves deterministic Jira fast-path behavior, and can auto-create task/run after clarification.

## Scope
- Slack slash parser updated for free-text payloads while keeping `fix <JIRA_KEY>` fast-path.
- New Slack intent intake module with strict-JSON parser path, deterministic fallback, and KV-backed thread session state.
- Slack command/event/interaction handlers extended for:
  - intake parsing
  - clarification loop continuation from thread replies
  - repo disambiguation for generic tasks
  - auto-create task/run when intent is complete/high-confidence
- Slack docs + plan docs updated for new behavior.

## Behavior changes
- `/kanvy fix <JIRA_KEY>` remains deterministic and unchanged in flow semantics.
- `/kanvy <free text>` now:
  - parses intent
  - persists session by `tenant+channel+thread`
  - asks clarification questions (max turns default 4)
  - auto-starts task/run when complete/confident
- Added `intent_repo_select` Slack interaction action for generic task repo selection.
- Slack events now process message replies for active intake sessions.
- Jira fast-path default task model updated to `gpt-5.1-codex-mini`.

## API/type changes
- `SlackSlashCommandPayload.issueKey` is now optional (fast-path only).
- `SlackInteractionAction` now includes:
  - `intent_repo_select`
  - `intent_confirm_create`
  - `intent_cancel`
- `SlackInteractionValue` / `ParsedSlackInteraction` include `sessionKey`.
- Slack event payload parsing now surfaces message event fields used by intake continuation.
- Added `src/server/integrations/slack/intent.ts` for intent/session contracts.

## Backward compatibility
- Existing `/kanvy fix <JIRA_KEY>` route and Jira mapping/disambiguation flow are preserved.
- Existing rerun/pause/close Slack interactions remain intact.
- Existing dedupe/idempotency behavior remains and is reused for free-text ingress.

## Manual QA
- Verified task context from local Agents Kanban (`task_repo_abuiles_agents_kanban_sbmelmv3`).
- Verified branch/worktree isolation from main.
- Added/updated tests covering:
  - free-text slash intake auto-start with single repo
  - thread-reply continuation path from Slack events
  - existing Jira fast-path expectation update

## Risks/Rollback
- Risk: free-text heuristics fallback may produce low-quality intent in environments without parser model key configured.
- Risk: new interaction/event paths can increase Slack message volume if sessions are noisy.
- Rollback: revert this PR commit to restore strict Jira-only slash parsing and prior Slack event no-op behavior.

## Deferred follow-ups
- Add dedicated persistence table for intake sessions (currently KV-backed).
- Tighten structured validation for generic-task acceptance criteria composition.
- Expand interactive disambiguation UX for event-thread continuation (currently text guidance path for non-response_url continuation).
