### PR TITLE
S10: Slack free-text intent intake + clarification loop

### DIFF
--- a/docs/integrations/slack-jira-gitlab-mvp.md
+++ b/docs/integrations/slack-jira-gitlab-mvp.md
@@ -8,6 +8,7 @@ In scope (MVP):
 
 - Slack-triggered task start from Jira key (`/kanvy fix <JIRA_KEY>`)
 - Slack slash help response (`/kanvy help`) with concise usage examples
+- Slack free-text intake (`/kanvy <request>`) with in-thread clarification loop
 - Jira issue load and repo resolution (mapping and disambiguation)
 - Task/run start from `main`
 - GitLab MR lifecycle and feedback mirrored to Slack thread
@@ -39,12 +40,13 @@ Out of scope (this phase):
 
 ## Operator day-to-day flow (no dashboard required)
 
-1. In Slack, run `/kanvy fix ABC-123`.
-   - For usage guidance, run `/kanvy help`.
-2. If multiple repo mappings are available, click a repo disambiguation button.
-3. Monitor status and MR feedback in the same Slack thread.
-4. When feedback arrives and run enters `DECISION_REQUIRED`, click `Approve rerun`.
-5. Continue the thread loop until `DONE`, `PAUSED`, or `FAILED`.
+1. In Slack, run `/kanvy fix ABC-123` for deterministic Jira flow, or `/kanvy <free-text request>` from a thread.
+2. For free-text flow, answer clarifying questions in the same thread (max 4 turns before structured handoff prompt).
+3. For usage guidance, run `/kanvy help`.
+4. If multiple repo mappings are available, click a repo disambiguation button (Jira flow) or reply with repo id (free-text flow).
+5. Monitor status and MR feedback in the same Slack thread.
+6. When feedback arrives and run enters `DECISION_REQUIRED`, click `Approve rerun`.
+7. Continue the thread loop until `DONE`, `PAUSED`, or `FAILED`.
 
 ## Reliability and hardening behavior
 
@@ -122,5 +124,5 @@ Execution sequencing for task pack remains strict:
 Model config standard for task creation:
 
 - `codex`
-- `gpt-5.3-codex-spark`
-- `high`
+- `gpt-5.1-codex-mini` (default; override via scoped Slack config `intentModel`)
+- `medium` (generic/default intake), deterministic Jira remains compatible

--- a/docs/plans/current/README.md
+++ b/docs/plans/current/README.md
@@ -13,7 +13,7 @@ This folder is the source of truth for active planning and execution.
 - [P7: Built-in Sentinel Orchestration](./p7-sentinel-orchestration.md)
 - [P8: Checkpoint Recovery + Ephemeral Context Notes](./p8-checkpoint-recovery-and-context-notes.md)
 - [P9: GitHub Auto-Review Provider](./p9-github-auto-review-provider.md)
-- [P10: Slack Free-Text Intent Intake + Model-Selectable Parser (One-Shot)](./p10-slack-intent-intake-one-shot.md)
+- [P10: Slack Free-Text Intent Intake + Model-Selectable Parser (One-Shot, S10 in progress)](./p10-slack-intent-intake-one-shot.md)
 - [P11: Review Sandbox Operator Control and Attachability](./p11-review-sandbox-operator-control.md)
 - [Migration Status](./migration-status.md)
 

--- a/docs/plans/current/p10-slack-intent-intake-one-shot.md
+++ b/docs/plans/current/p10-slack-intent-intake-one-shot.md
@@ -1,6 +1,6 @@
 # Stage: Slack Free-Text Intent Intake + Model-Selectable Parser (One-Shot Execution)
 
-**Status:** Planned
+**Status:** In progress (S10 implementation landed)
 
 ## Goal
 

--- a/migrations/0004_slack_intake_sessions.sql
+++ b/migrations/0004_slack_intake_sessions.sql
@@ -1,0 +1,20 @@
+CREATE TABLE IF NOT EXISTS slack_intake_sessions (
+  id INTEGER PRIMARY KEY,
+  external_id TEXT NOT NULL UNIQUE,
+  tenant_id TEXT NOT NULL,
+  channel_id TEXT NOT NULL,
+  thread_ts TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'completed', 'cancelled', 'expired')),
+  turn_count INTEGER NOT NULL DEFAULT 0,
+  last_confidence REAL,
+  session_json TEXT NOT NULL DEFAULT '{}',
+  last_activity_at TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  UNIQUE (tenant_id, channel_id, thread_ts)
+);
+
+CREATE INDEX IF NOT EXISTS idx_slack_intake_sessions_tenant_channel_thread
+  ON slack_intake_sessions (tenant_id, channel_id, thread_ts);
+CREATE INDEX IF NOT EXISTS idx_slack_intake_sessions_status
+  ON slack_intake_sessions (tenant_id, status, last_activity_at);

--- a/src/server/integrations/slack-jira-gitlab-mvp.e2e.test.ts
+++ b/src/server/integrations/slack-jira-gitlab-mvp.e2e.test.ts
@@ -16,6 +16,7 @@ const tenantAuthDbMocks = vi.hoisted(() => {
       return { ok: true };
     }),
     getPrimaryTenantId: vi.fn(async () => 'tenant_local'),
+    getSlackIntakeSession: vi.fn(async () => undefined),
     listJiraProjectRepoMappingsByProject: vi.fn(async () => ([
       {
         id: 'mapping_1',
@@ -28,6 +29,19 @@ const tenantAuthDbMocks = vi.hoisted(() => {
         updatedAt: ''
       }
     ])),
+    listIntegrationConfigs: vi.fn(async () => []),
+    upsertSlackIntakeSession: vi.fn(async () => ({
+      id: 'intake_1',
+      tenantId: 'tenant_local',
+      channelId: 'C_ENG',
+      threadTs: '1710000000.100',
+      status: 'active',
+      turnCount: 1,
+      data: {},
+      lastActivityAt: '2026-01-01T00:00:00.000Z',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z'
+    })),
     upsertSlackThreadBinding: vi.fn(async (_env: Env, input: {
       tenantId: string;
       taskId: string;

--- a/src/server/integrations/slack/client.ts
+++ b/src/server/integrations/slack/client.ts
@@ -34,7 +34,7 @@ async function resolveSlackBotToken(env: Env, config: IntegrationConfig | undefi
   return fallback?.trim() || undefined;
 }
 
-async function resolveSlackConfig(env: Env, target: { tenantId: string; repoId: string; channelId: string }) {
+async function resolveSlackConfig(env: Env, target: { tenantId: string; repoId?: string; channelId: string }) {
   const configs = await tenantAuthDb.listIntegrationConfigs(env, target.tenantId, {
     pluginKind: 'slack',
     enabledOnly: true
@@ -56,7 +56,7 @@ export async function postSlackThreadMessage(
   env: Env,
   target: {
     tenantId: string;
-    repoId: string;
+    repoId?: string;
     channelId: string;
     threadTs: string;
     text: string;

--- a/src/server/integrations/slack/handlers.test.ts
+++ b/src/server/integrations/slack/handlers.test.ts
@@ -5,7 +5,10 @@ import { handleSlackCommands, handleSlackEvents, handleSlackInteractions } from 
 const tenantAuthDbMocks = vi.hoisted(() => ({
   deleteSlackThreadBinding: vi.fn(),
   getPrimaryTenantId: vi.fn(),
+  getSlackIntakeSession: vi.fn(),
   listJiraProjectRepoMappingsByProject: vi.fn(),
+  listIntegrationConfigs: vi.fn(),
+  upsertSlackIntakeSession: vi.fn(),
   upsertSlackThreadBinding: vi.fn()
 }));
 
@@ -99,7 +102,8 @@ function makeEnv(secret = 'secret', repoBoard = makeRepoBoard({ taskId: 'task_1'
   return {
     SECRETS_KV: createKv(secret),
     REPO_BOARD: { getByName: vi.fn(() => repoBoard) },
-    BOARD_INDEX: boardIndex
+    BOARD_INDEX: boardIndex,
+    OPENAI_API_KEY: 'sk-test'
   } as unknown as Env;
 }
 
@@ -123,6 +127,20 @@ describe('slack handlers', () => {
       channelId: string;
       threadTs: string;
     }) => taskBinding(input.taskId, input.channelId, input.threadTs));
+    tenantAuthDbMocks.getSlackIntakeSession.mockResolvedValue(undefined);
+    tenantAuthDbMocks.listIntegrationConfigs.mockResolvedValue([]);
+    tenantAuthDbMocks.upsertSlackIntakeSession.mockResolvedValue({
+      id: 'intake_1',
+      tenantId: 'tenant_local',
+      channelId: 'C123',
+      threadTs: '1672531200.1234',
+      status: 'active',
+      turnCount: 1,
+      data: {},
+      lastActivityAt: '2026-01-01T00:00:00.000Z',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z'
+    });
     tenantAuthDbMocks.deleteSlackThreadBinding.mockResolvedValue({ ok: true });
     tenantAuthDbMocks.listJiraProjectRepoMappingsByProject.mockResolvedValue([]);
     jiraClientMocks.createJiraIssueSourceIntegrationFromEnv.mockReturnValue({
@@ -167,8 +185,8 @@ describe('slack handlers', () => {
       repoId: 'repo_alpha',
       sourceRef: 'main',
       llmAdapter: 'codex',
-      codexModel: 'gpt-5.3-codex-spark',
-      codexReasoningEffort: 'high'
+      codexModel: 'gpt-5.1-codex-mini',
+      codexReasoningEffort: 'medium'
     }));
     expect(repoBoard.startRun).toHaveBeenCalledWith('task_single', { tenantId: 'team_one' });
     expect(repoBoard.transitionRun).toHaveBeenCalledWith('run_single', {
@@ -232,7 +250,7 @@ describe('slack handlers', () => {
 
     expect(response.status).toBe(200);
     expect(body.ok).toBe(true);
-    expect(body.text).toContain('Accepted /kanvy help command');
+    expect(body.text).toContain('Accepted /kanvy command.');
     expect(waitUntil).toHaveBeenCalledTimes(1);
     await waitUntilTasks[0];
     const calledPayload = JSON.parse(((vi.mocked(global.fetch).mock.calls[0] as [string, RequestInit])[1].body as string));
@@ -242,6 +260,66 @@ describe('slack handlers', () => {
     expect(fetchIssue).not.toHaveBeenCalled();
     expect(repoBoard.createTask).not.toHaveBeenCalled();
     expect(repoBoard.startRun).not.toHaveBeenCalled();
+  });
+
+  it('supports free-text intake and auto-creates task when parser returns complete intent', async () => {
+    const repoBoard = makeRepoBoard({ taskId: 'task_intake', runId: 'run_intake' });
+    tenantAuthDbMocks.listJiraProjectRepoMappingsByProject.mockResolvedValue([]);
+    fetchSpy.mockImplementation(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/v1/chat/completions')) {
+        return new Response(JSON.stringify({
+          choices: [{
+            message: {
+              content: JSON.stringify({
+                intent: 'create_task',
+                confidence: 0.92,
+                repoId: 'repo_alpha',
+                taskTitle: 'Improve README',
+                taskPrompt: 'Update README structure and examples.',
+                acceptanceCriteria: ['README has clearer setup', 'Examples compile'],
+                missingFields: []
+              })
+            }
+          }]
+        }), { status: 200 });
+      }
+      return new Response('{}', { status: 200 });
+    });
+
+    const rawBody = new URLSearchParams({
+      command: '/kanvy',
+      text: 'draft MR for README improvements in repo_alpha',
+      channel_id: 'C123',
+      thread_ts: '1672531200.1234',
+      team_id: 'team_one',
+      user_id: 'U1',
+      response_url: 'https://hooks.slack.com/commands/response'
+    }).toString();
+    const signature = await buildSlackSignature('secret', nowTs, rawBody);
+    const request = new Request('https://example.test/api/integrations/slack/commands', {
+      method: 'POST',
+      headers: slackHeaders(nowTs, signature),
+      body: rawBody
+    });
+    const waitUntilTasks: Array<Promise<unknown>> = [];
+    const waitUntil = vi.fn((task: Promise<unknown>) => waitUntilTasks.push(task));
+    const response = await handleSlackCommands(request, makeEnv('secret', repoBoard), { waitUntil } as unknown as ExecutionContext<unknown>);
+
+    expect(response.status).toBe(200);
+    await waitUntilTasks[0];
+    expect(repoBoard.createTask).toHaveBeenCalledWith(expect.objectContaining({
+      repoId: 'repo_alpha',
+      title: 'Improve README',
+      codexModel: 'gpt-5.1-codex-mini'
+    }));
+    expect(repoBoard.startRun).toHaveBeenCalledWith('task_intake', { tenantId: 'team_one' });
+    expect(tenantAuthDbMocks.upsertSlackIntakeSession).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+      tenantId: 'team_one',
+      channelId: 'C123',
+      threadTs: '1672531200.1234',
+      status: 'completed'
+    }));
   });
 
   it('asks for repo disambiguation when multiple mappings exist', async () => {

--- a/src/server/integrations/slack/handlers.ts
+++ b/src/server/integrations/slack/handlers.ts
@@ -7,6 +7,7 @@ import { createJiraIssueSourceIntegrationFromEnv } from '../jira/client';
 import { scheduleRunJob } from '../../run-orchestrator';
 import { buildIdempotencyKey } from '../idempotency';
 import {
+  parseJiraFastPathIssueKey,
   parseSlackEventBody,
   parseSlackInteractionBody,
   parseSlackSlashCommandBody,
@@ -14,14 +15,21 @@ import {
 } from './payload';
 import { resolveThreadTenant, verifySlackRequest } from './verification';
 import { mirrorRunLifecycleMilestone } from './timeline';
+import { postSlackThreadMessage } from './client';
+import { resolveIntegrationConfig } from '../config-resolution';
+import {
+  parseSlackIntentWithLlm,
+  resolveSlackIntentSettings,
+  type SlackIntentParseResult
+} from './intent';
 
 const DEFAULT_TASK_ID_PREFIX = 'issue';
 const DEFAULT_REVIEW_ROUND = 0;
 const BOARD_OBJECT_NAME = 'agentboard';
 const SOURCE_REF = 'main';
 const JIRA_LLM_ADAPTER: CreateTaskInput['llmAdapter'] = 'codex';
-const JIRA_LLM_MODEL: CreateTaskInput['codexModel'] = 'gpt-5.3-codex-spark';
-const JIRA_LLM_REASONING_EFFORT: CreateTaskInput['codexReasoningEffort'] = 'high';
+const DEFAULT_TASK_LLM_MODEL: CreateTaskInput['codexModel'] = 'gpt-5.1-codex-mini';
+const JIRA_LLM_REASONING_EFFORT: CreateTaskInput['codexReasoningEffort'] = 'medium';
 const FALLBACK_DISAMBIGUATION_WARNING = 'No matching repository was auto-selected for this issue.';
 const DISAMBIGUATION_MULTIPLE_MAPPINGS_MESSAGE = 'Multiple repositories are mapped for Jira project';
 const DISAMBIGUATION_NO_MAPPING_MESSAGE = 'No active mapping exists for project';
@@ -32,6 +40,8 @@ const KANVY_HELP_TEXT = [
   '- Jira fast-path: `/kanvy fix ABC-123`',
   '- Free-text flow: `/kanvy Investigate flaky checkout tests and propose a fix plan`'
 ].join('\n');
+const SESSION_EXPIRY_MS = 24 * 60 * 60 * 1000;
+const AUTO_CREATE_CONFIDENCE_THRESHOLD = 0.8;
 
 type RepoDisambiguationChoice = {
   repoId: string;
@@ -70,7 +80,11 @@ function buildTaskPromptFromIssue(issue: IntegrationIssueRef) {
   return `Fix Jira issue ${issue.issueKey}: ${issue.title}\n\n${issue.body}`.trim();
 }
 
-function buildTaskPayloadFromIssue(issue: IntegrationIssueRef, repoId: string): CreateTaskInput {
+function buildTaskPayloadFromIssue(
+  issue: IntegrationIssueRef,
+  repoId: string,
+  model = DEFAULT_TASK_LLM_MODEL
+): CreateTaskInput {
   return {
     repoId,
     title: `[${issue.issueKey}] ${issue.title}`.trim(),
@@ -87,8 +101,32 @@ function buildTaskPayloadFromIssue(issue: IntegrationIssueRef, repoId: string): 
       notes: `Imported from Jira issue ${issue.issueKey}: ${issue.title}`
     },
     llmAdapter: JIRA_LLM_ADAPTER,
-    codexModel: JIRA_LLM_MODEL,
+    codexModel: model,
     codexReasoningEffort: JIRA_LLM_REASONING_EFFORT
+  };
+}
+
+function buildTaskPayloadFromIntent(input: {
+  repoId: string;
+  title: string;
+  prompt: string;
+  acceptanceCriteria: string[];
+  model: CreateTaskInput['codexModel'];
+}): CreateTaskInput {
+  return {
+    repoId: input.repoId,
+    title: input.title,
+    description: input.prompt,
+    sourceRef: SOURCE_REF,
+    taskPrompt: input.prompt,
+    acceptanceCriteria: input.acceptanceCriteria,
+    context: {
+      links: [],
+      notes: 'Created from Slack /kanvy intent intake.'
+    },
+    llmAdapter: JIRA_LLM_ADAPTER,
+    codexModel: input.model,
+    codexReasoningEffort: 'medium'
   };
 }
 
@@ -196,6 +234,13 @@ function normalizeLatestReviewRound(value: number | undefined) {
   return Number.isFinite(value) ? Number(value) : DEFAULT_REVIEW_ROUND;
 }
 
+function toSupportedCodexModel(value: string | undefined): CreateTaskInput['codexModel'] {
+  if (value === 'gpt-5.3-codex' || value === 'gpt-5.3-codex-spark' || value === 'gpt-5.1-codex-mini') {
+    return value;
+  }
+  return DEFAULT_TASK_LLM_MODEL;
+}
+
 function normalizeJiraIssueFromInteraction(values: {
   issueKey: string;
   issueTitle?: string;
@@ -240,6 +285,93 @@ async function resolveRepoCandidates(
   } catch {
     return [];
   }
+}
+
+async function resolveSlackIntentScopeConfig(
+  env: Env,
+  tenantId: string,
+  scope: { repoId?: string; channelId: string }
+) {
+  const configs = await tenantAuthDb.listIntegrationConfigs(env, tenantId, {
+    pluginKind: 'slack',
+    enabledOnly: true
+  });
+  return {
+    config: resolveIntegrationConfig(configs, {
+      tenantId,
+      pluginKind: 'slack',
+      repoId: scope.repoId,
+      channelId: scope.channelId
+    }),
+    settings: resolveSlackIntentSettings(configs, {
+      tenantId,
+      repoId: scope.repoId,
+      channelId: scope.channelId
+    })
+  };
+}
+
+function isSessionExpired(lastActivityAt: string) {
+  const parsed = Date.parse(lastActivityAt);
+  if (!Number.isFinite(parsed)) {
+    return false;
+  }
+  return Date.now() - parsed > SESSION_EXPIRY_MS;
+}
+
+function normalizeIntentMissingFields(fields: string[], repoResolved: boolean) {
+  if (!repoResolved && !fields.includes('repo')) {
+    return [...fields, 'repo'];
+  }
+  return fields;
+}
+
+async function resolveRepoIdForIntent(
+  env: Env,
+  tenantId: string,
+  channelId: string,
+  parsed: SlackIntentParseResult
+) {
+  if (parsed.repoId?.trim()) {
+    return { repoId: parsed.repoId.trim(), ambiguous: false, choices: [] as string[] };
+  }
+
+  const { settings } = await resolveSlackIntentScopeConfig(env, tenantId, {
+    channelId,
+    repoId: undefined
+  });
+  if (settings.defaultRepoId?.trim()) {
+    return { repoId: settings.defaultRepoId.trim(), ambiguous: false, choices: [] as string[] };
+  }
+
+  const boardIndex = env.BOARD_INDEX?.getByName(BOARD_OBJECT_NAME);
+  if (!boardIndex) {
+    return { repoId: undefined, ambiguous: false, choices: [] as string[] };
+  }
+  try {
+    const repos = await boardIndex.listRepos(tenantId);
+    if (repos.length === 1 && repos[0]?.repoId) {
+      return { repoId: repos[0].repoId, ambiguous: false, choices: [] as string[] };
+    }
+    if (repos.length > 1) {
+      const choices = repos.map((repo) => repo.repoId).filter((repoId): repoId is string => Boolean(repoId));
+      if (parsed.repoHint?.trim()) {
+        const hint = parsed.repoHint.trim().toLowerCase();
+        const exact = choices.find((repoId) => repoId.toLowerCase() === hint);
+        if (exact) {
+          return { repoId: exact, ambiguous: false, choices };
+        }
+        const partial = choices.find((repoId) => repoId.toLowerCase().includes(hint));
+        if (partial) {
+          return { repoId: partial, ambiguous: false, choices };
+        }
+      }
+      return { repoId: undefined, ambiguous: true, choices };
+    }
+  } catch {
+    // Best effort.
+  }
+  return { repoId: undefined, ambiguous: false, choices: [] as string[] };
 }
 
 async function resolveRepoIdForRun(env: Env, runId: string): Promise<string | undefined> {
@@ -408,7 +540,8 @@ async function processJiraIssueFlow(
     threadTs?: string;
     latestReviewRound?: number;
   },
-  responseUrl: string | undefined
+  responseUrl: string | undefined,
+  llmModel: CreateTaskInput['codexModel'] = DEFAULT_TASK_LLM_MODEL
 ) {
   const issueProjectKey = issueProjectKeyFromIssue(issue.issueKey);
   const mappings = await tenantAuthDb.listJiraProjectRepoMappingsByProject(env, tenantId, issueProjectKey, true);
@@ -452,7 +585,7 @@ async function processJiraIssueFlow(
   }
 
   const repoId = candidates[0]!.repoId;
-  const payload = buildTaskPayloadFromIssue(issue, repoId);
+  const payload = buildTaskPayloadFromIssue(issue, repoId, llmModel);
   try {
     const started = await startRunForTask(env, ctx, tenantId, repoId, payload);
     if (bindings.threadTs) {
@@ -514,12 +647,170 @@ async function updateBindingForAction(
   });
 }
 
+async function postThreadPrompt(
+  env: Env,
+  input: {
+    tenantId: string;
+    channelId: string;
+    threadTs: string;
+    text: string;
+  }
+) {
+  await postSlackThreadMessage(env, {
+    tenantId: input.tenantId,
+    channelId: input.channelId,
+    threadTs: input.threadTs,
+    text: input.text
+  }).catch(() => {});
+}
+
+async function runIntentIntake(
+  env: Env,
+  ctx: ExecutionContext<unknown> | undefined,
+  input: {
+    tenantId: string;
+    channelId: string;
+    threadTs: string;
+    text: string;
+    responseUrl?: string;
+  }
+) {
+  const existing = await tenantAuthDb.getSlackIntakeSession(env, input.tenantId, input.channelId, input.threadTs);
+  const expired = existing ? isSessionExpired(existing.lastActivityAt) : false;
+  if (existing && expired && existing.status === 'active') {
+    await tenantAuthDb.upsertSlackIntakeSession(env, {
+      tenantId: input.tenantId,
+      channelId: input.channelId,
+      threadTs: input.threadTs,
+      status: 'expired',
+      turnCount: existing.turnCount,
+      data: existing.data
+    });
+  }
+
+  const currentTurn = existing?.status === 'active' && !expired ? existing.turnCount : 0;
+  const { settings } = await resolveSlackIntentScopeConfig(env, input.tenantId, {
+    channelId: input.channelId
+  });
+  const parsed = await parseSlackIntentWithLlm(env, {
+    text: input.text,
+    settings,
+    priorTurns: currentTurn
+  });
+
+  const repoResolution = await resolveRepoIdForIntent(env, input.tenantId, input.channelId, parsed);
+  const missingFields = normalizeIntentMissingFields(parsed.missingFields, Boolean(repoResolution.repoId));
+  const isComplete = parsed.confidence >= AUTO_CREATE_CONFIDENCE_THRESHOLD
+    && parsed.intent === 'create_task'
+    && Boolean(parsed.taskPrompt?.trim())
+    && Boolean(parsed.taskTitle?.trim())
+    && missingFields.length === 0;
+
+  if (isComplete && settings.intentAutoCreate && repoResolution.repoId) {
+    const payload = buildTaskPayloadFromIntent({
+      repoId: repoResolution.repoId,
+      title: parsed.taskTitle!.trim(),
+      prompt: parsed.taskPrompt!.trim(),
+      acceptanceCriteria: parsed.acceptanceCriteria.length > 0
+        ? parsed.acceptanceCriteria
+        : ['Task is complete and validated in the target repository.'],
+      model: toSupportedCodexModel(settings.intentModel)
+    });
+    const started = await startRunForTask(env, ctx, input.tenantId, repoResolution.repoId, payload);
+    await tenantAuthDb.upsertSlackThreadBinding(env, {
+      tenantId: input.tenantId,
+      taskId: started.taskId,
+      channelId: input.channelId,
+      threadTs: input.threadTs,
+      currentRunId: started.runId,
+      latestReviewRound: DEFAULT_REVIEW_ROUND
+    });
+    await tenantAuthDb.upsertSlackIntakeSession(env, {
+      tenantId: input.tenantId,
+      channelId: input.channelId,
+      threadTs: input.threadTs,
+      status: 'completed',
+      turnCount: currentTurn,
+      lastConfidence: parsed.confidence,
+      data: {
+        ...parsed,
+        lastUserText: input.text
+      }
+    });
+    const completionText = `Created task ${started.taskId} and started run ${started.runId} in ${repoResolution.repoId}.`;
+    if (input.responseUrl) {
+      await postSlackResponse(input.responseUrl, { response_type: 'ephemeral', text: completionText });
+    } else {
+      await postThreadPrompt(env, {
+        tenantId: input.tenantId,
+        channelId: input.channelId,
+        threadTs: input.threadTs,
+        text: completionText
+      });
+    }
+    return;
+  }
+
+  const nextTurn = currentTurn + 1;
+  const maxTurns = settings.intentClarifyMaxTurns;
+  const needsRepoDisambiguation = !repoResolution.repoId && repoResolution.ambiguous && repoResolution.choices.length > 0;
+  const question = needsRepoDisambiguation
+    ? `I found multiple repos: ${repoResolution.choices.join(', ')}. Which repo should I use?`
+    : parsed.clarifyingQuestion
+      ?? 'Please clarify repo, exact goal, and acceptance criteria.';
+
+  await tenantAuthDb.upsertSlackIntakeSession(env, {
+    tenantId: input.tenantId,
+    channelId: input.channelId,
+    threadTs: input.threadTs,
+    status: nextTurn >= maxTurns ? 'active' : 'active',
+    turnCount: nextTurn,
+    lastConfidence: parsed.confidence,
+    data: {
+      ...parsed,
+      missingFields,
+      clarifyingQuestion: question,
+      lastUserText: input.text
+    }
+  });
+
+  if (nextTurn >= maxTurns) {
+    const handoff = [
+      `I still need more detail after ${maxTurns} clarification turns.`,
+      'Please hand off in a structured format:',
+      '`repo=<repo_id>; title=<short title>; prompt=<goal>; acceptance=<item1 | item2>`'
+    ].join('\n');
+    if (input.responseUrl) {
+      await postSlackResponse(input.responseUrl, { response_type: 'ephemeral', text: handoff });
+    } else {
+      await postThreadPrompt(env, {
+        tenantId: input.tenantId,
+        channelId: input.channelId,
+        threadTs: input.threadTs,
+        text: handoff
+      });
+    }
+    return;
+  }
+
+  if (input.responseUrl) {
+    await postSlackResponse(input.responseUrl, { response_type: 'ephemeral', text: question });
+    return;
+  }
+  await postThreadPrompt(env, {
+    tenantId: input.tenantId,
+    channelId: input.channelId,
+    threadTs: input.threadTs,
+    text: question
+  });
+}
+
 async function runSlackCommandAsync(
   env: Env,
   payload: ReturnType<typeof parseSlackSlashCommandBody>,
   ctx?: ExecutionContext<unknown>
 ) {
-  if (payload.intent === 'help') {
+  if (payload.text.trim().toLowerCase() === 'help') {
     await postSlackResponse(payload.responseUrl, {
       response_type: 'ephemeral',
       text: KANVY_HELP_TEXT
@@ -528,40 +819,81 @@ async function runSlackCommandAsync(
   }
 
   const tenantId = await resolveThreadTenantId(env, payload.teamId);
+  const issueKey = parseJiraFastPathIssueKey(payload.text);
+  const dedupeSubject = issueKey ?? payload.text.trim() || 'empty';
   const slashDedupeKey = buildIdempotencyKey({
     provider: 'slack',
     tenantId,
-    eventType: 'slash_command.fix',
-    providerEventId: payload.responseUrl ?? `${payload.teamId ?? 'team:default'}:${payload.channelId}:${payload.issueKey}`,
+    eventType: issueKey ? 'slash_command.fix' : 'slash_command.intent',
+    providerEventId: payload.responseUrl ?? `${payload.teamId ?? 'team:default'}:${payload.channelId}:${dedupeSubject}`,
     subjectId: `${payload.channelId}:${payload.threadTs ?? 'root'}`,
     metadata: {
-      issueKey: payload.issueKey,
+      issueKey: issueKey ?? null,
       userId: payload.userId
     }
   });
   if (!(await markIngressDeliveryIfNew(env, slashDedupeKey))) {
     await postSlackResponse(payload.responseUrl, {
       response_type: 'ephemeral',
-      text: `Duplicate /kanvy command ignored for ${payload.issueKey}.`
+      text: issueKey
+        ? `Duplicate /kanvy command ignored for ${issueKey}.`
+        : 'Duplicate /kanvy command ignored.'
     });
     return;
   }
+
+  if (!payload.text.trim()) {
+    await postSlackResponse(payload.responseUrl, {
+      response_type: 'ephemeral',
+      text: 'Usage: `/kanvy fix ABC-123` or `/kanvy <free-text request>`.'
+    });
+    return;
+  }
+
+  if (!issueKey) {
+    if (!payload.threadTs) {
+      await postSlackResponse(payload.responseUrl, {
+        response_type: 'ephemeral',
+        text: 'For free-text intake, run `/kanvy ...` from a thread so clarification can continue in-thread.'
+      });
+      return;
+    }
+    try {
+      await runIntentIntake(env, ctx, {
+        tenantId,
+        channelId: payload.channelId,
+        threadTs: payload.threadTs,
+        text: payload.text,
+        responseUrl: payload.responseUrl
+      });
+    } catch (error) {
+      await postSlackResponse(payload.responseUrl, {
+        response_type: 'ephemeral',
+        text: `Failed to process /kanvy command: ${toReadableErrorMessage(error)}`
+      });
+    }
+    return;
+  }
+
   const bindingTaskId = payload.threadTs
-    ? await createThreadBindingForSlashCommand(env, tenantId, payload.issueKey, payload.channelId, payload.threadTs)
-    : buildTaskIdFromIssue(payload.issueKey);
+    ? await createThreadBindingForSlashCommand(env, tenantId, issueKey, payload.channelId, payload.threadTs)
+    : buildTaskIdFromIssue(issueKey);
 
   try {
-    const issue = await resolveTenantAndJiraIssue(env, tenantId, payload.issueKey);
+    const issue = await resolveTenantAndJiraIssue(env, tenantId, issueKey);
+    const { settings } = await resolveSlackIntentScopeConfig(env, tenantId, {
+      channelId: payload.channelId
+    });
     await processJiraIssueFlow(env, ctx, tenantId, issue, {
       taskId: bindingTaskId,
       channelId: payload.channelId,
       threadTs: payload.threadTs,
       latestReviewRound: DEFAULT_REVIEW_ROUND
-    }, payload.responseUrl);
+    }, payload.responseUrl, toSupportedCodexModel(settings.intentModel));
   } catch (error) {
     await postSlackResponse(payload.responseUrl, {
       response_type: 'ephemeral',
-      text: `Failed to process /kanvy command for ${payload.issueKey}: ${toReadableErrorMessage(error)}`
+      text: `Failed to process /kanvy command for ${issueKey}: ${toReadableErrorMessage(error)}`
     });
   }
 }
@@ -627,9 +959,7 @@ export async function handleSlackCommands(
     }
     return json({
       ok: true,
-      text: payload.intent === 'help'
-        ? 'Accepted /kanvy help command.'
-        : `Accepted /kanvy command for ${payload.issueKey}.`
+      text: 'Accepted /kanvy command.'
     });
   } catch (error) {
     return handleError(error);
@@ -643,6 +973,31 @@ export async function handleSlackEvents(request: Request, env: Env): Promise<Res
     const payload = parseSlackEventBody(rawBody);
     if (payload.type === 'url_verification' && payload.challenge) {
       return json({ challenge: payload.challenge });
+    }
+    if (payload.event?.type === 'message' && payload.event.threadTs && payload.event.channelId && payload.event.text && !payload.event.botId) {
+      const tenantId = await resolveThreadTenantId(env, payload.teamId);
+      const eventDedupeKey = buildIdempotencyKey({
+        provider: 'slack',
+        tenantId,
+        eventType: 'event.thread_message',
+        providerEventId: payload.eventId ?? `${payload.event.channelId}:${payload.event.ts ?? payload.event.threadTs}`,
+        subjectId: `${payload.event.channelId}:${payload.event.threadTs}`,
+        metadata: {
+          userId: payload.event.userId ?? null
+        }
+      });
+      if (!(await markIngressDeliveryIfNew(env, eventDedupeKey))) {
+        return json({ ok: true, status: 'duplicate_event_ignored' });
+      }
+      const session = await tenantAuthDb.getSlackIntakeSession(env, tenantId, payload.event.channelId, payload.event.threadTs);
+      if (session?.status === 'active') {
+        await runIntentIntake(env, undefined, {
+          tenantId,
+          channelId: payload.event.channelId,
+          threadTs: payload.event.threadTs,
+          text: payload.event.text
+        });
+      }
     }
     return json({ ok: true, status: 'accepted' });
   } catch (error) {

--- a/src/server/integrations/slack/intent.test.ts
+++ b/src/server/integrations/slack/intent.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { resolveSlackIntentSettings } from './intent';
+import type { IntegrationConfig } from '../../../ui/domain/types';
+
+function config(input: Partial<IntegrationConfig> & Pick<IntegrationConfig, 'id' | 'tenantId' | 'scopeType' | 'pluginKind' | 'enabled' | 'settings' | 'createdAt' | 'updatedAt'>): IntegrationConfig {
+  return {
+    scopeId: undefined,
+    secretRef: undefined,
+    ...input
+  };
+}
+
+describe('slack intent settings resolution', () => {
+  it('uses precedence channel > repo > tenant and defaults model to gpt-5.1-codex-mini', () => {
+    const configs: IntegrationConfig[] = [
+      config({
+        id: 'tenant',
+        tenantId: 'tenant_local',
+        scopeType: 'tenant',
+        pluginKind: 'slack',
+        enabled: true,
+        settings: { intentModel: 'gpt-5.3-codex-spark', intentClarifyMaxTurns: 6 },
+        createdAt: '',
+        updatedAt: '2026-01-01T00:00:00.000Z'
+      }),
+      config({
+        id: 'repo',
+        tenantId: 'tenant_local',
+        scopeType: 'repo',
+        scopeId: 'repo_alpha',
+        pluginKind: 'slack',
+        enabled: true,
+        settings: { intentModel: 'gpt-5.3-codex', intentClarifyMaxTurns: 5 },
+        createdAt: '',
+        updatedAt: '2026-01-02T00:00:00.000Z'
+      }),
+      config({
+        id: 'channel',
+        tenantId: 'tenant_local',
+        scopeType: 'channel',
+        scopeId: 'C123',
+        pluginKind: 'slack',
+        enabled: true,
+        settings: { intentModel: 'gpt-5.1-codex-mini', intentClarifyMaxTurns: 4 },
+        createdAt: '',
+        updatedAt: '2026-01-03T00:00:00.000Z'
+      })
+    ];
+    const resolved = resolveSlackIntentSettings(configs, {
+      tenantId: 'tenant_local',
+      repoId: 'repo_alpha',
+      channelId: 'C123'
+    });
+    expect(resolved.intentModel).toBe('gpt-5.1-codex-mini');
+    expect(resolved.intentClarifyMaxTurns).toBe(4);
+  });
+
+  it('falls back to default parser model when no override exists', () => {
+    const resolved = resolveSlackIntentSettings([], {
+      tenantId: 'tenant_local',
+      repoId: 'repo_alpha',
+      channelId: 'C123'
+    });
+    expect(resolved.intentModel).toBe('gpt-5.1-codex-mini');
+    expect(resolved.intentClarifyMaxTurns).toBe(4);
+  });
+});

--- a/src/server/integrations/slack/intent.ts
+++ b/src/server/integrations/slack/intent.ts
@@ -1,0 +1,230 @@
+import type { IntegrationConfig, IntegrationConfigSettings } from '../../../ui/domain/types';
+import { resolveIntegrationConfig } from '../config-resolution';
+
+export type SlackIntentKind = 'fix_jira' | 'create_task' | 'unknown';
+
+export type SlackIntentParseResult = {
+  intent: SlackIntentKind;
+  confidence: number;
+  jiraKey?: string;
+  repoHint?: string;
+  repoId?: string;
+  taskTitle?: string;
+  taskPrompt?: string;
+  acceptanceCriteria: string[];
+  missingFields: string[];
+  clarifyingQuestion?: string;
+};
+
+export type SlackIntentSettings = {
+  intentEnabled: boolean;
+  intentModel: string;
+  intentReasoningEffort: 'low' | 'medium' | 'high';
+  intentAutoCreate: boolean;
+  intentClarifyMaxTurns: number;
+  defaultRepoId?: string;
+};
+
+export const DEFAULT_INTENT_MODEL = 'gpt-5.1-codex-mini';
+
+const INTENT_JSON_SCHEMA = {
+  name: 'slack_intent_parser',
+  schema: {
+    type: 'object',
+    additionalProperties: false,
+    properties: {
+      intent: { type: 'string', enum: ['fix_jira', 'create_task', 'unknown'] },
+      confidence: { type: 'number', minimum: 0, maximum: 1 },
+      jiraKey: { type: 'string' },
+      repoHint: { type: 'string' },
+      repoId: { type: 'string' },
+      taskTitle: { type: 'string' },
+      taskPrompt: { type: 'string' },
+      acceptanceCriteria: { type: 'array', items: { type: 'string' } },
+      missingFields: { type: 'array', items: { type: 'string' } },
+      clarifyingQuestion: { type: 'string' }
+    },
+    required: ['intent', 'confidence', 'acceptanceCriteria', 'missingFields']
+  },
+  strict: true
+} as const;
+
+function readBoolean(settings: IntegrationConfigSettings, key: string, fallback: boolean): boolean {
+  const value = settings[key];
+  if (typeof value === 'boolean') {
+    return value;
+  }
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+    if (normalized === 'true' || normalized === '1') {
+      return true;
+    }
+    if (normalized === 'false' || normalized === '0') {
+      return false;
+    }
+  }
+  return fallback;
+}
+
+function readString(settings: IntegrationConfigSettings, key: string): string | undefined {
+  const value = settings[key];
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
+function readReasoningEffort(settings: IntegrationConfigSettings, fallback: SlackIntentSettings['intentReasoningEffort']) {
+  const value = readString(settings, 'intentReasoningEffort');
+  if (value === 'low' || value === 'medium' || value === 'high') {
+    return value;
+  }
+  return fallback;
+}
+
+function readPositiveInt(settings: IntegrationConfigSettings, key: string, fallback: number): number {
+  const value = settings[key];
+  if (typeof value === 'number' && Number.isFinite(value) && value > 0) {
+    return Math.trunc(value);
+  }
+  if (typeof value === 'string') {
+    const parsed = Number.parseInt(value, 10);
+    if (Number.isFinite(parsed) && parsed > 0) {
+      return parsed;
+    }
+  }
+  return fallback;
+}
+
+function normalizeResult(raw: unknown): SlackIntentParseResult {
+  const parsed = raw && typeof raw === 'object' ? raw as Record<string, unknown> : {};
+  const intent = parsed.intent === 'fix_jira' || parsed.intent === 'create_task' || parsed.intent === 'unknown'
+    ? parsed.intent
+    : 'unknown';
+  const confidenceRaw = typeof parsed.confidence === 'number' ? parsed.confidence : 0;
+  const confidence = Math.max(0, Math.min(1, confidenceRaw));
+  const readStringValue = (value: unknown) => (typeof value === 'string' && value.trim() ? value.trim() : undefined);
+  const acceptanceCriteria = Array.isArray(parsed.acceptanceCriteria)
+    ? parsed.acceptanceCriteria.filter((item): item is string => typeof item === 'string' && item.trim().length > 0).map((item) => item.trim())
+    : [];
+  const missingFields = Array.isArray(parsed.missingFields)
+    ? parsed.missingFields.filter((item): item is string => typeof item === 'string' && item.trim().length > 0).map((item) => item.trim())
+    : [];
+
+  return {
+    intent,
+    confidence,
+    jiraKey: readStringValue(parsed.jiraKey),
+    repoHint: readStringValue(parsed.repoHint),
+    repoId: readStringValue(parsed.repoId),
+    taskTitle: readStringValue(parsed.taskTitle),
+    taskPrompt: readStringValue(parsed.taskPrompt),
+    acceptanceCriteria,
+    missingFields,
+    clarifyingQuestion: readStringValue(parsed.clarifyingQuestion)
+  };
+}
+
+function fallbackIntent(text: string): SlackIntentParseResult {
+  const trimmed = text.trim();
+  if (!trimmed) {
+    return {
+      intent: 'unknown',
+      confidence: 0,
+      acceptanceCriteria: [],
+      missingFields: ['intent'],
+      clarifyingQuestion: 'Tell me what you want to accomplish, plus target repo (if known).'
+    };
+  }
+  return {
+    intent: 'create_task',
+    confidence: 0.55,
+    taskPrompt: trimmed,
+    acceptanceCriteria: [],
+    missingFields: ['repo', 'acceptanceCriteria'],
+    clarifyingQuestion: 'Which repo should I use, and what are the acceptance criteria?'
+  };
+}
+
+export function resolveSlackIntentSettings(
+  configs: readonly IntegrationConfig[],
+  scope: { tenantId: string; repoId?: string; channelId?: string }
+): SlackIntentSettings {
+  const config = resolveIntegrationConfig(configs, {
+    tenantId: scope.tenantId,
+    pluginKind: 'slack',
+    repoId: scope.repoId,
+    channelId: scope.channelId
+  });
+  const settings = config?.settings ?? {};
+  return {
+    intentEnabled: readBoolean(settings, 'intentEnabled', true),
+    intentModel: readString(settings, 'intentModel') ?? DEFAULT_INTENT_MODEL,
+    intentReasoningEffort: readReasoningEffort(settings, 'low'),
+    intentAutoCreate: readBoolean(settings, 'intentAutoCreate', true),
+    intentClarifyMaxTurns: readPositiveInt(settings, 'intentClarifyMaxTurns', 4),
+    defaultRepoId: readString(settings, 'defaultRepoId')
+  };
+}
+
+export async function parseSlackIntentWithLlm(
+  env: Env,
+  input: {
+    text: string;
+    settings: SlackIntentSettings;
+    priorTurns: number;
+  }
+): Promise<SlackIntentParseResult> {
+  const trimmed = input.text.trim();
+  if (!trimmed) {
+    return fallbackIntent(trimmed);
+  }
+  const apiKey = env.OPENAI_API_KEY?.trim();
+  if (!apiKey || !input.settings.intentEnabled) {
+    return fallbackIntent(trimmed);
+  }
+
+  try {
+    const response = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        model: input.settings.intentModel || DEFAULT_INTENT_MODEL,
+        messages: [
+          {
+            role: 'system',
+            content: [
+              'Parse Slack /kanvy free-text into a strict intent JSON object.',
+              'Prefer intent=create_task for generic requests.',
+              'Use intent=fix_jira only when user asks to fix a Jira issue.',
+              'Return one targeted clarifyingQuestion if needed.'
+            ].join(' ')
+          },
+          {
+            role: 'user',
+            content: `turn=${input.priorTurns}\ntext=${trimmed}`
+          }
+        ],
+        response_format: {
+          type: 'json_schema',
+          json_schema: INTENT_JSON_SCHEMA
+        },
+        temperature: 0
+      })
+    });
+    if (!response.ok) {
+      return fallbackIntent(trimmed);
+    }
+    const payload = await response.json() as {
+      choices?: Array<{ message?: { content?: string } }>;
+    };
+    const rawContent = payload.choices?.[0]?.message?.content;
+    if (!rawContent) {
+      return fallbackIntent(trimmed);
+    }
+    const parsed = JSON.parse(rawContent);
+    return normalizeResult(parsed);
+  } catch {
+    return fallbackIntent(trimmed);
+  }
+}

--- a/src/server/integrations/slack/payload.test.ts
+++ b/src/server/integrations/slack/payload.test.ts
@@ -1,48 +1,37 @@
 import { describe, expect, it } from 'vitest';
-import { parseSlackSlashCommandBody } from './payload';
+import { parseJiraFastPathIssueKey, parseSlackSlashCommandBody } from './payload';
 
-describe('parseSlackSlashCommandBody', () => {
-  it('parses fix jira-key command', () => {
+describe('slack payload parsing', () => {
+  it('accepts free-text slash command input', () => {
     const rawBody = new URLSearchParams({
       command: '/kanvy',
-      text: 'fix abc-123',
+      text: 'draft MR for docs improvements',
       channel_id: 'C123',
-      thread_ts: '1672531200.1234',
-      team_id: 'T123',
-      user_id: 'U123',
-      response_url: 'https://hooks.slack.test/fix'
+      team_id: 'T1',
+      user_id: 'U1',
+      response_url: 'https://hooks.slack.com/commands/response'
     }).toString();
-
-    const payload = parseSlackSlashCommandBody(rawBody);
-    expect(payload.intent).toBe('fix');
-    if (payload.intent === 'fix') {
-      expect(payload.issueKey).toBe('ABC-123');
-    }
+    const parsed = parseSlackSlashCommandBody(rawBody);
+    expect(parsed.text).toBe('draft MR for docs improvements');
+    expect(parsed.channelId).toBe('C123');
   });
 
-  it('parses help command', () => {
+  it('keeps deterministic Jira fast-path parsing for fix <JIRA_KEY>', () => {
+    expect(parseJiraFastPathIssueKey('fix ABC-123')).toBe('ABC-123');
+    expect(parseJiraFastPathIssueKey('fix abc-123')).toBe('ABC-123');
+    expect(parseJiraFastPathIssueKey('draft mr')).toBeUndefined();
+  });
+
+  it('accepts help text as regular slash payload text', () => {
     const rawBody = new URLSearchParams({
       command: '/kanvy',
       text: 'help',
       channel_id: 'C123',
-      team_id: 'T123',
-      user_id: 'U123',
-      response_url: 'https://hooks.slack.test/help'
+      team_id: 'T1',
+      user_id: 'U1',
+      response_url: 'https://hooks.slack.com/commands/response'
     }).toString();
-
-    const payload = parseSlackSlashCommandBody(rawBody);
-    expect(payload.intent).toBe('help');
-  });
-
-  it('rejects unsupported format', () => {
-    const rawBody = new URLSearchParams({
-      command: '/kanvy',
-      text: 'status ABC-123',
-      channel_id: 'C123'
-    }).toString();
-
-    expect(() => parseSlackSlashCommandBody(rawBody)).toThrow(
-      'Invalid slash command format. Expected: /kanvy fix <JIRA_KEY> or /kanvy help.'
-    );
+    const parsed = parseSlackSlashCommandBody(rawBody);
+    expect(parsed.text).toBe('help');
   });
 });

--- a/src/server/integrations/slack/payload.ts
+++ b/src/server/integrations/slack/payload.ts
@@ -10,14 +10,7 @@ type SlackSlashCommandPayloadBase = {
   responseUrl: string | undefined;
 };
 
-export type SlackSlashCommandPayload =
-  | (SlackSlashCommandPayloadBase & {
-    intent: 'help';
-  })
-  | (SlackSlashCommandPayloadBase & {
-    intent: 'fix';
-    issueKey: string;
-  });
+export type SlackSlashCommandPayload = SlackSlashCommandPayloadBase;
 
 export type SlackInteractionAction = 'repo_disambiguation' | 'approve_rerun' | 'pause' | 'close';
 
@@ -54,12 +47,20 @@ export type ParsedSlackInteraction = {
 type SlackEventPayload = {
   type: string;
   challenge?: string;
+  eventId?: string;
   teamId?: string;
+  event?: {
+    type?: string;
+    channelId?: string;
+    threadTs?: string;
+    text?: string;
+    userId?: string;
+    botId?: string;
+    ts?: string;
+  };
 };
 
 const ISSUE_KEY_PATTERN = /^[A-Z][A-Z0-9_]*-\d+$/i;
-const FIX_COMMAND_PATTERN = /^fix\s+([A-Z][A-Z0-9_]*-\d+)\s*$/i;
-const HELP_COMMAND_PATTERN = /^help\s*$/i;
 const SUPPORTED_SLACK_COMMAND = '/kanvy';
 const SUPPORTED_ACTION_IDS: Set<string> = new Set([
   'repo_disambiguation',
@@ -128,42 +129,15 @@ export function parseSlackSlashCommandBody(rawBody: string): SlackSlashCommandPa
     throw badRequest('Unknown Slack slash command.');
   }
   const text = readFormValue(params, 'text', false) ?? '';
-  const teamId = readFormValue(params, 'team_id', false);
-  const channelId = readFormValue(params, 'channel_id', true);
-  const threadTs = readFormValue(params, 'thread_ts', false);
-  const userId = readFormValue(params, 'user_id', false) ?? 'unknown';
-  const responseUrl = readFormValue(params, 'response_url', false);
-  if (HELP_COMMAND_PATTERN.test(text)) {
-    return {
-      intent: 'help',
-      command,
-      text,
-      teamId,
-      channelId,
-      threadTs,
-      userId,
-      responseUrl
-    };
-  }
-  const match = FIX_COMMAND_PATTERN.exec(text);
-  if (!match || !match[1]) {
-    throw badRequest('Invalid slash command format. Expected: /kanvy fix <JIRA_KEY> or /kanvy help.');
-  }
-  const issueKey = match[1].toUpperCase();
-  if (!ISSUE_KEY_PATTERN.test(issueKey)) {
-    throw badRequest('Invalid issue key.');
-  }
 
   return {
-    intent: 'fix',
     command,
     text,
-    issueKey,
-    teamId,
-    channelId,
-    threadTs,
-    userId,
-    responseUrl
+    teamId: readFormValue(params, 'team_id', false),
+    channelId: readFormValue(params, 'channel_id', true),
+    threadTs: readFormValue(params, 'thread_ts', false),
+    userId: readFormValue(params, 'user_id', false) ?? 'unknown',
+    responseUrl: readFormValue(params, 'response_url', false)
   };
 }
 
@@ -243,6 +217,7 @@ export function parseSlackEventBody(rawBody: string): SlackEventPayload {
   return {
     type: payload.type,
     challenge: typeof payload.challenge === 'string' ? payload.challenge : undefined,
+    eventId: typeof payload.event_id === 'string' && payload.event_id.trim() ? payload.event_id.trim() : undefined,
     teamId: (() => {
       const event = payload as Record<string, unknown>;
       if (typeof event.team_id === 'string' && event.team_id.trim()) {
@@ -250,6 +225,31 @@ export function parseSlackEventBody(rawBody: string): SlackEventPayload {
       }
       const team = event.team as Record<string, unknown> | undefined;
       return typeof team?.id === 'string' && team.id.trim() ? team.id.trim() : undefined;
+    })(),
+    event: (() => {
+      const event = payload.event as Record<string, unknown> | undefined;
+      if (!event || typeof event !== 'object') {
+        return undefined;
+      }
+      const read = (value: unknown) => (typeof value === 'string' && value.trim() ? value.trim() : undefined);
+      return {
+        type: read(event.type),
+        channelId: read(event.channel),
+        threadTs: read(event.thread_ts),
+        text: read(event.text),
+        userId: read(event.user),
+        botId: read(event.bot_id),
+        ts: read(event.ts)
+      };
     })()
   };
+}
+
+export function parseJiraFastPathIssueKey(text: string): string | undefined {
+  const match = /^fix\s+([A-Z][A-Z0-9_]*-\d+)\s*$/i.exec(text.trim());
+  if (!match?.[1]) {
+    return undefined;
+  }
+  const issueKey = match[1].toUpperCase();
+  return ISSUE_KEY_PATTERN.test(issueKey) ? issueKey : undefined;
 }

--- a/src/server/tenant-auth-db.test.ts
+++ b/src/server/tenant-auth-db.test.ts
@@ -12,6 +12,7 @@ import {
   getSentinelRun,
   getIntegrationConfig,
   getSlackThreadBinding,
+  getSlackIntakeSession,
   createUserApiToken,
   listIntegrationConfigs,
   listJiraProjectRepoMappings,
@@ -22,6 +23,7 @@ import {
   upsertIntegrationConfig,
   upsertJiraProjectRepoMapping,
   upsertRepoSentinelConfig,
+  upsertSlackIntakeSession,
   upsertSlackThreadBinding,
   updateSentinelRun,
   listTenantInvites,
@@ -86,6 +88,7 @@ class FakeTenantAuthDb {
   integrationConfigs: Row[] = [];
   jiraProjectRepoMappings: Row[] = [];
   slackThreadBindings: Row[] = [];
+  slackIntakeSessions: Row[] = [];
   repoSentinelConfigs: Row[] = [];
   sentinelRuns: Row[] = [];
   sentinelEvents: Row[] = [];
@@ -114,6 +117,7 @@ class FakeTenantAuthDb {
           { name: 'integration_configs' },
           { name: 'jira_project_repo_mappings' },
           { name: 'slack_thread_bindings' },
+          { name: 'slack_intake_sessions' },
           { name: 'repo_sentinel_configs' },
           { name: 'sentinel_runs' },
           { name: 'sentinel_events' }
@@ -299,6 +303,54 @@ class FakeTenantAuthDb {
         rows = rows.slice(0, 1);
       }
       return { results: rows };
+    }
+
+    if (sql.includes('INSERT INTO slack_intake_sessions')) {
+      const row = {
+        external_id: String(bindings[0]),
+        tenant_id: String(bindings[1]),
+        channel_id: String(bindings[2]),
+        thread_ts: String(bindings[3]),
+        status: String(bindings[4]),
+        turn_count: Number(bindings[5]),
+        last_confidence: bindings[6] === null ? null : Number(bindings[6]),
+        session_json: String(bindings[7]),
+        last_activity_at: String(bindings[8]),
+        created_at: String(bindings[9]),
+        updated_at: String(bindings[10])
+      };
+      const existingIndex = this.slackIntakeSessions.findIndex((entry) => (
+        entry.tenant_id === row.tenant_id
+        && entry.channel_id === row.channel_id
+        && entry.thread_ts === row.thread_ts
+      ));
+      if (existingIndex >= 0) {
+        this.slackIntakeSessions[existingIndex] = {
+          ...this.slackIntakeSessions[existingIndex],
+          status: row.status,
+          turn_count: row.turn_count,
+          last_confidence: row.last_confidence,
+          session_json: row.session_json,
+          last_activity_at: row.last_activity_at,
+          updated_at: row.updated_at
+        };
+      } else {
+        this.slackIntakeSessions.push(row);
+      }
+      return {};
+    }
+
+    if (sql === 'SELECT * FROM slack_intake_sessions WHERE tenant_id = ? AND channel_id = ? AND thread_ts = ? LIMIT 1') {
+      const tenantId = String(bindings[0]);
+      const channelId = String(bindings[1]);
+      const threadTs = String(bindings[2]);
+      return {
+        results: this.slackIntakeSessions.filter((row) => (
+          row.tenant_id === tenantId
+          && row.channel_id === channelId
+          && row.thread_ts === threadTs
+        )).slice(0, 1)
+      };
     }
 
     if (sql.includes('INSERT INTO repo_sentinel_configs')) {
@@ -1073,6 +1125,46 @@ describe('tenant-auth-db single-tenant auth store', () => {
     await deleteSlackThreadBinding(env, tenantId, 'task_1', 'C123');
     const afterDelete = await getSlackThreadBinding(env, tenantId, 'task_1', 'C123');
     expect(afterDelete).toBeUndefined();
+  });
+
+  it('persists slack intake sessions with upsert/lookup by thread identity', async () => {
+    const tenantId = 'tenant_local';
+    const initial = await upsertSlackIntakeSession(env, {
+      tenantId,
+      channelId: 'C123',
+      threadTs: '123.456',
+      status: 'active',
+      turnCount: 1,
+      lastConfidence: 0.61,
+      data: {
+        intent: 'create_task',
+        taskPrompt: 'Update README and docs.',
+        missingFields: ['repo']
+      }
+    });
+    expect(initial.status).toBe('active');
+    expect(initial.turnCount).toBe(1);
+
+    await upsertSlackIntakeSession(env, {
+      tenantId,
+      channelId: 'C123',
+      threadTs: '123.456',
+      status: 'completed',
+      turnCount: 2,
+      lastConfidence: 0.91,
+      data: {
+        intent: 'create_task',
+        repoId: 'repo_alpha',
+        taskTitle: 'Docs cleanup',
+        taskPrompt: 'Refine Slack docs',
+        acceptanceCriteria: ['Docs updated']
+      }
+    });
+    const lookedUp = await getSlackIntakeSession(env, tenantId, 'C123', '123.456');
+    expect(lookedUp?.status).toBe('completed');
+    expect(lookedUp?.turnCount).toBe(2);
+    expect(lookedUp?.lastConfidence).toBe(0.91);
+    expect(lookedUp?.data.repoId).toBe('repo_alpha');
   });
 
   it('persists repo sentinel config and returns deterministic defaults when missing', async () => {

--- a/src/server/tenant-auth-db.ts
+++ b/src/server/tenant-auth-db.ts
@@ -5,6 +5,9 @@ import type {
   IntegrationScopeType,
   JiraProjectRepoMapping,
   RepoSentinelConfig,
+  SlackIntakeSession,
+  SlackIntakeSessionData,
+  SlackIntakeSessionStatus,
   SentinelEvent,
   SentinelRun,
   SlackThreadBinding,
@@ -106,6 +109,16 @@ type SlackThreadBindingInput = {
   currentRunId?: string;
   latestReviewRound?: number;
 };
+type SlackIntakeSessionInput = {
+  tenantId: string;
+  channelId: string;
+  threadTs: string;
+  status?: SlackIntakeSessionStatus;
+  turnCount?: number;
+  lastConfidence?: number;
+  data?: SlackIntakeSessionData;
+  lastActivityAt?: string;
+};
 type RepoSentinelConfigInput = {
   tenantId: string;
   repoId: string;
@@ -148,6 +161,7 @@ const INVITE_TTL_MS = 1000 * 60 * 60 * 24 * 30;
 const SINGLE_TENANT_FALLBACK_ID = 'tenant_local';
 const DEFAULT_INTEGRATION_PRIORITY = 0;
 const DEFAULT_INTEGRATION_LATEST_REVIEW_ROUND = 0;
+const DEFAULT_INTAKE_SESSION_STATUS: SlackIntakeSessionStatus = 'active';
 const PASSWORD_HASH_SCHEME = 'pbkdf2_sha256';
 const PASSWORD_HASH_ITERATIONS = 210_000;
 const PASSWORD_SALT_BYTES = 16;
@@ -199,6 +213,7 @@ async function ensureSchema(db: D1Database): Promise<void> {
         'integration_configs',
         'jira_project_repo_mappings',
         'slack_thread_bindings',
+        'slack_intake_sessions',
         'repo_sentinel_configs',
         'sentinel_runs',
         'sentinel_events'
@@ -404,6 +419,64 @@ function mapSlackThreadBinding(row: Record<string, unknown>): SlackThreadBinding
   };
 }
 
+function parseSlackIntakeStatus(value: unknown): SlackIntakeSessionStatus {
+  const candidate = String(value ?? '').trim();
+  if (candidate === 'active' || candidate === 'completed' || candidate === 'cancelled' || candidate === 'expired') {
+    return candidate;
+  }
+  return DEFAULT_INTAKE_SESSION_STATUS;
+}
+
+function parseSlackIntakeSessionData(value: unknown): SlackIntakeSessionData {
+  if (typeof value !== 'string' || !value.trim()) {
+    return {};
+  }
+  try {
+    const parsed = JSON.parse(value);
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return {};
+    }
+    const data = parsed as Record<string, unknown>;
+    const readString = (raw: unknown) => (typeof raw === 'string' && raw.trim() ? raw.trim() : undefined);
+    const readStringArray = (raw: unknown) => (
+      Array.isArray(raw)
+        ? raw.filter((entry): entry is string => typeof entry === 'string' && entry.trim().length > 0).map((entry) => entry.trim())
+        : undefined
+    );
+    return {
+      intent: data.intent === 'fix_jira' || data.intent === 'create_task' || data.intent === 'unknown' ? data.intent : undefined,
+      confidence: typeof data.confidence === 'number' && Number.isFinite(data.confidence) ? data.confidence : undefined,
+      jiraKey: readString(data.jiraKey),
+      repoHint: readString(data.repoHint),
+      repoId: readString(data.repoId),
+      taskTitle: readString(data.taskTitle),
+      taskPrompt: readString(data.taskPrompt),
+      acceptanceCriteria: readStringArray(data.acceptanceCriteria),
+      missingFields: readStringArray(data.missingFields),
+      clarifyingQuestion: readString(data.clarifyingQuestion),
+      lastUserText: readString(data.lastUserText)
+    };
+  } catch {
+    return {};
+  }
+}
+
+function mapSlackIntakeSession(row: Record<string, unknown>): SlackIntakeSession {
+  return {
+    id: externalId(row),
+    tenantId: String(row.tenant_id),
+    channelId: String(row.channel_id),
+    threadTs: String(row.thread_ts),
+    status: parseSlackIntakeStatus(row.status),
+    turnCount: Number(row.turn_count ?? 0),
+    lastConfidence: typeof row.last_confidence === 'number' ? row.last_confidence : row.last_confidence ? Number(row.last_confidence) : undefined,
+    data: parseSlackIntakeSessionData(row.session_json),
+    lastActivityAt: String(row.last_activity_at ?? row.updated_at),
+    createdAt: String(row.created_at),
+    updatedAt: String(row.updated_at)
+  };
+}
+
 function normalizeIntegrationScope(scopeType: IntegrationScopeType, scopeId: string | undefined): string {
   if (scopeType === 'tenant') {
     return '';
@@ -468,6 +541,32 @@ function normalizeSlackBindingInput(input: SlackThreadBindingInput): SlackThread
     threadTs,
     currentRunId: input.currentRunId?.trim(),
     latestReviewRound: Number.isFinite(input.latestReviewRound) ? input.latestReviewRound : 0
+  };
+}
+
+function normalizeSlackIntakeSessionInput(input: SlackIntakeSessionInput): SlackIntakeSessionInput {
+  const channelId = input.channelId.trim();
+  const threadTs = input.threadTs.trim();
+  if (!channelId || !threadTs) {
+    throw badRequest('channelId and threadTs are required.');
+  }
+  const status = input.status ?? DEFAULT_INTAKE_SESSION_STATUS;
+  if (status !== 'active' && status !== 'completed' && status !== 'cancelled' && status !== 'expired') {
+    throw badRequest('Invalid slack intake session status.');
+  }
+  const turnCount = Number.isFinite(input.turnCount) && Number(input.turnCount) >= 0
+    ? Math.trunc(Number(input.turnCount))
+    : 0;
+  const lastConfidence = Number.isFinite(input.lastConfidence) ? Number(input.lastConfidence) : undefined;
+  return {
+    tenantId: input.tenantId,
+    channelId,
+    threadTs,
+    status,
+    turnCount,
+    lastConfidence,
+    data: input.data ?? {},
+    lastActivityAt: input.lastActivityAt
   };
 }
 
@@ -864,6 +963,10 @@ function buildSlackThreadBindingRowId() {
   return `thread_binding_${crypto.randomUUID ? crypto.randomUUID() : Math.random().toString(36).slice(2, 10)}`;
 }
 
+function buildSlackIntakeSessionRowId() {
+  return `slack_intake_${crypto.randomUUID ? crypto.randomUUID() : Math.random().toString(36).slice(2, 10)}`;
+}
+
 export async function upsertIntegrationConfig(env: Env, input: IntegrationConfigInput): Promise<IntegrationConfig> {
   const db = getDb(env);
   await ensureSchema(db);
@@ -1140,6 +1243,65 @@ export async function deleteSlackThreadBinding(
     'DELETE FROM slack_thread_bindings WHERE tenant_id = ? AND task_id = ? AND channel_id = ?'
   ).bind(tenantId, taskId.trim(), channelId.trim()).run();
   return { ok: true };
+}
+
+export async function upsertSlackIntakeSession(
+  env: Env,
+  input: SlackIntakeSessionInput
+): Promise<SlackIntakeSession> {
+  const db = getDb(env);
+  await ensureSchema(db);
+  const normalized = normalizeSlackIntakeSessionInput(input);
+  const now = new Date().toISOString();
+  const id = buildSlackIntakeSessionRowId();
+  const sessionJson = JSON.stringify(normalized.data ?? {});
+  const lastActivityAt = normalized.lastActivityAt ?? now;
+  await db.prepare(
+    `INSERT INTO slack_intake_sessions
+     (external_id, tenant_id, channel_id, thread_ts, status, turn_count, last_confidence, session_json, last_activity_at, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+     ON CONFLICT (tenant_id, channel_id, thread_ts) DO UPDATE SET
+       status = excluded.status,
+       turn_count = excluded.turn_count,
+       last_confidence = excluded.last_confidence,
+       session_json = excluded.session_json,
+       last_activity_at = excluded.last_activity_at,
+       updated_at = excluded.updated_at`
+  ).bind(
+    id,
+    normalized.tenantId,
+    normalized.channelId,
+    normalized.threadTs,
+    normalized.status,
+    normalized.turnCount,
+    normalized.lastConfidence ?? null,
+    sessionJson,
+    lastActivityAt,
+    now,
+    now
+  ).run();
+  const stored = await getSlackIntakeSession(env, normalized.tenantId, normalized.channelId, normalized.threadTs);
+  if (!stored) {
+    throw badRequest('Failed to persist slack intake session.');
+  }
+  return stored;
+}
+
+export async function getSlackIntakeSession(
+  env: Env,
+  tenantId: string,
+  channelId: string,
+  threadTs: string
+): Promise<SlackIntakeSession | undefined> {
+  const db = getDb(env);
+  await ensureSchema(db);
+  const row = await db.prepare(
+    'SELECT * FROM slack_intake_sessions WHERE tenant_id = ? AND channel_id = ? AND thread_ts = ? LIMIT 1'
+  ).bind(tenantId, channelId.trim(), threadTs.trim()).first<Record<string, unknown>>();
+  if (!row) {
+    return undefined;
+  }
+  return mapSlackIntakeSession(row);
 }
 
 export async function upsertRepoSentinelConfig(env: Env, input: RepoSentinelConfigInput): Promise<RepoSentinelConfig> {

--- a/src/ui/domain/types.ts
+++ b/src/ui/domain/types.ts
@@ -61,6 +61,33 @@ export type SlackThreadBinding = {
   createdAt: string;
   updatedAt: string;
 };
+export type SlackIntakeSessionStatus = 'active' | 'completed' | 'cancelled' | 'expired';
+export type SlackIntakeSessionData = {
+  intent?: 'fix_jira' | 'create_task' | 'unknown';
+  confidence?: number;
+  jiraKey?: string;
+  repoHint?: string;
+  repoId?: string;
+  taskTitle?: string;
+  taskPrompt?: string;
+  acceptanceCriteria?: string[];
+  missingFields?: string[];
+  clarifyingQuestion?: string;
+  lastUserText?: string;
+};
+export type SlackIntakeSession = {
+  id: string;
+  tenantId: string;
+  channelId: string;
+  threadTs: string;
+  status: SlackIntakeSessionStatus;
+  turnCount: number;
+  lastConfidence?: number;
+  data: SlackIntakeSessionData;
+  lastActivityAt: string;
+  createdAt: string;
+  updatedAt: string;
+};
 export type RepoPreviewConfig = {
   checkName?: string;
   promptRecipe?: string;


### PR DESCRIPTION
## Objective
Implement P10/S10 one-shot Slack free-text `/kanvy` intake with deterministic Jira fast-path preservation, scoped intake model config, thread clarification loop, and auto task/run creation when intent is complete.

## Scope
- Free-text slash parsing for `/kanvy <text>`
- Deterministic Jira fast-path retained for `fix <JIRA_KEY>`
- LLM parser path for non-fast-path inputs with strict JSON schema output
- Thread-scoped intake session persistence and continuation from Slack thread replies
- Clarification turn cap default 4 with explicit structured handoff prompt
- Scoped Slack intake model config precedence: channel > repo > tenant
- Auto-create task/run when complete + high confidence
- Generic repo resolution fallback/disambiguation (explicit repo -> scoped defaultRepoId -> single repo -> ask user)
- Added migration and DB helpers for intake sessions
- Updated Slack docs + current plan references

## Behavior changes
- `/kanvy` now accepts free-text requests in addition to `fix <JIRA_KEY>`.
- `fix <JIRA_KEY>` remains deterministic and backward compatible.
- Non-fast-path commands run through intent parsing and either:
  - auto-create task/run when complete + confident, or
  - ask targeted clarification in the same thread.
- Intake sessions persist by `tenant_id + channel_id + thread_ts` and are resumed on thread message events.
- Clarification loop enforces max turns (default 4) and then responds with explicit structured handoff instructions.
- Jira and generic intent-created tasks default to `gpt-5.1-codex-mini` unless scoped override is configured.

## API/type changes
- Added Slack intake session domain types (`SlackIntakeSession*`) in `src/ui/domain/types.ts`.
- Added new DB helpers:
  - `upsertSlackIntakeSession`
  - `getSlackIntakeSession`
- Added migration: `migrations/0004_slack_intake_sessions.sql`.
- Extended Slack payload parsing:
  - free-text slash body support
  - helper `parseJiraFastPathIssueKey`
  - richer event payload parsing for thread replies.
- Added new Slack intent module:
  - `src/server/integrations/slack/intent.ts`

## Backward compatibility
- Existing `fix <JIRA_KEY>` slash path is preserved.
- Existing rerun/pause/close interaction handling remains operational.
- Existing dedupe/idempotency behavior remains in place and is extended for thread reply event intake continuation.

## Manual QA
1. Run `/kanvy fix ABC-123` and verify deterministic Jira flow still starts task/run.
2. Run `/kanvy draft MR for README improvements` in a thread and verify clarification or auto-create behavior.
3. Reply in same thread to continue intake until task/run is created.
4. Repeat same slash/event payload to verify dedupe suppression (no duplicate task/run).
5. Verify rerun/pause/close interactions continue to work as before.

## Risks/Rollback
- Risk: stricter/expanded Slack command flow could affect integrations with unusual payloads.
- Risk: intake parser depends on LLM availability for best results; fallback asks for structured clarification.
- Rollback: revert this PR and migration `0004_slack_intake_sessions.sql` usage; fast-path Jira logic remains isolated in same handler path.

## Deferred follow-ups
- Button-based repo disambiguation UX for generic intake path.
- Additional intent classes beyond `fix_jira` and `create_task`.
- Stronger atomic dedupe ledger beyond KV get/put race window.
- Session cleanup job for old active sessions beyond passive expiry checks.
