### PR TITLE
RS1 - Plan and implement review-sandbox attachability + native review fallback

### DIFF
--- a/src/server/durable/repo-board.ts
+++ b/src/server/durable/repo-board.ts
@@ -4,6 +4,7 @@ import type {
   IntegrationLoopState,
   OperatorSession,
   Repo,
+  SandboxRole,
   RunCheckpoint,
   RunCommand,
   RunError,
@@ -727,13 +728,16 @@ export class RepoBoardDO extends DurableObject<Env> {
   async updateOperatorSession(runId: string, session?: OperatorSession, tenantId?: string) {
     await this.ready;
     const run = await this.getRun(runId, tenantId);
+    const sessionRole: SandboxRole = session?.sandboxRole ?? 'main';
+    const resolvedSandboxId = resolveRunSandboxByRole(run, sessionRole).sandboxId;
     const normalizedSession = normalizeOperatorSession(
       session
         ? {
             ...session,
             tenantId: run.tenantId,
             runId,
-            sandboxId: session.sandboxId || run.sandboxId || ''
+            sandboxRole: sessionRole,
+            sandboxId: session.sandboxId || resolvedSandboxId || run.sandboxId || ''
           }
         : undefined
     );
@@ -756,21 +760,25 @@ export class RepoBoardDO extends DurableObject<Env> {
     return updated;
   }
 
-  async getTerminalBootstrap(runId: string, tenantId?: string): Promise<TerminalBootstrap> {
+  async getTerminalBootstrap(runId: string, tenantId?: string, sandboxRole: SandboxRole = 'main'): Promise<TerminalBootstrap> {
     await this.ready;
     const run = await this.getRun(runId, tenantId);
-    const sessionName = getOperatorSessionName(run);
-    if (!run.sandboxId) {
+    const sessionName = getOperatorSessionName(run, sandboxRole);
+    const resolved = resolveRunSandboxByRole(run, sandboxRole);
+    if (!resolved.sandboxId) {
       return {
         tenantId: run.tenantId,
         runId,
         repoId: run.repoId,
         taskId: run.taskId,
+        sandboxRole,
+        requestedSandboxId: resolved.requestedSandboxId,
+        resolvedSandboxId: resolved.sandboxId,
         sandboxId: '',
         sessionName,
         status: run.status,
         attachable: false,
-        reason: 'sandbox_missing',
+        reason: resolved.reason,
         cols: 120,
         rows: 32,
         llmSupportsResume: run.llmSupportsResume,
@@ -785,7 +793,10 @@ export class RepoBoardDO extends DurableObject<Env> {
         runId,
         repoId: run.repoId,
         taskId: run.taskId,
-        sandboxId: run.sandboxId,
+        sandboxRole,
+        requestedSandboxId: resolved.requestedSandboxId,
+        resolvedSandboxId: resolved.sandboxId,
+        sandboxId: resolved.sandboxId,
         sessionName,
         status: run.status,
         attachable: false,
@@ -804,11 +815,16 @@ export class RepoBoardDO extends DurableObject<Env> {
       runId,
       repoId: run.repoId,
       taskId: run.taskId,
-      sandboxId: run.sandboxId,
+      sandboxRole,
+      requestedSandboxId: resolved.requestedSandboxId,
+      resolvedSandboxId: resolved.sandboxId,
+      sandboxId: resolved.sandboxId,
       sessionName,
       status: run.status,
       attachable: true,
-      wsPath: `/api/runs/${encodeURIComponent(runId)}/ws`,
+      wsPath: sandboxRole === 'main'
+        ? `/api/runs/${encodeURIComponent(runId)}/ws`
+        : `/api/runs/${encodeURIComponent(runId)}/ws?sandboxRole=${encodeURIComponent(sandboxRole)}`,
       cols: 120,
       rows: 32,
       session: run.operatorSession,
@@ -818,20 +834,29 @@ export class RepoBoardDO extends DurableObject<Env> {
     };
   }
 
-  async takeOverRun(runId: string, actor = { actorId: 'same-session', actorLabel: 'Operator' }, tenantId?: string) {
+  async takeOverRun(
+    runId: string,
+    actor = { actorId: 'same-session', actorLabel: 'Operator' },
+    tenantId?: string,
+    sandboxRole: SandboxRole = 'main'
+  ) {
     await this.ready;
     const run = await this.getRun(runId, tenantId);
-    if (!run.sandboxId) {
+    const resolved = resolveRunSandboxByRole(run, sandboxRole);
+    if (!resolved.sandboxId) {
       throw notFound(`Sandbox for run ${runId} not found.`, { runId });
     }
 
     const now = new Date().toISOString();
-    const sessionName = getOperatorSessionName(run);
-    const session = run.operatorSession ?? {
+    const sessionName = getOperatorSessionName(run, sandboxRole);
+    const session = (run.operatorSession && (run.operatorSession.sandboxRole ?? 'main') === sandboxRole)
+      ? run.operatorSession
+      : {
       tenantId: run.tenantId,
       id: `${runId}:${sessionName}`,
       runId,
-      sandboxId: run.sandboxId,
+      sandboxRole,
+      sandboxId: resolved.sandboxId,
       sessionName,
       startedAt: now,
       actorId: actor.actorId,
@@ -844,11 +869,13 @@ export class RepoBoardDO extends DurableObject<Env> {
       llmResumeCommand: run.llmResumeCommand ?? run.latestCodexResumeCommand,
       codexThreadId: undefined,
       codexResumeCommand: run.latestCodexResumeCommand
-    };
+      };
     const nextSession: OperatorSession = normalizeOperatorSession({
       ...session,
       actorId: actor.actorId,
       actorLabel: actor.actorLabel,
+      sandboxRole,
+      sandboxId: resolved.sandboxId,
       takeoverState: run.llmSupportsResume && run.llmResumeCommand ? 'resumable' : 'operator_control',
       connectionState: session.connectionState === 'failed' ? 'failed' : 'open'
     })!;
@@ -1280,12 +1307,41 @@ function isTerminalRunStatus(status: AgentRun['status']) {
   return status === 'DONE' || status === 'FAILED';
 }
 
-function getOperatorSessionName(run: AgentRun) {
-  if (!run.operatorSession?.sessionName || run.operatorSession.sessionName === 'operator') {
-    return `operator-${run.runId}`;
+function getOperatorSessionName(run: AgentRun, sandboxRole: SandboxRole = 'main') {
+  const existingRole: SandboxRole = run.operatorSession?.sandboxRole ?? 'main';
+  if (run.operatorSession?.sessionName && run.operatorSession.sessionName !== 'operator' && existingRole === sandboxRole) {
+    return run.operatorSession.sessionName;
+  }
+  return sandboxRole === 'review' ? `operator-${run.runId}-review` : `operator-${run.runId}`;
+}
+
+function resolveRunSandboxByRole(
+  run: AgentRun,
+  sandboxRole: SandboxRole
+): { sandboxId?: string; requestedSandboxId?: string; reason?: 'sandbox_missing' | 'review_sandbox_not_initialized' } {
+  if (sandboxRole === 'review') {
+    if (!run.reviewSandboxId) {
+      return {
+        requestedSandboxId: run.reviewSandboxId,
+        reason: run.sandboxId ? 'review_sandbox_not_initialized' : 'sandbox_missing'
+      };
+    }
+    return {
+      sandboxId: run.reviewSandboxId,
+      requestedSandboxId: run.reviewSandboxId
+    };
   }
 
-  return run.operatorSession.sessionName;
+  if (!run.sandboxId) {
+    return {
+      requestedSandboxId: run.sandboxId,
+      reason: 'sandbox_missing'
+    };
+  }
+  return {
+    sandboxId: run.sandboxId,
+    requestedSandboxId: run.sandboxId
+  };
 }
 
 function assertTenantMatch(entityTenantId: string | undefined, expectedTenantId: string | undefined, entityLabel: 'Task' | 'Run', entityId: string) {
@@ -1386,7 +1442,8 @@ function normalizeRepoBoardState(state?: Partial<RepoBoardState> | null): RepoBo
           ...run.operatorSession,
           tenantId,
           runId: run.runId,
-          sandboxId: run.operatorSession.sandboxId || run.sandboxId || ''
+          sandboxRole: run.operatorSession.sandboxRole ?? 'main',
+          sandboxId: run.operatorSession.sandboxId || resolveRunSandboxByRole(run, run.operatorSession.sandboxRole ?? 'main').sandboxId || ''
         })
       : undefined;
     return {

--- a/src/server/http/validation.test.ts
+++ b/src/server/http/validation.test.ts
@@ -8,6 +8,7 @@ import {
   parseCreateUserApiTokenInput,
   parseStartRepoSentinelInput,
   parseRetryRunInput,
+  parseTakeOverRunInput,
   parseRequestRunChangesInput,
   parseUpdateRepoSentinelConfigInput,
   parseUpdateRepoInput,
@@ -281,7 +282,8 @@ describe('repo validation', () => {
     expect(parsed.autoReview).toEqual({
       enabled: false,
       provider: 'gitlab',
-      postInline: false
+      postInline: false,
+      postingMode: 'platform'
     });
     expect(parsed.sentinelConfig).toEqual({});
     expect(parsed.checkpointConfig).toEqual({});
@@ -432,7 +434,8 @@ describe('repo validation', () => {
       enabled: true,
       provider: 'gitlab',
       postInline: true,
-      prompt: 'Check all security findings first.'
+      prompt: 'Check all security findings first.',
+      postingMode: 'platform'
     });
   });
 
@@ -450,7 +453,8 @@ describe('repo validation', () => {
     expect(parsed.autoReview).toEqual({
       enabled: true,
       provider: 'github',
-      postInline: true
+      postInline: true,
+      postingMode: 'platform'
     });
   });
 
@@ -468,7 +472,8 @@ describe('repo validation', () => {
     expect(parsed.autoReview).toEqual({
       enabled: true,
       provider: 'github',
-      postInline: false
+      postInline: false,
+      postingMode: 'platform'
     });
   });
 
@@ -486,7 +491,8 @@ describe('repo validation', () => {
     expect(parsed.autoReview).toEqual({
       enabled: true,
       provider: 'gitlab',
-      postInline: false
+      postInline: false,
+      postingMode: 'platform'
     });
   });
 
@@ -716,6 +722,17 @@ describe('request run validation', () => {
         checkpointId: 'run_1:cp:002:codex'
       })
     ).toThrow('checkpointId cannot be provided when recoveryMode is fresh.');
+  });
+
+  it('parses takeover payload sandbox role when provided', () => {
+    expect(parseTakeOverRunInput({ sandboxRole: 'review' })).toEqual({ sandboxRole: 'review' });
+    expect(parseTakeOverRunInput({})).toEqual({});
+  });
+
+  it('rejects invalid takeover sandbox role', () => {
+    expect(() =>
+      parseTakeOverRunInput({ sandboxRole: 'preview' })
+    ).toThrow('Invalid sandboxRole.');
   });
 });
 

--- a/src/server/http/validation.ts
+++ b/src/server/http/validation.ts
@@ -4,6 +4,7 @@ import type {
   RepoSentinelConfigInput,
   RequestRunChangesInput,
   RetryRunInput,
+  TakeOverRunInput,
   UpdateRepoInput,
   UpdateTaskInput,
   UpsertScmCredentialInput
@@ -19,6 +20,7 @@ const AUTO_REVIEW_POSTING_MODES = new Set(['platform', 'agent'] as const);
 const AUTO_REVIEW_MODES = new Set(['inherit', 'on', 'off'] as const);
 const AUTO_REVIEW_SELECTION_MODES = new Set(['all', 'include', 'exclude', 'freeform'] as const);
 const RETRY_RECOVERY_MODES = new Set(['latest_checkpoint', 'fresh'] as const);
+const SANDBOX_ROLES = new Set(['main', 'review'] as const);
 const PREVIEW_ADAPTERS = new Set(['cloudflare_checks', 'prompt_recipe'] as const);
 const SENTINEL_MERGE_METHODS = new Set(['merge', 'squash', 'rebase'] as const);
 const CHECKPOINT_TRIGGER_MODES = new Set(['phase_boundary'] as const);
@@ -845,6 +847,17 @@ export function parseRetryRunInput(body: unknown): RetryRunInput {
     throw badRequest('checkpointId cannot be provided when recoveryMode is fresh.');
   }
   return retryInput;
+}
+
+export function parseTakeOverRunInput(body: unknown): TakeOverRunInput {
+  if (!isRecord(body)) {
+    throw badRequest('Invalid takeover payload.');
+  }
+
+  const sandboxRole = hasOwn(body, 'sandboxRole')
+    ? readEnumValue(body.sandboxRole, 'sandboxRole', SANDBOX_ROLES, false)
+    : undefined;
+  return sandboxRole ? { sandboxRole } : {};
 }
 
 export function parseUpdateRepoSentinelConfigInput(body: unknown): RepoSentinelConfigInput {

--- a/src/server/router.operator-control.test.ts
+++ b/src/server/router.operator-control.test.ts
@@ -1,0 +1,226 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const tenantAuthDbMocks = vi.hoisted(() => ({
+  resolveSessionByToken: vi.fn(),
+  hasActiveTenantAccess: vi.fn(),
+  getTenantMembership: vi.fn(),
+  resolveApiToken: vi.fn(),
+  listUserMemberships: vi.fn()
+}));
+
+const sandboxMocks = vi.hoisted(() => ({
+  getSandbox: vi.fn()
+}));
+
+vi.mock('./tenant-auth-db', () => tenantAuthDbMocks);
+vi.mock('@cloudflare/sandbox', () => ({
+  getSandbox: sandboxMocks.getSandbox
+}));
+
+import { handleGetRunTerminal, handleGetRunWs, handleTakeoverRun } from './router';
+
+function createEnv(overrides: {
+  repoBoard?: Record<string, unknown>;
+  board?: Record<string, unknown>;
+} = {}): Env {
+  const repoBoardBase = {
+    getTerminalBootstrap: vi.fn(async (_runId: string, _tenantId?: string, sandboxRole: 'main' | 'review' = 'main') => ({
+      runId: 'run_repo_1_demo',
+      repoId: 'repo_1',
+      taskId: 'task_1',
+      sandboxRole,
+      requestedSandboxId: sandboxRole === 'review' ? 'run_repo_1_demo:review' : 'run_repo_1_demo',
+      resolvedSandboxId: sandboxRole === 'review' ? 'run_repo_1_demo:review' : 'run_repo_1_demo',
+      sandboxId: sandboxRole === 'review' ? 'run_repo_1_demo:review' : 'run_repo_1_demo',
+      sessionName: sandboxRole === 'review' ? 'operator-run_repo_1_demo-review' : 'operator-run_repo_1_demo',
+      status: 'PR_OPEN',
+      attachable: true,
+      wsPath: sandboxRole === 'review'
+        ? '/api/runs/run_repo_1_demo/ws?sandboxRole=review'
+        : '/api/runs/run_repo_1_demo/ws',
+      cols: 120,
+      rows: 32
+    })),
+    getRun: vi.fn(async () => ({
+      runId: 'run_repo_1_demo',
+      repoId: 'repo_1',
+      taskId: 'task_1',
+      sandboxId: 'run_repo_1_demo',
+      reviewSandboxId: 'run_repo_1_demo:review',
+      codexProcessId: 'proc_1',
+      llmAdapter: 'codex',
+      llmSupportsResume: true,
+      llmSessionId: 'thread-1',
+      llmResumeCommand: 'codex resume thread-1',
+      latestCodexResumeCommand: 'codex resume thread-1',
+      status: 'PR_OPEN'
+    })),
+    updateOperatorSession: vi.fn(async () => undefined),
+    takeOverRun: vi.fn(async () => ({ runId: 'run_repo_1_demo', status: 'OPERATOR_CONTROLLED' }))
+  };
+
+  const boardBase = {
+    findRunRepoId: vi.fn(async () => 'repo_1'),
+    getRepo: vi.fn(async () => ({
+      repoId: 'repo_1',
+      tenantId: 'tenant_local'
+    }))
+  };
+  const repoBoard = { ...repoBoardBase, ...(overrides.repoBoard ?? {}) };
+  const board = { ...boardBase, ...(overrides.board ?? {}) };
+
+  return {
+    BOARD_INDEX: {
+      getByName: vi.fn(() => board)
+    },
+    REPO_BOARD: {
+      getByName: vi.fn(() => repoBoard)
+    },
+    Sandbox: {}
+  } as unknown as Env;
+}
+
+describe('router sandbox role operator controls', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    tenantAuthDbMocks.resolveSessionByToken.mockResolvedValue({
+      user: { id: 'user_1' },
+      session: { id: 'sess_1', activeTenantId: 'tenant_local' }
+    });
+    tenantAuthDbMocks.hasActiveTenantAccess.mockResolvedValue(true);
+  });
+
+  it('defaults terminal bootstrap to main sandbox role', async () => {
+    const env = createEnv();
+    const response = await handleGetRunTerminal(
+      new Request('https://minions.example.test/api/runs/run_repo_1_demo/terminal', {
+        headers: { 'x-session-token': 'session-token' }
+      }),
+      env,
+      { runId: 'run_repo_1_demo' }
+    );
+
+    expect(response.status).toBe(200);
+    const repoBoard = env.REPO_BOARD.getByName('repo_1') as unknown as { getTerminalBootstrap: ReturnType<typeof vi.fn> };
+    expect(repoBoard.getTerminalBootstrap).toHaveBeenCalledWith('run_repo_1_demo', 'tenant_local', 'main');
+  });
+
+  it('accepts explicit review sandbox role for terminal bootstrap', async () => {
+    const env = createEnv();
+    const response = await handleGetRunTerminal(
+      new Request('https://minions.example.test/api/runs/run_repo_1_demo/terminal?sandboxRole=review', {
+        headers: { 'x-session-token': 'session-token' }
+      }),
+      env,
+      { runId: 'run_repo_1_demo' }
+    );
+
+    expect(response.status).toBe(200);
+    const repoBoard = env.REPO_BOARD.getByName('repo_1') as unknown as { getTerminalBootstrap: ReturnType<typeof vi.fn> };
+    expect(repoBoard.getTerminalBootstrap).toHaveBeenCalledWith('run_repo_1_demo', 'tenant_local', 'review');
+  });
+
+  it('rejects invalid sandbox role query values', async () => {
+    const env = createEnv();
+    const response = await handleGetRunTerminal(
+      new Request('https://minions.example.test/api/runs/run_repo_1_demo/terminal?sandboxRole=preview', {
+        headers: { 'x-session-token': 'session-token' }
+      }),
+      env,
+      { runId: 'run_repo_1_demo' }
+    );
+    expect(response.status).toBe(400);
+  });
+
+  it('boots websocket sessions on the review sandbox when requested', async () => {
+    const env = createEnv();
+    const terminal = vi.fn(async () => new Response('ok', { status: 200 }));
+    sandboxMocks.getSandbox.mockReturnValue({
+      createSession: vi.fn(async () => undefined),
+      getSession: vi.fn(async () => ({ terminal }))
+    });
+
+    const response = await handleGetRunWs(
+      new Request('https://minions.example.test/api/runs/run_repo_1_demo/ws?sandboxRole=review', {
+        headers: {
+          'x-session-token': 'session-token',
+          Upgrade: 'websocket'
+        }
+      }),
+      env,
+      { runId: 'run_repo_1_demo' }
+    );
+
+    expect(response.status).toBe(200);
+    const repoBoard = env.REPO_BOARD.getByName('repo_1') as unknown as {
+      updateOperatorSession: ReturnType<typeof vi.fn>;
+    };
+    expect(repoBoard.updateOperatorSession).toHaveBeenCalledWith(
+      'run_repo_1_demo',
+      expect.objectContaining({
+        sandboxRole: 'review',
+        sandboxId: 'run_repo_1_demo:review'
+      }),
+      'tenant_local'
+    );
+  });
+
+  it('keeps takeover backward-compatible with empty payload (main sandbox default)', async () => {
+    const env = createEnv();
+    const killProcess = vi.fn(async () => undefined);
+    const getProcess = vi.fn(async () => ({ status: 'stopped' }));
+    sandboxMocks.getSandbox.mockReturnValue({
+      killProcess,
+      getProcess
+    });
+
+    const response = await handleTakeoverRun(
+      new Request('https://minions.example.test/api/runs/run_repo_1_demo/takeover', {
+        method: 'POST',
+        headers: { 'x-session-token': 'session-token' }
+      }),
+      env,
+      { runId: 'run_repo_1_demo' }
+    );
+
+    expect(response.status).toBe(200);
+    expect(sandboxMocks.getSandbox).toHaveBeenCalledWith((env as unknown as { Sandbox: unknown }).Sandbox, 'run_repo_1_demo');
+    const repoBoard = env.REPO_BOARD.getByName('repo_1') as unknown as { takeOverRun: ReturnType<typeof vi.fn> };
+    expect(repoBoard.takeOverRun).toHaveBeenCalledWith(
+      'run_repo_1_demo',
+      { actorId: 'same-session', actorLabel: 'Operator' },
+      'tenant_local',
+      'main'
+    );
+  });
+
+  it('supports explicit review-sandbox takeover targeting', async () => {
+    const env = createEnv();
+    const killProcess = vi.fn(async () => undefined);
+    const getProcess = vi.fn(async () => ({ status: 'stopped' }));
+    sandboxMocks.getSandbox.mockReturnValue({
+      killProcess,
+      getProcess
+    });
+
+    const response = await handleTakeoverRun(
+      new Request('https://minions.example.test/api/runs/run_repo_1_demo/takeover', {
+        method: 'POST',
+        headers: { 'x-session-token': 'session-token', 'content-type': 'application/json' },
+        body: JSON.stringify({ sandboxRole: 'review' })
+      }),
+      env,
+      { runId: 'run_repo_1_demo' }
+    );
+
+    expect(response.status).toBe(200);
+    expect(sandboxMocks.getSandbox).toHaveBeenCalledWith((env as unknown as { Sandbox: unknown }).Sandbox, 'run_repo_1_demo:review');
+    const repoBoard = env.REPO_BOARD.getByName('repo_1') as unknown as { takeOverRun: ReturnType<typeof vi.fn> };
+    expect(repoBoard.takeOverRun).toHaveBeenCalledWith(
+      'run_repo_1_demo',
+      { actorId: 'same-session', actorLabel: 'Operator' },
+      'tenant_local',
+      'review'
+    );
+  });
+});

--- a/src/server/router.ts
+++ b/src/server/router.ts
@@ -20,6 +20,7 @@ import {
   parsePlatformAuthLoginInput,
   parsePlatformSupportAssumeTenantInput,
   parseRetryRunInput,
+  parseTakeOverRunInput,
   parseSetActiveTenantInput,
   parseRequestRunChangesInput,
   parseUpdateRepoSentinelConfigInput,
@@ -47,7 +48,7 @@ import {
 import { handleGitlabWebhook as handleGitlabWebhookHandler } from './integrations/gitlab/handlers';
 import { handleGithubWebhook as handleGithubWebhookHandler } from './integrations/github/handlers';
 import { listGithubReplyContextHints } from './integrations/github/reply-context-store';
-import type { AutoReviewProvider, Repo, SentinelRun } from '../ui/domain/types';
+import type { AutoReviewProvider, Repo, SandboxRole, SentinelRun } from '../ui/domain/types';
 import { getScmAdapter } from './scm/registry';
 import { getReviewPostingAdapter } from './review-posting/registry';
 import type { ReviewReplyContext } from './review-posting/adapter';
@@ -1273,12 +1274,14 @@ export async function handleGetRunCommands(request: Request, env: Env, params: R
 
 export async function handleGetRunTerminal(request: Request, env: Env, params: RouteParams): Promise<Response> {
   return withApiError(async () => {
+    const url = new URL(request.url);
+    const sandboxRole = parseSandboxRoleQuery(url.searchParams.get('sandboxRole'));
     const board = getBoard(env);
     const requestContext = await resolveRequestTenantContext(env, board, request, { requireSession: true });
     const runId = parsePathParam(params.runId);
     const repoId = await resolveRepoIdForRun(board, runId);
     await assertRepoAccess(env, board, requestContext, repoId);
-    const bootstrap = await env.REPO_BOARD.getByName(repoId).getTerminalBootstrap(runId, requestContext.activeTenantId);
+    const bootstrap = await env.REPO_BOARD.getByName(repoId).getTerminalBootstrap(runId, requestContext.activeTenantId, sandboxRole);
     if (!bootstrap.attachable) {
       return json(bootstrap, { status: 409 });
     }
@@ -1288,12 +1291,14 @@ export async function handleGetRunTerminal(request: Request, env: Env, params: R
 
 export async function handleGetRunWs(request: Request, env: Env, params: RouteParams): Promise<Response> {
   return withApiError(async () => {
+    const url = new URL(request.url);
+    const sandboxRole = parseSandboxRoleQuery(url.searchParams.get('sandboxRole'));
     const board = getBoard(env);
     const requestContext = await resolveRequestTenantContext(env, board, request, { requireSession: true });
     const runId = parsePathParam(params.runId);
     const repoId = await resolveRepoIdForRun(board, runId);
     await assertRepoAccess(env, board, requestContext, repoId);
-    const bootstrap = await env.REPO_BOARD.getByName(repoId).getTerminalBootstrap(runId, requestContext.activeTenantId);
+    const bootstrap = await env.REPO_BOARD.getByName(repoId).getTerminalBootstrap(runId, requestContext.activeTenantId, sandboxRole);
     if (!bootstrap.attachable) {
       return json(bootstrap, { status: 409 });
     }
@@ -1306,6 +1311,7 @@ export async function handleGetRunWs(request: Request, env: Env, params: RoutePa
       tenantId: run.tenantId,
       id: `${runId}:${bootstrap.sessionName}`,
       runId,
+      sandboxRole,
       sandboxId: bootstrap.sandboxId,
       sessionName: bootstrap.sessionName,
       startedAt: run.operatorSession?.startedAt ?? new Date().toISOString(),
@@ -1352,6 +1358,8 @@ export async function handleGetRunArtifacts(request: Request, env: Env, params: 
 
 export async function handleTakeoverRun(request: Request, env: Env, params: RouteParams): Promise<Response> {
   return withApiError(async () => {
+    const input = parseTakeOverRunInput(await readOptionalJson(request));
+    const sandboxRole = input.sandboxRole ?? 'main';
     const board = getBoard(env);
     const requestContext = await resolveRequestTenantContext(env, board, request, { requireSession: true });
     const runId = parsePathParam(params.runId);
@@ -1359,8 +1367,9 @@ export async function handleTakeoverRun(request: Request, env: Env, params: Rout
     await assertRepoAccess(env, board, requestContext, repoId);
     const repoBoard = env.REPO_BOARD.getByName(repoId);
     const run = await repoBoard.getRun(runId, requestContext.activeTenantId);
-    if (run.sandboxId && run.codexProcessId) {
-      const sandbox = getSandbox(env.Sandbox, run.sandboxId);
+    const selectedSandboxId = sandboxRole === 'review' ? run.reviewSandboxId : run.sandboxId;
+    if (selectedSandboxId && run.codexProcessId) {
+      const sandbox = getSandbox(env.Sandbox, selectedSandboxId);
       try {
         await sandbox.killProcess(run.codexProcessId);
         const stopDeadline = Date.now() + 3_000;
@@ -1375,8 +1384,30 @@ export async function handleTakeoverRun(request: Request, env: Env, params: Rout
         console.warn('Failed to kill Codex process during takeover', { runId, processId: run.codexProcessId, error });
       }
     }
-    return json(await repoBoard.takeOverRun(runId, { actorId: 'same-session', actorLabel: 'Operator' }, requestContext.activeTenantId));
+    return json(await repoBoard.takeOverRun(runId, { actorId: 'same-session', actorLabel: 'Operator' }, requestContext.activeTenantId, sandboxRole));
   });
+}
+
+function parseSandboxRoleQuery(value: string | null): SandboxRole {
+  if (!value) {
+    return 'main';
+  }
+  if (value === 'main' || value === 'review') {
+    return value;
+  }
+  throw badRequest('Invalid sandboxRole.');
+}
+
+async function readOptionalJson(request: Request): Promise<unknown> {
+  const raw = await request.text();
+  if (!raw.trim()) {
+    return {};
+  }
+  try {
+    return JSON.parse(raw) as unknown;
+  } catch {
+    throw badRequest('Request body must be valid JSON.');
+  }
 }
 
 export async function handleDebugExport(request: Request, env: Env): Promise<Response> {

--- a/src/server/run-orchestrator.llm.test.ts
+++ b/src/server/run-orchestrator.llm.test.ts
@@ -457,7 +457,7 @@ describe('executeRunJob LLM adapter coverage', () => {
       findingsCount: 1,
       errors: []
     });
-    expect(harness.getRun().timeline.some((entry) => entry.note?.includes('Posting via github succeeded.'))).toBe(true);
+    expect(harness.getRun().timeline.some((entry) => entry.note?.includes('Posting via github/platform succeeded.'))).toBe(true);
     expect(fetchMock.mock.calls.some((call) => String(call[0]).includes('/pulls/17/comments'))).toBe(true);
   });
 
@@ -540,7 +540,7 @@ describe('executeRunJob LLM adapter coverage', () => {
       findingsCount: 1,
       errors: ['Missing GITHUB_TOKEN: set this secret to enable github auto-review posting.']
     });
-    expect(harness.getRun().timeline.some((entry) => entry.note?.includes('Posting via github failed: Missing GITHUB_TOKEN'))).toBe(true);
+    expect(harness.getRun().timeline.some((entry) => entry.note?.includes('Posting via github/platform failed: Missing GITHUB_TOKEN'))).toBe(true);
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
@@ -641,6 +641,130 @@ describe('executeRunJob LLM adapter coverage', () => {
     });
     expect(harness.getRun().timeline.some((entry) => entry.note?.includes('Manual review started (round 2).'))).toBe(true);
     expect(harness.getRun().timeline.some((entry) => entry.note?.includes('Review completed (round 2;'))).toBe(true);
+  });
+
+  it('falls back to native adapter review mode when no custom review prompt is configured', async () => {
+    const task = buildTask({
+      uiMeta: {
+        llmAdapter: 'codex',
+        llmModel: 'gpt-5.3-codex',
+        llmReasoningEffort: 'medium'
+      }
+    });
+    const repo = buildRepo({
+      autoReview: {
+        enabled: true,
+        provider: 'jira',
+        postInline: false,
+        postingMode: 'agent'
+      }
+    });
+    const harness = createHarness(task, repo);
+    const sandbox = buildSandbox([
+      { type: 'stdout', data: 'Applied fix.\n' },
+      { type: 'exit', exitCode: 0 }
+    ]);
+    const baseExec = sandbox.exec.bind(sandbox);
+    const promptCommands: string[] = [];
+    let promptCall = 0;
+    sandbox.exec = async (command) => {
+      if (command.includes('codex exec') && command.includes('/workspace/prompt.txt')) {
+        promptCommands.push(command);
+      }
+      if (command.includes('/workspace/prompt-last-message.txt')) {
+        promptCall += 1;
+        return {
+          success: true,
+          exitCode: 0,
+          stdout: promptCall === 1
+            ? '\n===CODEX_LAST_MESSAGE===\nFound one issue: missing null guard in src/index.ts line 12.\n'
+            : '\n===CODEX_LAST_MESSAGE===\n{"findings":[{"severity":"high","title":"Missing null guard","description":"Guard undefined payload before property access.","filePath":"src/index.ts","lineStart":12}]}\n'
+        };
+      }
+      return baseExec(command);
+    };
+    sandboxState.current = sandbox;
+
+    await executeRunJob(
+      harness.env,
+      {
+        tenantId: 'tenant_legacy',
+        repoId: repo.repoId,
+        taskId: task.taskId,
+        runId: 'run_1',
+        mode: 'review_only'
+      },
+      async () => {}
+    );
+
+    expect(harness.getRun().reviewExecution).toMatchObject({
+      enabled: true,
+      trigger: 'manual_rerun',
+      promptSource: 'native',
+      status: 'completed',
+      round: 1
+    });
+    expect(harness.getRun().reviewFindingsSummary).toMatchObject({ total: 1, open: 1, posted: 0, provider: 'jira' });
+    expect(promptCommands).toHaveLength(2);
+    expect(promptCommands[0]).not.toContain('--output-schema /workspace/prompt-output-schema.json');
+    expect(promptCommands[1]).toContain('--output-schema /workspace/prompt-output-schema.json');
+  });
+
+  it('recovers review checkout when /workspace/repo already exists before clone on rerun', async () => {
+    const task = buildTask({
+      uiMeta: {
+        llmAdapter: 'codex',
+        llmModel: 'gpt-5.3-codex',
+        llmReasoningEffort: 'medium',
+        autoReviewPrompt: 'Return structured findings only.'
+      }
+    });
+    const repo = buildRepo({
+      autoReview: {
+        enabled: true,
+        provider: 'jira',
+        postInline: false,
+        postingMode: 'agent'
+      }
+    });
+    const harness = createHarness(task, repo);
+    const sandbox = buildSandbox([
+      { type: 'stdout', data: 'Applied fix.\n' },
+      { type: 'exit', exitCode: 0 }
+    ]);
+    const gitCheckout = vi.fn()
+      .mockRejectedValueOnce(new Error("destination path '/workspace/repo' already exists and is not an empty directory"))
+      .mockResolvedValue(undefined);
+    sandbox.gitCheckout = gitCheckout;
+    const baseExec = sandbox.exec.bind(sandbox);
+    sandbox.exec = async (command) => {
+      if (command.includes('/workspace/prompt-last-message.txt')) {
+        return {
+          success: true,
+          exitCode: 0,
+          stdout: '\n===CODEX_LAST_MESSAGE===\n{"findings":[]}\n'
+        };
+      }
+      return baseExec(command);
+    };
+    sandboxState.current = sandbox;
+
+    await executeRunJob(
+      harness.env,
+      {
+        tenantId: 'tenant_legacy',
+        repoId: repo.repoId,
+        taskId: task.taskId,
+        runId: 'run_1',
+        mode: 'review_only'
+      },
+      async () => {}
+    );
+
+    expect(gitCheckout).toHaveBeenCalledTimes(2);
+    expect(harness.commands.some((command) => command.command === 'rm -rf /workspace/repo')).toBe(true);
+    expect(harness.getRun().reviewExecution).toMatchObject({ status: 'completed', round: 1, trigger: 'manual_rerun' });
+    expect(harness.getRun().reviewSandboxId).toMatch(/^sbx-review-/);
   });
 
   it('skips auto-review when effective setting is disabled', async () => {

--- a/src/server/run-orchestrator.ts
+++ b/src/server/run-orchestrator.ts
@@ -689,10 +689,13 @@ async function executeRunReview(
     const llmReasoningEffort = task.uiMeta?.llmReasoningEffort ?? task.uiMeta?.codexReasoningEffort ?? 'medium';
     const scmAdapter = getScmAdapter(repo);
     const scmCredential = await getScmCredential(env, repo, scmAdapter);
-    const reviewSandbox = getSandbox(env.Sandbox, buildSandboxId(runId, 'review'));
+    const reviewSandboxId = buildSandboxId(runId, 'review');
+    const reviewSandbox = getSandbox(env.Sandbox, reviewSandboxId);
     const llmContext = { env, sandbox: reviewSandbox, repoBoard, runId };
+    await repoBoard.transitionRun(runId, { reviewSandboxId });
 
     await configureSandboxRuntimeSecrets(reviewSandbox, env);
+    const cloneUrl = scmAdapter.buildCloneUrl(repo, scmCredential);
     const repoState = await emitCommandLifecycle(
       repoBoard,
       runId,
@@ -744,9 +747,12 @@ fi`)}`
         }
       }
 
-      await reviewSandbox.gitCheckout(scmAdapter.buildCloneUrl(repo, scmCredential), {
-        branch: repo.defaultBranch,
-        targetDir: '/workspace/repo'
+      await checkoutReviewWorkspace({
+        repoBoard,
+        reviewSandbox,
+        runId,
+        cloneUrl,
+        defaultBranch: repo.defaultBranch
       });
     }
     const checkout = await emitCommandLifecycle(
@@ -760,32 +766,29 @@ fi`)}`
       throw new Error(checkout.stderr || `Failed to prepare review branch ${run.branchName}.`);
     }
 
-    const promptResult = await executePromptWithLlmAdapter(
-      llmAdapter,
-      llmContext,
-      {
+    const parsed = autoReview.promptSource === 'native'
+      ? await runNativeReviewAndNormalize({
+        llmAdapter,
+        llmContext,
         repo,
         task,
         run,
-        cwd: '/workspace/repo',
-        prompt: buildReviewPrompt(task, repo, run, autoReview),
         model: llmModel,
         reasoningEffort: llmReasoningEffort,
-        timeoutMs: 180_000,
-        outputSchema: REVIEW_FINDINGS_OUTPUT_SCHEMA,
-        phase: 'pr'
-      },
-      sleepFn
-    );
-    if (promptResult.status !== 'success') {
-      throw new Error(
-        promptResult.status === 'timed_out'
-          ? `Review prompt timed out after ${promptResult.timeoutMs}ms.`
-          : promptResult.message
-      );
-    }
-
-    const parsed = parseReviewFindings(promptResult.rawOutput);
+        sleepFn,
+        autoReview
+      })
+      : await runStructuredReview({
+        llmAdapter,
+        llmContext,
+        repo,
+        task,
+        run,
+        model: llmModel,
+        reasoningEffort: llmReasoningEffort,
+        sleepFn,
+        autoReview
+      });
     if (!parsed.ok) {
       throw new Error(`${parsed.code}: ${parsed.message}`);
     }
@@ -994,6 +997,208 @@ function buildReviewPrompt(
     '{ "findings": [ { "severity": "critical|high|medium|low|info", "title": "string", "description": "string", "filePath": "string|null?", "lineStart": "number|null?", "lineEnd": "number|null?", "providerThreadId": "string|null?" } ] }',
     'If there are no issues, return {"findings":[]}.'
   ].filter(Boolean).join('\n');
+}
+
+async function runStructuredReview({
+  llmAdapter,
+  llmContext,
+  repo,
+  task,
+  run,
+  model,
+  reasoningEffort,
+  sleepFn,
+  autoReview
+}: {
+  llmAdapter: ReturnType<typeof getLlmAdapter>;
+  llmContext: { env: Env; sandbox: ReturnType<typeof getSandbox>; repoBoard: DurableObjectStub<RepoBoardDO>; runId: string };
+  repo: Repo;
+  task: Task;
+  run: Awaited<ReturnType<RepoBoardDO['getRun']>>;
+  model: string;
+  reasoningEffort: LlmReasoningEffort;
+  sleepFn: SleepFn;
+  autoReview: { prompt?: string; provider: AutoReviewProvider; postingMode: 'platform' | 'agent'; postInline: boolean };
+}) {
+  const promptResult = await executePromptWithLlmAdapter(
+    llmAdapter,
+    llmContext,
+    {
+      repo,
+      task,
+      run,
+      cwd: '/workspace/repo',
+      prompt: buildReviewPrompt(task, repo, run, autoReview),
+      model,
+      reasoningEffort,
+      timeoutMs: 180_000,
+      outputSchema: REVIEW_FINDINGS_OUTPUT_SCHEMA,
+      phase: 'pr'
+    },
+    sleepFn
+  );
+  if (promptResult.status !== 'success') {
+    throw new Error(
+      promptResult.status === 'timed_out'
+        ? `Review prompt timed out after ${promptResult.timeoutMs}ms.`
+        : promptResult.message
+    );
+  }
+  return parseReviewFindings(promptResult.rawOutput);
+}
+
+async function runNativeReviewAndNormalize({
+  llmAdapter,
+  llmContext,
+  repo,
+  task,
+  run,
+  model,
+  reasoningEffort,
+  sleepFn,
+  autoReview
+}: {
+  llmAdapter: ReturnType<typeof getLlmAdapter>;
+  llmContext: { env: Env; sandbox: ReturnType<typeof getSandbox>; repoBoard: DurableObjectStub<RepoBoardDO>; runId: string };
+  repo: Repo;
+  task: Task;
+  run: Awaited<ReturnType<RepoBoardDO['getRun']>>;
+  model: string;
+  reasoningEffort: LlmReasoningEffort;
+  sleepFn: SleepFn;
+  autoReview: { prompt?: string; provider: AutoReviewProvider; postingMode: 'platform' | 'agent'; postInline: boolean };
+}) {
+  const nativeReviewResult = await executePromptWithLlmAdapter(
+    llmAdapter,
+    llmContext,
+    {
+      repo,
+      task,
+      run,
+      cwd: '/workspace/repo',
+      prompt: buildNativeReviewPrompt(task, repo, run),
+      model,
+      reasoningEffort,
+      timeoutMs: 180_000,
+      phase: 'pr'
+    },
+    sleepFn
+  );
+
+  if (nativeReviewResult.status !== 'success') {
+    throw new Error(
+      nativeReviewResult.status === 'timed_out'
+        ? `Native review command timed out after ${nativeReviewResult.timeoutMs}ms.`
+        : nativeReviewResult.message
+    );
+  }
+
+  const normalizeResult = await executePromptWithLlmAdapter(
+    llmAdapter,
+    llmContext,
+    {
+      repo,
+      task,
+      run,
+      cwd: '/workspace/repo',
+      prompt: buildReviewNormalizationPrompt(nativeReviewResult.rawOutput, autoReview),
+      model,
+      reasoningEffort,
+      timeoutMs: 60_000,
+      outputSchema: REVIEW_FINDINGS_OUTPUT_SCHEMA,
+      phase: 'pr'
+    },
+    sleepFn
+  );
+
+  if (normalizeResult.status !== 'success') {
+    throw new Error(
+      normalizeResult.status === 'timed_out'
+        ? `Review findings normalization timed out after ${normalizeResult.timeoutMs}ms.`
+        : normalizeResult.message
+    );
+  }
+  return parseReviewFindings(normalizeResult.rawOutput);
+}
+
+function buildNativeReviewPrompt(task: Task, repo: Repo, run: Awaited<ReturnType<RepoBoardDO['getRun']>>) {
+  return [
+    `You are reviewing code changes for ${repo.slug}.`,
+    `Run: ${run.runId}`,
+    `Branch: ${run.branchName}`,
+    '',
+    `Task: ${task.title}`,
+    task.description ? `Task description: ${task.description}` : undefined,
+    '',
+    'Acceptance criteria:',
+    ...task.acceptanceCriteria.map((item) => `- ${item}`),
+    '',
+    'Run /review on the current branch diff and return a concise narrative review.',
+    'Focus on correctness, regressions, security risks, and missing tests.'
+  ].filter(Boolean).join('\n');
+}
+
+function buildReviewNormalizationPrompt(
+  rawReviewOutput: string,
+  autoReview: { provider: AutoReviewProvider; postingMode: 'platform' | 'agent' }
+) {
+  const trimmed = rawReviewOutput.trim();
+  const summary = trimmed.length > 20_000 ? `${trimmed.slice(0, 20_000)}\n\n[truncated]` : trimmed;
+  return [
+    'Convert the following review output into strict findings JSON.',
+    'Return JSON only using this exact schema shape:',
+    '{ "findings": [ { "severity": "critical|high|medium|low|info", "title": "string", "description": "string", "filePath": "string|null?", "lineStart": "number|null?", "lineEnd": "number|null?", "providerThreadId": "string|null?" } ] }',
+    'If there are no actionable issues, return {"findings":[]}.',
+    autoReview.postingMode === 'agent'
+      ? `If the review output includes posted ${autoReview.provider} thread/comment IDs, include them in providerThreadId.`
+      : 'Set providerThreadId to null unless an explicit thread/comment id is present in the review output.',
+    '',
+    'Review output:',
+    summary || '(empty)'
+  ].join('\n');
+}
+
+async function checkoutReviewWorkspace({
+  repoBoard,
+  reviewSandbox,
+  runId,
+  cloneUrl,
+  defaultBranch
+}: {
+  repoBoard: DurableObjectStub<RepoBoardDO>;
+  reviewSandbox: ReturnType<typeof getSandbox>;
+  runId: string;
+  cloneUrl: string;
+  defaultBranch: string;
+}) {
+  try {
+    await reviewSandbox.gitCheckout(cloneUrl, {
+      branch: defaultBranch,
+      targetDir: '/workspace/repo'
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    const likelyExistingDir = /already exists|not an empty directory/i.test(message);
+    if (!likelyExistingDir) {
+      throw error;
+    }
+
+    const cleanupWorkspace = await emitCommandLifecycle(
+      repoBoard,
+      runId,
+      'pr',
+      'rm -rf /workspace/repo',
+      () => reviewSandbox.exec('rm -rf /workspace/repo')
+    );
+    if (!cleanupWorkspace.success) {
+      throw new Error(cleanupWorkspace.stderr || 'Failed to clean review workspace after checkout collision.');
+    }
+
+    await reviewSandbox.gitCheckout(cloneUrl, {
+      branch: defaultBranch,
+      targetDir: '/workspace/repo'
+    });
+  }
 }
 
 async function waitForPreview(

--- a/src/server/shared/real-run.ts
+++ b/src/server/shared/real-run.ts
@@ -33,6 +33,7 @@ export type RunTransitionPatch = {
   workflowInstanceId?: string;
   orchestrationMode?: AgentRun['orchestrationMode'];
   sandboxId?: string;
+  reviewSandboxId?: AgentRun['reviewSandboxId'];
   evidenceSandboxId?: string;
   commitSha?: string;
   commitMessage?: string;

--- a/src/ui/api/http-agent-board-api.ts
+++ b/src/ui/api/http-agent-board-api.ts
@@ -15,13 +15,14 @@ import type {
   CreateUserApiTokenResult,
   InviteRecord,
   RequestRunChangesInput,
+  TakeOverRunInput,
   RetryRunInput,
   UpdateRepoInput,
   UpdateTaskInput,
   UserApiTokenRecord,
   UpsertScmCredentialInput
 } from '../domain/api';
-import type { AgentRun, BoardSnapshotV1, OperatorSession, Repo, RunCheckpoint, RunCommand, RunEvent, RunLogEntry, ScmCredential, Task, TaskDetail, TerminalBootstrap } from '../domain/types';
+import type { AgentRun, BoardSnapshotV1, OperatorSession, Repo, RunCheckpoint, RunCommand, RunEvent, RunLogEntry, SandboxRole, ScmCredential, Task, TaskDetail, TerminalBootstrap } from '../domain/types';
 import { getTaskDetail } from '../domain/selectors';
 import { parseBoardSnapshot } from '../store/board-snapshot';
 import { UiPreferencesStore } from '../store/ui-preferences-store';
@@ -315,8 +316,11 @@ export class HttpAgentBoardApi implements AgentBoardApi {
     return run;
   }
 
-  async takeOverRun(runId: string) {
-    const run = await this.request<AgentRun>(`/api/runs/${encodeURIComponent(runId)}/takeover`, { method: 'POST' });
+  async takeOverRun(runId: string, input?: TakeOverRunInput) {
+    const run = await this.request<AgentRun>(`/api/runs/${encodeURIComponent(runId)}/takeover`, {
+      method: 'POST',
+      body: JSON.stringify(input ?? {})
+    });
     await this.refresh();
     return run;
   }
@@ -352,8 +356,9 @@ export class HttpAgentBoardApi implements AgentBoardApi {
     return commands;
   }
 
-  async getTerminalBootstrap(runId: string) {
-    return this.request<TerminalBootstrap>(`/api/runs/${encodeURIComponent(runId)}/terminal`);
+  async getTerminalBootstrap(runId: string, sandboxRole?: SandboxRole) {
+    const search = sandboxRole ? `?sandboxRole=${encodeURIComponent(sandboxRole)}` : '';
+    return this.request<TerminalBootstrap>(`/api/runs/${encodeURIComponent(runId)}/terminal${search}`);
   }
 
   exportState() {

--- a/src/ui/domain/api.ts
+++ b/src/ui/domain/api.ts
@@ -25,6 +25,7 @@ import type {
   TenantMember,
   TenantSeatSummary,
   TerminalBootstrap,
+  SandboxRole,
   User
 } from './types';
 
@@ -154,6 +155,10 @@ export type RetryRunInput = {
   checkpointId?: string;
 };
 
+export type TakeOverRunInput = {
+  sandboxRole?: SandboxRole;
+};
+
 export type AuthSession = {
   user: User;
   memberships: TenantMember[];
@@ -258,11 +263,11 @@ export interface AgentBoardApi {
   requestRunChanges(runId: string, input: RequestRunChangesInput): Promise<AgentRun>;
   retryPreview(runId: string): Promise<AgentRun>;
   retryEvidence(runId: string): Promise<AgentRun>;
-  takeOverRun(runId: string): Promise<AgentRun>;
+  takeOverRun(runId: string, input?: TakeOverRunInput): Promise<AgentRun>;
   getRunLogs(runId: string, options?: { tail?: number }): Promise<RunLogEntry[]>;
   getRunEvents(runId: string): Promise<RunEvent[]>;
   getRunCommands(runId: string): Promise<RunCommand[]>;
-  getTerminalBootstrap(runId: string): Promise<TerminalBootstrap>;
+  getTerminalBootstrap(runId: string, sandboxRole?: SandboxRole): Promise<TerminalBootstrap>;
   exportState(): string;
   importState(serialized: string): Promise<void>;
   getSelectedRepoId(): string | 'all';

--- a/src/ui/domain/types.ts
+++ b/src/ui/domain/types.ts
@@ -153,6 +153,7 @@ export type SentinelEvent = {
 export type ReviewFindingSeverity = 'critical' | 'high' | 'medium' | 'low' | 'info';
 export type ReviewFindingStatus = 'open' | 'addressed' | 'ignored';
 export type ReviewPromptSource = 'task' | 'repo' | 'native';
+export type SandboxRole = 'main' | 'review';
 export type ReviewExecutionTrigger = 'auto_on_review' | 'manual_rerun';
 export type ReviewExecutionStatus = 'not_started' | 'running' | 'completed' | 'failed';
 export type ReviewFinding = {
@@ -452,6 +453,7 @@ export type OperatorSession = {
   tenantId?: string;
   id: string;
   runId: string;
+  sandboxRole?: SandboxRole;
   sandboxId: string;
   sessionName: string;
   startedAt: string;
@@ -474,6 +476,9 @@ export type TerminalBootstrap = {
   runId: string;
   repoId: string;
   taskId: string;
+  sandboxRole?: SandboxRole;
+  requestedSandboxId?: string;
+  resolvedSandboxId?: string;
   sandboxId: string;
   sessionName: string;
   status: RunStatus;
@@ -572,6 +577,7 @@ export type AgentRun = {
   workflowInstanceId?: string;
   orchestrationMode?: 'workflow' | 'local_alarm';
   sandboxId?: string;
+  reviewSandboxId?: string;
   evidenceSandboxId?: string;
   commitSha?: string;
   commitMessage?: string;

--- a/src/ui/mock/local-agent-board-api.ts
+++ b/src/ui/mock/local-agent-board-api.ts
@@ -15,13 +15,14 @@ import type {
   CreateUserApiTokenResult,
   InviteRecord,
   RequestRunChangesInput,
+  TakeOverRunInput,
   RetryRunInput,
   UpdateRepoInput,
   UpdateTaskInput,
   UserApiTokenRecord,
   UpsertScmCredentialInput
 } from '../domain/api';
-import type { AgentRun, Repo, RunCheckpoint, RunCommand, RunEvent, RunLogEntry, ScmCredential, Task, TaskDetail, TenantMember, TerminalBootstrap, User } from '../domain/types';
+import type { AgentRun, Repo, RunCheckpoint, RunCommand, RunEvent, RunLogEntry, SandboxRole, ScmCredential, Task, TaskDetail, TenantMember, TerminalBootstrap, User } from '../domain/types';
 import { getTaskDetail, getTasksForRepo } from '../domain/selectors';
 import { LocalBoardStore } from '../store/local-board-store';
 import { parseImportedBoard } from '../store/import-export';
@@ -779,7 +780,7 @@ export class LocalAgentBoardApi implements AgentBoardApi {
     return this.simulator.retryEvidence(runId);
   }
 
-  async takeOverRun(runId: string): Promise<AgentRun> {
+  async takeOverRun(runId: string, _input?: TakeOverRunInput): Promise<AgentRun> {
     let updatedRun: AgentRun | undefined;
     const updatedAt = nowIso();
     this.store.update((snapshot) => ({
@@ -846,7 +847,7 @@ export class LocalAgentBoardApi implements AgentBoardApi {
     return this.store.getSnapshot().commands.filter((command) => command.runId === runId);
   }
 
-  async getTerminalBootstrap(runId: string): Promise<TerminalBootstrap> {
+  async getTerminalBootstrap(runId: string, _sandboxRole?: SandboxRole): Promise<TerminalBootstrap> {
     const run = await this.getRun(runId);
     if (!run.sandboxId || ['DONE', 'FAILED'].includes(run.status)) {
       return {


### PR DESCRIPTION
Task: RS1 - Plan and implement review-sandbox attachability + native review fallback

Fix review rerun checkout failures in reused review sandbox, add explicit review sandbox operator attach/takeover support, and default to native /review behavior when no custom prompt is configured.
Source ref: main

Acceptance criteria:
- Manual review rerun no longer fails when review sandbox already contains /workspace/repo.
- Operators can explicitly attach/take over review sandbox via role-aware terminal/ws APIs.
- Default attach behavior remains unchanged for existing clients.
- When no custom review prompt is configured, review execution uses native adapter review behavior while still producing normalized findings.
- Automated coverage includes rerun stability, sandbox role selection, and native-review fallback paths.

Run ID: run_repo_abuiles_agents_kanban_mmchwunavb5r