### PR TITLE
Add /kanvy help support for Slack slash command

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ AgentsKanban helps you run AI-assisted software work the same way you already ma
 ### Slack, Jira, and GitLab MVP Loop
 
 - Trigger task execution from Slack slash commands with a Jira issue key (`/kanvy fix ABC-123`).
+- Show concise slash command usage help directly in Slack (`/kanvy help`).
 - Resolve Jira project -> repository mapping and start the first run from `main`.
 - Mirror GitLab MR lifecycle and review feedback into the same Slack thread.
 - Gate reruns behind explicit Slack approval (`approve rerun`) in-thread.

--- a/docs/features-and-api.md
+++ b/docs/features-and-api.md
@@ -79,7 +79,7 @@ Operational notes:
 
 - `POST /api/integrations/slack/commands`
   - Verified with Slack signing secret and replay window checks.
-  - Accepts `/kanvy fix <JIRA_KEY>`.
+  - Accepts `/kanvy fix <JIRA_KEY>` and `/kanvy help`.
   - Acknowledges immediately and continues Jira/repo/run processing asynchronously.
 - `POST /api/integrations/slack/interactions`
   - Supports actions: `repo_disambiguation`, `approve_rerun`, `pause`, `close`.

--- a/docs/integrations/slack-jira-gitlab-mvp.md
+++ b/docs/integrations/slack-jira-gitlab-mvp.md
@@ -7,6 +7,7 @@ This document is the operator and agent handoff artifact for the P5 MVP vertical
 In scope (MVP):
 
 - Slack-triggered task start from Jira key (`/kanvy fix <JIRA_KEY>`)
+- Slack slash help response (`/kanvy help`) with concise usage examples
 - Jira issue load and repo resolution (mapping and disambiguation)
 - Task/run start from `main`
 - GitLab MR lifecycle and feedback mirrored to Slack thread
@@ -39,6 +40,7 @@ Out of scope (this phase):
 ## Operator day-to-day flow (no dashboard required)
 
 1. In Slack, run `/kanvy fix ABC-123`.
+   - For usage guidance, run `/kanvy help`.
 2. If multiple repo mappings are available, click a repo disambiguation button.
 3. Monitor status and MR feedback in the same Slack thread.
 4. When feedback arrives and run enters `DECISION_REQUIRED`, click `Approve rerun`.

--- a/docs/local-testing.md
+++ b/docs/local-testing.md
@@ -280,10 +280,12 @@ Use this when validating day-to-day operator flow without dashboard actions.
 2. Configure Jira project -> repo mapping for the tenant.
 3. Trigger slash command:
    - `/kanvy fix ABC-123`
+   - `/kanvy help`
 4. Confirm slash command ack is immediate and async processing posts one of:
    - run start confirmation
    - repo disambiguation buttons
    - failure message (for example Jira read failure)
+   - usage instructions with examples for Jira fast-path and free-text flow (for `/kanvy help`)
 5. Confirm run thread binding stores:
    - `taskId`, `channelId`, `threadTs`, `currentRunId`, `latestReviewRound`
 6. Simulate or receive GitLab webhook events:

--- a/src/server/integrations/slack/handlers.test.ts
+++ b/src/server/integrations/slack/handlers.test.ts
@@ -204,6 +204,46 @@ describe('slack handlers', () => {
     });
   });
 
+  it('responds to /kanvy help with usage guidance and does not start a run', async () => {
+    const repoBoard = makeRepoBoard({ taskId: 'task_help', runId: 'run_help' });
+    const rawBody = new URLSearchParams({
+      command: '/kanvy',
+      text: 'help',
+      channel_id: 'C123',
+      thread_ts: '1672531200.1234',
+      team_id: 'team_one',
+      user_id: 'U1',
+      response_url: 'https://hooks.slack.com/commands/help'
+    }).toString();
+    const timestamp = nowTs;
+    const signature = await buildSlackSignature('secret', timestamp, rawBody);
+    const request = new Request('https://example.test/api/integrations/slack/commands', {
+      method: 'POST',
+      headers: slackHeaders(timestamp, signature),
+      body: rawBody
+    });
+    const waitUntilTasks: Array<Promise<unknown>> = [];
+    const waitUntil = vi.fn((task: Promise<unknown>) => {
+      waitUntilTasks.push(task);
+    });
+
+    const response = await handleSlackCommands(request, makeEnv('secret', repoBoard), { waitUntil } as unknown as ExecutionContext<unknown>);
+    const body = await response.json() as { ok: boolean; text: string };
+
+    expect(response.status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(body.text).toContain('Accepted /kanvy help command');
+    expect(waitUntil).toHaveBeenCalledTimes(1);
+    await waitUntilTasks[0];
+    const calledPayload = JSON.parse(((vi.mocked(global.fetch).mock.calls[0] as [string, RequestInit])[1].body as string));
+    expect(calledPayload.text).toContain('/kanvy fix <JIRA_KEY>');
+    expect(calledPayload.text).toContain('/kanvy help');
+    expect(calledPayload.text).toContain('Free-text flow');
+    expect(fetchIssue).not.toHaveBeenCalled();
+    expect(repoBoard.createTask).not.toHaveBeenCalled();
+    expect(repoBoard.startRun).not.toHaveBeenCalled();
+  });
+
   it('asks for repo disambiguation when multiple mappings exist', async () => {
     tenantAuthDbMocks.listJiraProjectRepoMappingsByProject.mockResolvedValue([
       { jiraProjectKey: 'ABC', repoId: 'repo_alpha', priority: 0, active: true, id: 'm1', tenantId: 'tenant_local', createdAt: '', updatedAt: '' },

--- a/src/server/integrations/slack/handlers.ts
+++ b/src/server/integrations/slack/handlers.ts
@@ -26,6 +26,12 @@ const FALLBACK_DISAMBIGUATION_WARNING = 'No matching repository was auto-selecte
 const DISAMBIGUATION_MULTIPLE_MAPPINGS_MESSAGE = 'Multiple repositories are mapped for Jira project';
 const DISAMBIGUATION_NO_MAPPING_MESSAGE = 'No active mapping exists for project';
 const INGRESS_DEDUPE_TTL_SECONDS = 10 * 60;
+const KANVY_HELP_TEXT = [
+  'Usage: `/kanvy fix <JIRA_KEY>` or `/kanvy help`.',
+  'Examples:',
+  '- Jira fast-path: `/kanvy fix ABC-123`',
+  '- Free-text flow: `/kanvy Investigate flaky checkout tests and propose a fix plan`'
+].join('\n');
 
 type RepoDisambiguationChoice = {
   repoId: string;
@@ -513,6 +519,14 @@ async function runSlackCommandAsync(
   payload: ReturnType<typeof parseSlackSlashCommandBody>,
   ctx?: ExecutionContext<unknown>
 ) {
+  if (payload.intent === 'help') {
+    await postSlackResponse(payload.responseUrl, {
+      response_type: 'ephemeral',
+      text: KANVY_HELP_TEXT
+    });
+    return;
+  }
+
   const tenantId = await resolveThreadTenantId(env, payload.teamId);
   const slashDedupeKey = buildIdempotencyKey({
     provider: 'slack',
@@ -613,7 +627,9 @@ export async function handleSlackCommands(
     }
     return json({
       ok: true,
-      text: `Accepted /kanvy command for ${payload.issueKey}.`
+      text: payload.intent === 'help'
+        ? 'Accepted /kanvy help command.'
+        : `Accepted /kanvy command for ${payload.issueKey}.`
     });
   } catch (error) {
     return handleError(error);

--- a/src/server/integrations/slack/payload.test.ts
+++ b/src/server/integrations/slack/payload.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { parseSlackSlashCommandBody } from './payload';
+
+describe('parseSlackSlashCommandBody', () => {
+  it('parses fix jira-key command', () => {
+    const rawBody = new URLSearchParams({
+      command: '/kanvy',
+      text: 'fix abc-123',
+      channel_id: 'C123',
+      thread_ts: '1672531200.1234',
+      team_id: 'T123',
+      user_id: 'U123',
+      response_url: 'https://hooks.slack.test/fix'
+    }).toString();
+
+    const payload = parseSlackSlashCommandBody(rawBody);
+    expect(payload.intent).toBe('fix');
+    if (payload.intent === 'fix') {
+      expect(payload.issueKey).toBe('ABC-123');
+    }
+  });
+
+  it('parses help command', () => {
+    const rawBody = new URLSearchParams({
+      command: '/kanvy',
+      text: 'help',
+      channel_id: 'C123',
+      team_id: 'T123',
+      user_id: 'U123',
+      response_url: 'https://hooks.slack.test/help'
+    }).toString();
+
+    const payload = parseSlackSlashCommandBody(rawBody);
+    expect(payload.intent).toBe('help');
+  });
+
+  it('rejects unsupported format', () => {
+    const rawBody = new URLSearchParams({
+      command: '/kanvy',
+      text: 'status ABC-123',
+      channel_id: 'C123'
+    }).toString();
+
+    expect(() => parseSlackSlashCommandBody(rawBody)).toThrow(
+      'Invalid slash command format. Expected: /kanvy fix <JIRA_KEY> or /kanvy help.'
+    );
+  });
+});

--- a/src/server/integrations/slack/payload.ts
+++ b/src/server/integrations/slack/payload.ts
@@ -1,15 +1,23 @@
 import { badRequest } from '../../http/errors';
 
-export type SlackSlashCommandPayload = {
+type SlackSlashCommandPayloadBase = {
   command: string;
   text: string;
-  issueKey: string;
   teamId: string | undefined;
   channelId: string;
   threadTs: string | undefined;
   userId: string;
   responseUrl: string | undefined;
 };
+
+export type SlackSlashCommandPayload =
+  | (SlackSlashCommandPayloadBase & {
+    intent: 'help';
+  })
+  | (SlackSlashCommandPayloadBase & {
+    intent: 'fix';
+    issueKey: string;
+  });
 
 export type SlackInteractionAction = 'repo_disambiguation' | 'approve_rerun' | 'pause' | 'close';
 
@@ -51,6 +59,7 @@ type SlackEventPayload = {
 
 const ISSUE_KEY_PATTERN = /^[A-Z][A-Z0-9_]*-\d+$/i;
 const FIX_COMMAND_PATTERN = /^fix\s+([A-Z][A-Z0-9_]*-\d+)\s*$/i;
+const HELP_COMMAND_PATTERN = /^help\s*$/i;
 const SUPPORTED_SLACK_COMMAND = '/kanvy';
 const SUPPORTED_ACTION_IDS: Set<string> = new Set([
   'repo_disambiguation',
@@ -119,9 +128,26 @@ export function parseSlackSlashCommandBody(rawBody: string): SlackSlashCommandPa
     throw badRequest('Unknown Slack slash command.');
   }
   const text = readFormValue(params, 'text', false) ?? '';
+  const teamId = readFormValue(params, 'team_id', false);
+  const channelId = readFormValue(params, 'channel_id', true);
+  const threadTs = readFormValue(params, 'thread_ts', false);
+  const userId = readFormValue(params, 'user_id', false) ?? 'unknown';
+  const responseUrl = readFormValue(params, 'response_url', false);
+  if (HELP_COMMAND_PATTERN.test(text)) {
+    return {
+      intent: 'help',
+      command,
+      text,
+      teamId,
+      channelId,
+      threadTs,
+      userId,
+      responseUrl
+    };
+  }
   const match = FIX_COMMAND_PATTERN.exec(text);
   if (!match || !match[1]) {
-    throw badRequest('Invalid slash command format. Expected: /kanvy fix <JIRA_KEY>.');
+    throw badRequest('Invalid slash command format. Expected: /kanvy fix <JIRA_KEY> or /kanvy help.');
   }
   const issueKey = match[1].toUpperCase();
   if (!ISSUE_KEY_PATTERN.test(issueKey)) {
@@ -129,14 +155,15 @@ export function parseSlackSlashCommandBody(rawBody: string): SlackSlashCommandPa
   }
 
   return {
+    intent: 'fix',
     command,
     text,
     issueKey,
-    teamId: readFormValue(params, 'team_id', false),
-    channelId: readFormValue(params, 'channel_id', true),
-    threadTs: readFormValue(params, 'thread_ts', false),
-    userId: readFormValue(params, 'user_id', false) ?? 'unknown',
-    responseUrl: readFormValue(params, 'response_url', false)
+    teamId,
+    channelId,
+    threadTs,
+    userId,
+    responseUrl
   };
 }
 


### PR DESCRIPTION
## Objective
Add end-to-end support for `/kanvy help` in the Slack slash-command integration.

## Scope
- Extend slash-command parsing to recognize `help` intent.
- Add Slack handler behavior to return concise usage instructions.
- Keep `fix <JIRA_KEY>` and interaction flows unchanged.
- Add focused tests for parser + handler behavior.
- Update Slack command documentation.

## Behavior changes
- `/kanvy help` now returns concise usage guidance and examples, including:
  - Jira fast-path: `/kanvy fix ABC-123`
  - Free-text flow example
- `/kanvy fix <JIRA_KEY>` behavior remains unchanged.

## API/type changes
- `SlackSlashCommandPayload` is now a discriminated union:
  - `intent: "help"`
  - `intent: "fix"` with `issueKey`

## Backward compatibility
- Existing `/kanvy fix <JIRA_KEY>` parsing and async handler flow are preserved.
- Existing interaction actions (`repo_disambiguation`, `approve_rerun`, `pause`, `close`) are unchanged.

## Tests
- Added: `src/server/integrations/slack/payload.test.ts`
- Updated: `src/server/integrations/slack/handlers.test.ts`
- Ran scoped tests only:
  - `npm run test -- src/server/integrations/slack/payload.test.ts src/server/integrations/slack/handlers.test.ts`

## Risks / Rollback
- Low risk: changes are isolated to slash parser/handler + docs.
- Rollback: revert this PR; existing `fix` flow remains in prior behavior.
