### PR TITLE
Slack /kanvy non-thread handoff + Jira observability logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ AgentsKanban helps you run AI-assisted software work the same way you already ma
 
 - Trigger task execution from Slack slash commands with a Jira issue key (`/kanvy fix ABC-123`).
 - Show concise slash command usage help directly in Slack (`/kanvy help`).
+- Allow free-text `/kanvy <request>` from channel or thread; channel commands auto-create a thread handoff for intake continuation.
 - Resolve Jira project -> repository mapping and start the first run from `main`.
 - Mirror GitLab MR lifecycle and review feedback into the same Slack thread.
 - Gate reruns behind explicit Slack approval (`approve rerun`) in-thread.

--- a/docs/features-and-api.md
+++ b/docs/features-and-api.md
@@ -79,7 +79,8 @@ Operational notes:
 
 - `POST /api/integrations/slack/commands`
   - Verified with Slack signing secret and replay window checks.
-  - Accepts `/kanvy fix <JIRA_KEY>` and `/kanvy help`.
+  - Accepts `/kanvy fix <JIRA_KEY>`, `/kanvy help`, and `/kanvy <free-text request>`.
+  - For free-text commands sent outside a thread, auto-creates a thread kickoff and responds with an ephemeral handoff link.
   - Acknowledges immediately and continues Jira/repo/run processing asynchronously.
 - `POST /api/integrations/slack/interactions`
   - Supports actions: `repo_disambiguation`, `approve_rerun`, `pause`, `close`.

--- a/docs/integrations/slack-jira-gitlab-mvp.md
+++ b/docs/integrations/slack-jira-gitlab-mvp.md
@@ -40,13 +40,14 @@ Out of scope (this phase):
 
 ## Operator day-to-day flow (no dashboard required)
 
-1. In Slack, run `/kanvy fix ABC-123` for deterministic Jira flow, or `/kanvy <free-text request>` from a thread.
-2. For free-text flow, answer clarifying questions in the same thread (max 4 turns before structured handoff prompt).
-3. For usage guidance, run `/kanvy help`.
-4. If multiple repo mappings are available, click a repo disambiguation button (Jira flow) or reply with repo id (free-text flow).
-5. Monitor status and MR feedback in the same Slack thread.
-6. When feedback arrives and run enters `DECISION_REQUIRED`, click `Approve rerun`.
-7. Continue the thread loop until `DONE`, `PAUSED`, or `FAILED`.
+1. In Slack, run `/kanvy fix ABC-123` for deterministic Jira flow, or `/kanvy <free-text request>` from channel or thread.
+2. If free-text starts in channel (non-thread), the system posts a thread kickoff and sends an ephemeral handoff link; continue clarification in that thread.
+3. For free-text flow, answer clarifying questions in the same thread (max 4 turns before structured handoff prompt).
+4. For usage guidance, run `/kanvy help`.
+5. If multiple repo mappings are available, click a repo disambiguation button (Jira flow) or reply with repo id (free-text flow).
+6. Monitor status and MR feedback in the same Slack thread.
+7. When feedback arrives and run enters `DECISION_REQUIRED`, click `Approve rerun`.
+8. Continue the thread loop until `DONE`, `PAUSED`, or `FAILED`.
 
 ## Reliability and hardening behavior
 
@@ -79,6 +80,7 @@ State and idempotency checks:
 1. Jira lookup failure
    - Symptom: slash command ack succeeds but follow-up reports Jira fetch failure.
    - Operator action: verify `JIRA_TOKEN`, issue key, Jira reachability.
+   - Logs: inspect structured `slack_command_lifecycle` checkpoints (`jira_fetch_started`, `jira_fetch_failed`) including Jira host/path, category, and sanitized message.
 2. Missing repo mapping
    - Symptom: disambiguation or no-mapping message in Slack.
    - Operator action: add/enable Jira project -> repo mapping.

--- a/docs/local-testing.md
+++ b/docs/local-testing.md
@@ -285,6 +285,7 @@ Use this when validating day-to-day operator flow without dashboard actions.
    - run start confirmation
    - repo disambiguation buttons
    - failure message (for example Jira read failure)
+   - thread handoff link + kickoff message when `/kanvy <free-text>` is invoked outside a thread
    - usage instructions with examples for Jira fast-path and free-text flow (for `/kanvy help`)
 5. Confirm run thread binding stores:
    - `taskId`, `channelId`, `threadTs`, `currentRunId`, `latestReviewRound`
@@ -300,6 +301,7 @@ Ingress/idempotency checks to verify in local logs:
 - Duplicate slash command deliveries are ignored for the same command response envelope.
 - Duplicate interaction deliveries are ignored to prevent duplicate task/run starts.
 - GitLab duplicate deliveries are ignored.
+- `slack_command_lifecycle` checkpoints appear for slash processing (`received`, `deduped`, `jira_fetch_started`, `jira_fetch_failed`, `task_started`) with sanitized Jira diagnostics.
 
 ## 9) Slack/GitLab failure-path checks
 

--- a/src/server/integrations/slack/client.ts
+++ b/src/server/integrations/slack/client.ts
@@ -95,3 +95,48 @@ export async function postSlackThreadMessage(
 
   return { delivered: true };
 }
+
+export async function postSlackChannelMessage(
+  env: Env,
+  target: {
+    tenantId: string;
+    repoId?: string;
+    channelId: string;
+    text: string;
+  }
+): Promise<{ delivered: boolean; reason?: string; ts?: string }> {
+  const config = await resolveSlackConfig(env, target);
+  const token = await resolveSlackBotToken(env, config, target.tenantId);
+  if (!token) {
+    return { delivered: false, reason: 'missing_slack_bot_token' };
+  }
+
+  const response = await fetch('https://slack.com/api/chat.postMessage', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json; charset=utf-8'
+    },
+    body: JSON.stringify({
+      channel: target.channelId,
+      text: target.text,
+      unfurl_links: false,
+      unfurl_media: false,
+      mrkdwn: true
+    })
+  });
+
+  if (!response.ok) {
+    return { delivered: false, reason: `slack_http_${response.status}` };
+  }
+
+  const payload = await response.json().catch(() => undefined) as { ok?: boolean; ts?: unknown } | undefined;
+  if (payload?.ok !== true) {
+    return { delivered: false, reason: 'slack_api_error' };
+  }
+
+  return {
+    delivered: true,
+    ts: typeof payload.ts === 'string' && payload.ts.trim() ? payload.ts.trim() : undefined
+  };
+}

--- a/src/server/integrations/slack/handlers.test.ts
+++ b/src/server/integrations/slack/handlers.test.ts
@@ -20,6 +20,7 @@ const runOrchestratorMocks = vi.hoisted(() => ({
   scheduleRunJob: vi.fn()
 }));
 const fetchSpy = vi.spyOn(globalThis, 'fetch');
+const consoleInfoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
 
 vi.mock('../../tenant-auth-db', () => tenantAuthDbMocks);
 vi.mock('../jira/client', () => jiraClientMocks);
@@ -121,6 +122,7 @@ describe('slack handlers', () => {
     vi.clearAllMocks();
     fetchSpy.mockReset();
     fetchSpy.mockResolvedValue(new Response('{}', { status: 200 }));
+    consoleInfoSpy.mockClear();
     tenantAuthDbMocks.getPrimaryTenantId.mockResolvedValue('tenant_local');
     tenantAuthDbMocks.upsertSlackThreadBinding.mockImplementation(async (input: {
       taskId: string;
@@ -322,6 +324,72 @@ describe('slack handlers', () => {
     }));
   });
 
+  it('auto-creates a thread handoff for non-thread free-text slash commands', async () => {
+    const repoBoard = makeRepoBoard({ taskId: 'task_handoff', runId: 'run_handoff' });
+    fetchSpy.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes('https://slack.com/api/chat.postMessage')) {
+        const payload = JSON.parse(String(init?.body ?? '{}')) as { thread_ts?: string };
+        if (payload.thread_ts) {
+          return new Response(JSON.stringify({ ok: true, ts: payload.thread_ts }), { status: 200 });
+        }
+        return new Response(JSON.stringify({ ok: true, ts: '1672531200.9999' }), { status: 200 });
+      }
+      if (url.includes('/v1/chat/completions')) {
+        return new Response(JSON.stringify({
+          choices: [{
+            message: {
+              content: JSON.stringify({
+                intent: 'create_task',
+                confidence: 0.4,
+                acceptanceCriteria: [],
+                missingFields: ['repo'],
+                clarifyingQuestion: 'Which repo should I use?'
+              })
+            }
+          }]
+        }), { status: 200 });
+      }
+      return new Response('{}', { status: 200 });
+    });
+
+    const rawBody = new URLSearchParams({
+      command: '/kanvy',
+      text: 'investigate flaky tests',
+      channel_id: 'C123',
+      team_id: 'team_one',
+      user_id: 'U1',
+      response_url: 'https://hooks.slack.com/commands/handoff'
+    }).toString();
+    const signature = await buildSlackSignature('secret', nowTs, rawBody);
+    const request = new Request('https://example.test/api/integrations/slack/commands', {
+      method: 'POST',
+      headers: slackHeaders(nowTs, signature),
+      body: rawBody
+    });
+    const waitUntilTasks: Array<Promise<unknown>> = [];
+    const waitUntil = vi.fn((task: Promise<unknown>) => waitUntilTasks.push(task));
+    const env = makeEnv('secret', repoBoard);
+    await env.SECRETS_KV.put('slack/bot-token', 'xoxb-test');
+
+    const response = await handleSlackCommands(request, env, { waitUntil } as unknown as ExecutionContext<unknown>);
+    expect(response.status).toBe(200);
+    await waitUntilTasks[0];
+
+    const calls = vi.mocked(global.fetch).mock.calls as Array<[RequestInfo | URL, RequestInit]>;
+    const channelKickoff = calls.find((entry) => String(entry[0]).includes('https://slack.com/api/chat.postMessage')
+      && !String(entry[1].body).includes('"thread_ts"'));
+    const threadPrompt = calls.find((entry) => String(entry[0]).includes('https://slack.com/api/chat.postMessage')
+      && String(entry[1].body).includes('"thread_ts":"1672531200.9999"'));
+    const responseAck = calls.find((entry) => String(entry[0]).includes('https://hooks.slack.com/commands/handoff'));
+
+    expect(channelKickoff).toBeTruthy();
+    expect(threadPrompt).toBeTruthy();
+    expect(responseAck?.[1].body).toContain('Continuing in thread:');
+    expect(responseAck?.[1].body).toContain('message_ts=1672531200.9999');
+    expect(repoBoard.createTask).not.toHaveBeenCalled();
+  });
+
   it('asks for repo disambiguation when multiple mappings exist', async () => {
     tenantAuthDbMocks.listJiraProjectRepoMappingsByProject.mockResolvedValue([
       { jiraProjectKey: 'ABC', repoId: 'repo_alpha', priority: 0, active: true, id: 'm1', tenantId: 'tenant_local', createdAt: '', updatedAt: '' },
@@ -434,6 +502,14 @@ describe('slack handlers', () => {
     const calledPayload = JSON.parse(((vi.mocked(global.fetch).mock.calls[0] as [string, RequestInit])[1].body as string));
     expect(calledPayload.text).toContain('Failed to process /kanvy command for ABC-100');
     expect(calledPayload.text).toContain('temporary outage');
+    const lifecycleLogs = consoleInfoSpy.mock.calls
+      .map((entry) => String(entry[0]))
+      .filter((line) => line.includes('"event":"slack_command_lifecycle"'));
+    expect(lifecycleLogs.some((line) => line.includes('"checkpoint":"received"'))).toBe(true);
+    expect(lifecycleLogs.some((line) => line.includes('"checkpoint":"jira_fetch_started"'))).toBe(true);
+    expect(lifecycleLogs.some((line) => line.includes('"checkpoint":"jira_fetch_failed"'))).toBe(true);
+    expect(lifecycleLogs.some((line) => line.includes('"jira_failure_category":"unknown"'))).toBe(true);
+    expect(lifecycleLogs.some((line) => line.includes('"issue_key":"ABC-100"'))).toBe(true);
     expect(failingBoard.createTask).not.toHaveBeenCalled();
   });
 

--- a/src/server/integrations/slack/handlers.ts
+++ b/src/server/integrations/slack/handlers.ts
@@ -15,7 +15,7 @@ import {
 } from './payload';
 import { resolveThreadTenant, verifySlackRequest } from './verification';
 import { mirrorRunLifecycleMilestone } from './timeline';
-import { postSlackThreadMessage } from './client';
+import { postSlackChannelMessage, postSlackThreadMessage } from './client';
 import { resolveIntegrationConfig } from '../config-resolution';
 import {
   parseSlackIntentWithLlm,
@@ -42,6 +42,10 @@ const KANVY_HELP_TEXT = [
 ].join('\n');
 const SESSION_EXPIRY_MS = 24 * 60 * 60 * 1000;
 const AUTO_CREATE_CONFIDENCE_THRESHOLD = 0.8;
+const DEFAULT_JIRA_API_PATH_PREFIX = '/rest/api/3/issue';
+const MAX_LOG_MESSAGE_CHARS = 300;
+
+type SlackLifecycleCheckpoint = 'received' | 'deduped' | 'jira_fetch_started' | 'jira_fetch_failed' | 'task_started';
 
 type RepoDisambiguationChoice = {
   repoId: string;
@@ -74,6 +78,99 @@ function toReadableErrorMessage(error: unknown) {
     return error.message;
   }
   return 'Unknown error.';
+}
+
+function sanitizeErrorMessageForLog(message: string | undefined) {
+  if (!message) {
+    return 'Unknown error.';
+  }
+  return message
+    .replace(/Bearer\s+[A-Za-z0-9._~+/=-]+/gi, 'Bearer [REDACTED]')
+    .replace(/Basic\s+[A-Za-z0-9._~+/=-]+/gi, 'Basic [REDACTED]')
+    .replace(/token=[^&\s]+/gi, 'token=[REDACTED]')
+    .slice(0, MAX_LOG_MESSAGE_CHARS);
+}
+
+function parseJiraFailureCategory(error: unknown): { category: 'network' | 'timeout' | 'http_status' | 'bad_request' | 'unknown'; status?: number } {
+  const message = error instanceof Error ? error.message : String(error);
+  if (message.includes('Unable to reach Jira issue endpoint')) {
+    return { category: 'network' };
+  }
+  if (message.toLowerCase().includes('timed out')) {
+    return { category: 'timeout' };
+  }
+  const statusMatch = message.match(/\((\d{3})\)/);
+  if (statusMatch) {
+    const status = Number.parseInt(statusMatch[1]!, 10);
+    if (Number.isFinite(status)) {
+      return { category: 'http_status', status };
+    }
+  }
+  if (message.startsWith('Invalid Jira issue key') || message.startsWith('Jira issue')) {
+    return { category: 'bad_request' };
+  }
+  return { category: 'unknown' };
+}
+
+function resolveJiraRequestTarget(env: Env, issueKey: string): { host: string; path: string } {
+  const envValues = env as unknown as Record<string, string | undefined>;
+  const rawBase = envValues.JIRA_API_BASE_URL ?? envValues.JIRA_API_URL ?? '';
+  const fallbackPath = `${DEFAULT_JIRA_API_PATH_PREFIX}/${issueKey}`;
+  if (!rawBase.trim()) {
+    return { host: 'unknown', path: fallbackPath };
+  }
+  try {
+    const parsed = new URL(rawBase);
+    const normalizedBasePath = parsed.pathname.replace(/\/$/, '');
+    const pathPrefix = normalizedBasePath.toLowerCase().includes('/rest/api/3')
+      ? normalizedBasePath
+      : `${normalizedBasePath}${DEFAULT_JIRA_API_PATH_PREFIX}`;
+    return {
+      host: parsed.host,
+      path: `${pathPrefix}/${issueKey}`
+    };
+  } catch {
+    return { host: 'invalid_jira_base_url', path: fallbackPath };
+  }
+}
+
+function logSlackCommandLifecycle(input: {
+  checkpoint: SlackLifecycleCheckpoint;
+  tenantId: string;
+  channelId: string;
+  issueKey?: string;
+  threadTs?: string;
+  dedupeKey?: string;
+  deduped?: boolean;
+  taskId?: string;
+  runId?: string;
+  jiraHost?: string;
+  jiraPath?: string;
+  jiraFailureCategory?: string;
+  jiraStatus?: number;
+  message?: string;
+}) {
+  console.info(JSON.stringify({
+    event: 'slack_command_lifecycle',
+    checkpoint: input.checkpoint,
+    tenant_id: input.tenantId,
+    channel_id: input.channelId,
+    thread_ts: input.threadTs ?? null,
+    issue_key: input.issueKey ?? null,
+    dedupe_key: input.dedupeKey ?? null,
+    deduped: input.deduped ?? null,
+    task_id: input.taskId ?? null,
+    run_id: input.runId ?? null,
+    jira_host: input.jiraHost ?? null,
+    jira_path: input.jiraPath ?? null,
+    jira_failure_category: input.jiraFailureCategory ?? null,
+    jira_status: input.jiraStatus ?? null,
+    message: input.message ? sanitizeErrorMessageForLog(input.message) : null
+  }));
+}
+
+function formatSlackThreadLink(channelId: string, threadTs: string) {
+  return `https://slack.com/app_redirect?channel=${encodeURIComponent(channelId)}&message_ts=${encodeURIComponent(threadTs)}`;
 }
 
 function buildTaskPromptFromIssue(issue: IntegrationIssueRef) {
@@ -542,14 +639,14 @@ async function processJiraIssueFlow(
   },
   responseUrl: string | undefined,
   llmModel: CreateTaskInput['codexModel'] = DEFAULT_TASK_LLM_MODEL
-) {
+): Promise<RunKickoff | undefined> {
   const issueProjectKey = issueProjectKeyFromIssue(issue.issueKey);
   const mappings = await tenantAuthDb.listJiraProjectRepoMappingsByProject(env, tenantId, issueProjectKey, true);
   if (mappings.length === 0) {
     const candidates = await resolveRepoCandidates(env, tenantId, issueProjectKey, []);
     if (candidates.length === 0) {
       await postSlackResponse(responseUrl, buildNoMappingResponse(issue, issueProjectKey));
-      return;
+      return undefined;
     }
     await postSlackResponse(responseUrl, buildDisambiguationResponse(
       issue,
@@ -559,14 +656,14 @@ async function processJiraIssueFlow(
       true,
       { taskId: bindings.taskId, channelId: bindings.channelId, threadTs: bindings.threadTs ?? '' }
     ));
-    return;
+    return undefined;
   }
 
   const candidates = await resolveRepoCandidates(env, tenantId, issueProjectKey, mappings);
   if (mappings.length > 1) {
     if (candidates.length === 0) {
       await postSlackResponse(responseUrl, buildNoMappingResponse(issue, issueProjectKey));
-      return;
+      return undefined;
     }
     await postSlackResponse(responseUrl, buildDisambiguationResponse(
       issue,
@@ -576,12 +673,12 @@ async function processJiraIssueFlow(
       false,
       { taskId: bindings.taskId, channelId: bindings.channelId, threadTs: bindings.threadTs ?? '' }
     ));
-    return;
+    return undefined;
   }
 
   if (candidates.length !== 1) {
     await postSlackResponse(responseUrl, buildNoMappingResponse(issue, issueProjectKey));
-    return;
+    return undefined;
   }
 
   const repoId = candidates[0]!.repoId;
@@ -601,6 +698,7 @@ async function processJiraIssueFlow(
       response_type: 'ephemeral',
       text: `Started ${issue.issueKey} in repo ${repoId} (task ${started.taskId}, run ${started.runId}).`
     });
+    return started;
   } catch (error) {
     await postSlackResponse(responseUrl, {
       response_type: 'ephemeral',
@@ -674,7 +772,7 @@ async function runIntentIntake(
     text: string;
     responseUrl?: string;
   }
-) {
+): Promise<RunKickoff | undefined> {
   const existing = await tenantAuthDb.getSlackIntakeSession(env, input.tenantId, input.channelId, input.threadTs);
   const expired = existing ? isSessionExpired(existing.lastActivityAt) : false;
   if (existing && expired && existing.status === 'active') {
@@ -748,7 +846,7 @@ async function runIntentIntake(
         text: completionText
       });
     }
-    return;
+    return started;
   }
 
   const nextTurn = currentTurn + 1;
@@ -790,12 +888,12 @@ async function runIntentIntake(
         text: handoff
       });
     }
-    return;
+    return undefined;
   }
 
   if (input.responseUrl) {
     await postSlackResponse(input.responseUrl, { response_type: 'ephemeral', text: question });
-    return;
+    return undefined;
   }
   await postThreadPrompt(env, {
     tenantId: input.tenantId,
@@ -803,6 +901,33 @@ async function runIntentIntake(
     threadTs: input.threadTs,
     text: question
   });
+  return undefined;
+}
+
+async function ensureThreadForChannelIntake(env: Env, input: {
+  tenantId: string;
+  channelId: string;
+  userId: string;
+  responseUrl?: string;
+}): Promise<string | undefined> {
+  const kickoff = await postSlackChannelMessage(env, {
+    tenantId: input.tenantId,
+    channelId: input.channelId,
+    text: `Starting /kanvy intake for <@${input.userId}>. Continue in this thread.`
+  });
+  if (!kickoff.delivered || !kickoff.ts) {
+    await postSlackResponse(input.responseUrl, {
+      response_type: 'ephemeral',
+      text: 'Unable to create a thread for intake continuation. Please retry in a thread.'
+    });
+    return undefined;
+  }
+
+  await postSlackResponse(input.responseUrl, {
+    response_type: 'ephemeral',
+    text: `Continuing in thread: ${formatSlackThreadLink(input.channelId, kickoff.ts)}`
+  });
+  return kickoff.ts;
 }
 
 async function runSlackCommandAsync(
@@ -810,6 +935,16 @@ async function runSlackCommandAsync(
   payload: ReturnType<typeof parseSlackSlashCommandBody>,
   ctx?: ExecutionContext<unknown>
 ) {
+  const tenantId = await resolveThreadTenantId(env, payload.teamId);
+  const issueKey = parseJiraFastPathIssueKey(payload.text);
+  logSlackCommandLifecycle({
+    checkpoint: 'received',
+    tenantId,
+    channelId: payload.channelId,
+    threadTs: payload.threadTs,
+    issueKey: issueKey ?? undefined
+  });
+
   if (payload.text.trim().toLowerCase() === 'help') {
     await postSlackResponse(payload.responseUrl, {
       response_type: 'ephemeral',
@@ -818,8 +953,6 @@ async function runSlackCommandAsync(
     return;
   }
 
-  const tenantId = await resolveThreadTenantId(env, payload.teamId);
-  const issueKey = parseJiraFastPathIssueKey(payload.text);
   const dedupeSubject = issueKey ?? (payload.text.trim() || 'empty');
   const slashDedupeKey = buildIdempotencyKey({
     provider: 'slack',
@@ -833,6 +966,15 @@ async function runSlackCommandAsync(
     }
   });
   if (!(await markIngressDeliveryIfNew(env, slashDedupeKey))) {
+    logSlackCommandLifecycle({
+      checkpoint: 'deduped',
+      tenantId,
+      channelId: payload.channelId,
+      threadTs: payload.threadTs,
+      issueKey: issueKey ?? undefined,
+      dedupeKey: slashDedupeKey,
+      deduped: true
+    });
     await postSlackResponse(payload.responseUrl, {
       response_type: 'ephemeral',
       text: issueKey
@@ -841,6 +983,15 @@ async function runSlackCommandAsync(
     });
     return;
   }
+  logSlackCommandLifecycle({
+    checkpoint: 'deduped',
+    tenantId,
+    channelId: payload.channelId,
+    threadTs: payload.threadTs,
+    issueKey: issueKey ?? undefined,
+    dedupeKey: slashDedupeKey,
+    deduped: false
+  });
 
   if (!payload.text.trim()) {
     await postSlackResponse(payload.responseUrl, {
@@ -851,21 +1002,32 @@ async function runSlackCommandAsync(
   }
 
   if (!issueKey) {
-    if (!payload.threadTs) {
-      await postSlackResponse(payload.responseUrl, {
-        response_type: 'ephemeral',
-        text: 'For free-text intake, run `/kanvy ...` from a thread so clarification can continue in-thread.'
-      });
-      return;
-    }
-    try {
-      await runIntentIntake(env, ctx, {
+    const threadTs = payload.threadTs
+      ?? await ensureThreadForChannelIntake(env, {
         tenantId,
         channelId: payload.channelId,
-        threadTs: payload.threadTs,
-        text: payload.text,
+        userId: payload.userId,
         responseUrl: payload.responseUrl
       });
+    if (!threadTs) return;
+    try {
+      const started = await runIntentIntake(env, ctx, {
+        tenantId,
+        channelId: payload.channelId,
+        threadTs,
+        text: payload.text,
+        responseUrl: payload.threadTs ? payload.responseUrl : undefined
+      });
+      if (started) {
+        logSlackCommandLifecycle({
+          checkpoint: 'task_started',
+          tenantId,
+          channelId: payload.channelId,
+          threadTs,
+          taskId: started.taskId,
+          runId: started.runId
+        });
+      }
     } catch (error) {
       await postSlackResponse(payload.responseUrl, {
         response_type: 'ephemeral',
@@ -880,17 +1042,49 @@ async function runSlackCommandAsync(
     : buildTaskIdFromIssue(issueKey);
 
   try {
+    const jiraTarget = resolveJiraRequestTarget(env, issueKey);
+    logSlackCommandLifecycle({
+      checkpoint: 'jira_fetch_started',
+      tenantId,
+      channelId: payload.channelId,
+      threadTs: payload.threadTs,
+      issueKey,
+      jiraHost: jiraTarget.host,
+      jiraPath: jiraTarget.path
+    });
     const issue = await resolveTenantAndJiraIssue(env, tenantId, issueKey);
     const { settings } = await resolveSlackIntentScopeConfig(env, tenantId, {
       channelId: payload.channelId
     });
-    await processJiraIssueFlow(env, ctx, tenantId, issue, {
+    const started = await processJiraIssueFlow(env, ctx, tenantId, issue, {
       taskId: bindingTaskId,
       channelId: payload.channelId,
       threadTs: payload.threadTs,
       latestReviewRound: DEFAULT_REVIEW_ROUND
     }, payload.responseUrl, toSupportedCodexModel(settings.intentModel));
+    if (started) {
+      logSlackCommandLifecycle({
+        checkpoint: 'task_started',
+        tenantId,
+        channelId: payload.channelId,
+        threadTs: payload.threadTs,
+        issueKey,
+        taskId: started.taskId,
+        runId: started.runId
+      });
+    }
   } catch (error) {
+    const jiraFailure = parseJiraFailureCategory(error);
+    logSlackCommandLifecycle({
+      checkpoint: 'jira_fetch_failed',
+      tenantId,
+      channelId: payload.channelId,
+      threadTs: payload.threadTs,
+      issueKey,
+      jiraFailureCategory: jiraFailure.category,
+      jiraStatus: jiraFailure.status,
+      message: toReadableErrorMessage(error)
+    });
     await postSlackResponse(payload.responseUrl, {
       response_type: 'ephemeral',
       text: `Failed to process /kanvy command for ${issueKey}: ${toReadableErrorMessage(error)}`


### PR DESCRIPTION
## Objective
Allow `/kanvy` free-text commands to start from channel (non-thread) by automatically creating a thread handoff, while adding actionable structured logs for Jira lookup and slash command lifecycle.

## Scope
- Auto-create Slack thread kickoff for non-thread free-text `/kanvy ...` usage.
- Reply to slash command with a handoff link to the created thread.
- Continue intake/questions in the created thread.
- Add structured server logs for command lifecycle and Jira fetch diagnostics.
- Add tests for thread handoff and Jira failure logging.
- Update Slack/Jira docs.

## Behavior changes
- Keeps `/kanvy help` behavior unchanged.
- Keeps deterministic `/kanvy fix <JIRA_KEY>` fast-path behavior.
- For non-thread free-text `/kanvy`, system now:
  1) posts kickoff message in channel,
  2) responds ephemerally with thread link,
  3) continues intake in that thread.
- Structured `slack_command_lifecycle` checkpoints are emitted:
  - `received`
  - `deduped`
  - `jira_fetch_started`
  - `jira_fetch_failed`
  - `task_started`
- Jira diagnostics include issue key + tenant + sanitized host/path and failure classification (`network|timeout|http_status|bad_request|unknown`) without secrets.

## API/type changes
- Added `postSlackChannelMessage(...)` helper to Slack client for thread-root message creation.
- `runIntentIntake(...)` and Jira flow internals now return kickoff metadata when a task/run starts.

## Backward compatibility
- Existing slash command ack behavior preserved.
- Existing Jira fast-path and help flow preserved.

## Manual QA
1. Run `/kanvy help` in Slack -> usage response unchanged.
2. Run `/kanvy fix ABC-123` in-thread -> task/run starts as before.
3. Run `/kanvy investigate flaky tests` in channel:
   - kickoff message appears,
   - ephemeral handoff includes thread link,
   - clarification prompt appears in created thread.
4. Force Jira lookup failure for `/kanvy fix ABC-123` and verify logs include `jira_fetch_started` + `jira_fetch_failed` with sanitized diagnostics.

## Validation
- `npm test -- src/server/integrations/slack/handlers.test.ts --run`
- `yarn typecheck`

## Risks / Rollback
- Risk: Slack bot token missing can prevent automatic thread kickoff; response now explicitly asks retry in thread.
- Rollback: revert this PR to restore previous thread-required free-text behavior and remove added lifecycle logs.
