### PR TITLE
fix: fallback bootstrap source ref when main is missing

### DIFF
--- a/src/server/run-orchestrator.llm.test.ts
+++ b/src/server/run-orchestrator.llm.test.ts
@@ -22,7 +22,7 @@ const sandboxState: { current: FakeSandbox | undefined } = { current: undefined 
 type FakeScmAdapter = {
   provider: 'github' | 'gitlab';
   buildCloneUrl: (repo: Repo, credential: { token: string }) => string;
-  inferSourceRefFromTask: () => undefined;
+  inferSourceRefFromTask: (task: Pick<Task, 'sourceRef' | 'title' | 'description' | 'taskPrompt'>, repo: Repo) => string | undefined;
   normalizeSourceRef: (sourceRef: string) => { kind: 'branch'; value: string; label: string };
   createReviewRequest: () => Promise<{ provider: 'github' | 'gitlab'; number: number; url: string }>;
   upsertRunComment: () => Promise<void>;
@@ -301,7 +301,7 @@ beforeEach(() => {
   scmState.current = {
     provider: 'github',
     buildCloneUrl: (_repo, credential) => `https://x-access-token:${credential.token}@github.com/abuiles/minions.git`,
-    inferSourceRefFromTask: () => undefined,
+    inferSourceRefFromTask: (task) => task.sourceRef?.trim() || undefined,
     normalizeSourceRef: (sourceRef) => ({ kind: 'branch', value: sourceRef, label: sourceRef }),
     createReviewRequest: async () => ({
       provider: 'github',
@@ -316,6 +316,140 @@ beforeEach(() => {
 });
 
 describe('executeRunJob LLM adapter coverage', () => {
+  it('keeps explicit source ref when remote ref exists', async () => {
+    const task = buildTask({
+      sourceRef: 'main',
+      uiMeta: {
+        llmAdapter: 'codex',
+        llmModel: 'gpt-5.3-codex',
+        llmReasoningEffort: 'medium'
+      }
+    });
+    const repo = buildRepo({
+      defaultBranch: 'master'
+    });
+    const harness = createHarness(task, repo);
+    const sandbox = buildSandbox([
+      { type: 'stdout', data: 'Applied fix.\n' },
+      { type: 'exit', exitCode: 0 }
+    ]);
+    const baseExec = sandbox.exec.bind(sandbox);
+    sandbox.exec = async (command) => {
+      sandbox.commands.push(command);
+      if (/git fetch origin .*main.*&& git checkout -B/.test(command)) {
+        return { success: true, exitCode: 0, stdout: '' };
+      }
+      return baseExec(command);
+    };
+    sandboxState.current = sandbox;
+
+    await executeRunJob(harness.env, {
+      tenantId: 'tenant_legacy',
+      repoId: repo.repoId,
+      taskId: task.taskId,
+      runId: 'run_1',
+      mode: 'full_run'
+    }, async () => {});
+
+    expect(sandbox.commands.some((command) => /git fetch origin .*main.*&& git checkout -B/.test(command))).toBe(true);
+    expect(sandbox.commands.some((command) => /git fetch origin .*master.*&& git checkout -B/.test(command))).toBe(false);
+    expect(harness.logs.some((entry) => entry.message.includes('falling back to default branch'))).toBe(false);
+  });
+
+  it('falls back to default branch when explicit source ref is missing on remote', async () => {
+    const task = buildTask({
+      sourceRef: 'main',
+      uiMeta: {
+        llmAdapter: 'codex',
+        llmModel: 'gpt-5.3-codex',
+        llmReasoningEffort: 'medium'
+      }
+    });
+    const repo = buildRepo({
+      defaultBranch: 'master'
+    });
+    const harness = createHarness(task, repo);
+    const sandbox = buildSandbox([
+      { type: 'stdout', data: 'Applied fix.\n' },
+      { type: 'exit', exitCode: 0 }
+    ]);
+    const baseExec = sandbox.exec.bind(sandbox);
+    sandbox.exec = async (command) => {
+      sandbox.commands.push(command);
+      if (/git fetch origin .*main.*&& git checkout -B/.test(command)) {
+        return {
+          success: false,
+          exitCode: 128,
+          stderr: "fatal: couldn't find remote ref main"
+        };
+      }
+      if (/git fetch origin .*master.*&& git checkout -B/.test(command)) {
+        return { success: true, exitCode: 0, stdout: '' };
+      }
+      return baseExec(command);
+    };
+    sandboxState.current = sandbox;
+
+    await executeRunJob(harness.env, {
+      tenantId: 'tenant_legacy',
+      repoId: repo.repoId,
+      taskId: task.taskId,
+      runId: 'run_1',
+      mode: 'full_run'
+    }, async () => {});
+
+    expect(sandbox.commands.some((command) => /git fetch origin .*main.*&& git checkout -B/.test(command))).toBe(true);
+    expect(sandbox.commands.some((command) => /git fetch origin .*master.*&& git checkout -B/.test(command))).toBe(true);
+    expect(harness.logs.some((entry) => entry.message.includes('falling back to default branch master'))).toBe(true);
+  });
+
+  it('fails clearly when explicit source ref, default branch, and remote HEAD are all missing', async () => {
+    const task = buildTask({
+      sourceRef: 'main',
+      uiMeta: {
+        llmAdapter: 'codex',
+        llmModel: 'gpt-5.3-codex',
+        llmReasoningEffort: 'medium'
+      }
+    });
+    const repo = buildRepo({
+      defaultBranch: 'master'
+    });
+    const harness = createHarness(task, repo);
+    const sandbox = buildSandbox([
+      { type: 'stdout', data: 'Applied fix.\n' },
+      { type: 'exit', exitCode: 0 }
+    ]);
+    const baseExec = sandbox.exec.bind(sandbox);
+    sandbox.exec = async (command) => {
+      sandbox.commands.push(command);
+      if (/git fetch origin .*main.*&& git checkout -B/.test(command)
+        || /git fetch origin .*master.*&& git checkout -B/.test(command)
+        || /git fetch origin .*HEAD.*&& git checkout -B/.test(command)) {
+        return {
+          success: false,
+          exitCode: 128,
+          stderr: "fatal: couldn't find remote ref"
+        };
+      }
+      return baseExec(command);
+    };
+    sandboxState.current = sandbox;
+
+    await expect(executeRunJob(harness.env, {
+      tenantId: 'tenant_legacy',
+      repoId: repo.repoId,
+      taskId: task.taskId,
+      runId: 'run_1',
+      mode: 'full_run'
+    }, async () => {})).rejects.toThrow(/fallback to master and remote HEAD also failed/i);
+
+    expect(harness.getRun().status).toBe('FAILED');
+    expect(harness.logs.some((entry) => entry.message.includes('falling back to default branch master'))).toBe(true);
+    expect(harness.logs.some((entry) => entry.message.includes('falling back to remote HEAD'))).toBe(true);
+    expect(sandbox.commands.some((command) => /git fetch origin .*HEAD.*&& git checkout -B/.test(command))).toBe(true);
+  });
+
   it('auto-runs review on REVIEW entry when enabled', async () => {
     const task = buildTask({
       sourceRef: 'https://jira.example.com/browse/AK-123',

--- a/src/server/run-orchestrator.ts
+++ b/src/server/run-orchestrator.ts
@@ -2357,6 +2357,20 @@ async function prepareRunBranchFromTaskSource(
   run: Awaited<ReturnType<RepoBoardDO['getRun']>>,
   scmAdapter: ScmAdapter
 ) {
+  const runFetchCheckout = async (fetchSpec: string) => {
+    const checkout = await sandbox.exec(
+      `cd /workspace/repo && git fetch origin ${shellEscape(fetchSpec)} && git checkout -B ${shellEscape(run.branchName)} FETCH_HEAD`
+    );
+    await appendCommandLogs(repoBoard, runId, 'bootstrap', checkout.stdout, checkout.stderr);
+    return checkout;
+  };
+  const isMissingRemoteRefError = (stderr: string | undefined) => {
+    const normalized = (stderr ?? '').toLowerCase();
+    return normalized.includes("couldn't find remote ref")
+      || normalized.includes('could not find remote ref')
+      || normalized.includes("fatal: couldn't find remote ref");
+  };
+
   if (run.changeRequest?.prompt && getRunReviewUrl(run)) {
     await repoBoard.appendRunLogs(runId, [
       buildRunLog(runId, `Preparing existing review branch ${run.branchName} for a review change request.`, 'bootstrap')
@@ -2419,12 +2433,45 @@ async function prepareRunBranchFromTaskSource(
   await repoBoard.appendRunLogs(runId, [
     buildRunLog(runId, `Preparing run branch ${run.branchName} from explicit source ref ${normalized.label}.`, 'bootstrap')
   ]);
-  const checkout = await sandbox.exec(
-    `cd /workspace/repo && git fetch origin ${shellEscape(getScmSourceRefFetchSpec(normalized))} && git checkout -B ${shellEscape(run.branchName)} FETCH_HEAD`
-  );
-  await appendCommandLogs(repoBoard, runId, 'bootstrap', checkout.stdout, checkout.stderr);
-  if (!checkout.success) {
-    throw new Error(checkout.stderr || `Failed to prepare run branch ${run.branchName} from ${normalized.label}.`);
+  const explicitFetchSpec = getScmSourceRefFetchSpec(normalized);
+  const explicitCheckout = await runFetchCheckout(explicitFetchSpec);
+  if (explicitCheckout.success) {
+    return;
+  }
+  if (!isMissingRemoteRefError(explicitCheckout.stderr)) {
+    throw new Error(explicitCheckout.stderr || `Failed to prepare run branch ${run.branchName} from ${normalized.label}.`);
+  }
+
+  if (repo.defaultBranch.trim() && repo.defaultBranch.trim() !== explicitFetchSpec) {
+    await repoBoard.appendRunLogs(runId, [
+      buildRunLog(
+        runId,
+        `Source ref ${normalized.label} is unavailable on remote; falling back to default branch ${repo.defaultBranch}.`,
+        'bootstrap'
+      )
+    ]);
+    const defaultCheckout = await runFetchCheckout(repo.defaultBranch);
+    if (defaultCheckout.success) {
+      return;
+    }
+    if (!isMissingRemoteRefError(defaultCheckout.stderr)) {
+      throw new Error(defaultCheckout.stderr || `Failed to prepare run branch ${run.branchName} from fallback default branch ${repo.defaultBranch}.`);
+    }
+  }
+
+  await repoBoard.appendRunLogs(runId, [
+    buildRunLog(
+      runId,
+      `Default fallback was unavailable; falling back to remote HEAD for run branch ${run.branchName}.`,
+      'bootstrap'
+    )
+  ]);
+  const headCheckout = await runFetchCheckout('HEAD');
+  if (!headCheckout.success) {
+    throw new Error(
+      `Failed to prepare run branch ${run.branchName} from ${normalized.label}; fallback to ${repo.defaultBranch} and remote HEAD also failed.`
+      + (headCheckout.stderr?.trim() ? ` Last error: ${headCheckout.stderr.trim()}` : '')
+    );
   }
 }
 


### PR DESCRIPTION
## Summary\n- add bootstrap source-ref fallback from explicit ref -> repo default branch -> remote HEAD\n- log fallback transitions in bootstrap logs for operator visibility\n- add run-orchestrator tests covering no-fallback, default-branch fallback, and failure after all fallbacks\n\n## Testing\n- /Users/ab/code/agents-kanban/node_modules/.bin/vitest src/server/run-orchestrator.llm.test.ts -t "keeps explicit source ref when remote ref exists|falls back to default branch when explicit source ref is missing on remote|fails clearly when explicit source ref, default branch, and remote HEAD are all missing"